### PR TITLE
Share built objects

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/Block.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Block.java
@@ -16,7 +16,7 @@ public class Block extends Excerpt implements SourceBuilder {
   public static Block methodBody(SourceBuilder parent, String... paramNames) {
     Scope methodScope = new Scope.MethodScope(parent.scope());
     for (String paramName : paramNames) {
-      methodScope.add(new Variable(paramName));
+      methodScope.add(new VariableName(paramName));
     }
     return new Block(parent, methodScope);
   }
@@ -58,7 +58,7 @@ public class Block extends Excerpt implements SourceBuilder {
     } else {
       name = pickName(preferredName);
       variableNames.put(preferredName, name);
-      body.scope().add(new Variable(name));
+      body.scope().add(new VariableName(name));
       Excerpt declaration = Excerpts.add("%s %s = %s;%n", typeAndPreamble, name, value);
       declarations.put(name, declaration);
       declarationsBlock.add(declaration);
@@ -89,7 +89,7 @@ public class Block extends Excerpt implements SourceBuilder {
   }
 
   private boolean nameCollides(String name) {
-    return body.scope().contains(new Variable(name))
+    return body.scope().contains(new VariableName(name))
         || body.scope().contains(new FieldAccess(name));
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/FieldAccess.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/FieldAccess.java
@@ -52,7 +52,7 @@ public class FieldAccess extends Excerpt implements Scope.Element<FieldAccess> {
 
   @Override
   public void addTo(SourceBuilder source) {
-    if (source.scope().contains(new Variable(fieldName))) {
+    if (source.scope().contains(new VariableName(fieldName))) {
       source.add("this.");
     } else {
       // Prevent a new variable being declared and obscuring this field access

--- a/src/main/java/org/inferred/freebuilder/processor/util/ValueType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ValueType.java
@@ -96,7 +96,7 @@ public abstract class ValueType {
   protected abstract void addFields(FieldReceiver fields);
 
   @Override
-  public final boolean equals(Object obj) {
+  public boolean equals(Object obj) {
     if ((obj == null) || (obj.getClass() != this.getClass())) {
       return false;
     }
@@ -108,7 +108,7 @@ public abstract class ValueType {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     ReceiverIntoHashCode receiver = new ReceiverIntoHashCode();
     addFields(receiver);
     return receiver.get();

--- a/src/main/java/org/inferred/freebuilder/processor/util/VariableName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/VariableName.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor.util;
+
+import org.inferred.freebuilder.processor.util.Scope.Level;
+
+class VariableName extends ValueType implements Scope.Element<VariableName> {
+
+  private final String name;
+
+  VariableName(String name) {
+    this.name = name;
+  }
+
+  String name() {
+    return name;
+  }
+
+  @Override
+  public Level level() {
+    return Level.METHOD;
+  }
+
+  @Override
+  protected void addFields(FieldReceiver fields) {
+    fields.add("name", name);
+  }
+}


### PR DESCRIPTION
Buildable properties now reuse built instances where possible, reducing the memory overhead of the modify-rebuild pattern.

This fixes #270.