### PR TITLE
Run with old JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
   apt:
     packages:
       - openjdk-6-jdk
+      - oraclejdk7
 
 install:
   - ./gradlew clean jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,12 @@ addons:
     packages:
       - oracle-java9-installer
 
-install: ./gradlew clean jar
+install:
+  - ./gradlew clean jar
+  - jdk_switcher home oraclejdk6
+  - jdk_switcher home oraclejdk7
+  - jdk_switcher home oraclejdk8
+  - jdk_switcher home oraclejdk9
 script: ./gradlew check
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ language: java
 
 jdk:
   - oraclejdk8
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
 
 install:
   - ./gradlew clean jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     packages:
       - openjdk-6-jdk
       - openjdk-7-jdk
-      - oraclejdk7
 
 install:
   - ./gradlew clean jar
@@ -20,8 +19,6 @@ install:
   - ls $(jdk_switcher home openjdk6)
   - jdk_switcher home openjdk7
   - ls $(jdk_switcher home openjdk7)
-  - jdk_switcher home oraclejdk7
-  - ls $(jdk_switcher home oraclejdk7)
   - jdk_switcher home oraclejdk8
   - ls $(jdk_switcher home oraclejdk8)
   - jdk_switcher home oraclejdk9
@@ -31,7 +28,7 @@ script: ./gradlew check
 env:
   global:
     - JAVA_6_HOME=$(jdk_switcher home openjdk6)
-    - JAVA_7_HOME=$(jdk_switcher home oraclejdk7)
+    - JAVA_7_HOME=$(jdk_switcher home openjdk7)
     - JAVA_9_HOME=$(jdk_switcher home oraclejdk9)
     - PGP_KEY_ID="2887CE9B"
     - PGP_PASSWORD=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script: ./gradlew check
 
 env:
   global:
+    - JAVA_6_HOME=$(jdk_switcher home oraclejdk6)
+    - JAVA_7_HOME=$(jdk_switcher home oraclejdk7)
     - JAVA_9_HOME=$(jdk_switcher home oraclejdk9)
     - PGP_KEY_ID="2887CE9B"
     - PGP_PASSWORD=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,11 @@ language: java
 
 jdk:
   - oraclejdk8
-addons:
-  apt:
-    packages:
-      - oracle-java6-installer
-      - oracle-java9-installer
 
 install:
   - ./gradlew clean jar
   - ls /usr/lib/jvm
+  - jdk_switcher home openjdk6
   - jdk_switcher home oraclejdk7
   - jdk_switcher home oraclejdk8
   - jdk_switcher home oraclejdk9
@@ -22,7 +18,7 @@ script: ./gradlew check
 
 env:
   global:
-    - JAVA_6_HOME=/usr/lib/jvm/java-6-oracle
+    - JAVA_6_HOME=$(jdk_switcher home openjdk6)
     - JAVA_7_HOME=$(jdk_switcher home oraclejdk7)
     - JAVA_9_HOME=$(jdk_switcher home oraclejdk9)
     - PGP_KEY_ID="2887CE9B"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,22 @@ addons:
   apt:
     packages:
       - openjdk-6-jdk
+      - openjdk-7-jdk
       - oraclejdk7
 
 install:
   - ./gradlew clean jar
   - ls /usr/lib/jvm
   - jdk_switcher home openjdk6
+  - ls $(jdk_switcher home openjdk6)
+  - jdk_switcher home openjdk7
+  - ls $(jdk_switcher home openjdk7)
   - jdk_switcher home oraclejdk7
+  - ls $(jdk_switcher home oraclejdk7)
   - jdk_switcher home oraclejdk8
+  - ls $(jdk_switcher home oraclejdk8)
   - jdk_switcher home oraclejdk9
+  - ls $(jdk_switcher home oraclejdk9)
 script: ./gradlew check
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ jdk:
 addons:
   apt:
     packages:
+      - oracle-java6-installer
       - oracle-java9-installer
 
 install:
   - ./gradlew clean jar
-  - jdk_switcher home oraclejdk6
+  - ls /usr/lib/jvm
   - jdk_switcher home oraclejdk7
   - jdk_switcher home oraclejdk8
   - jdk_switcher home oraclejdk9
@@ -21,7 +22,7 @@ script: ./gradlew check
 
 env:
   global:
-    - JAVA_6_HOME=$(jdk_switcher home oraclejdk6)
+    - JAVA_6_HOME=/usr/lib/jvm/java-6-oracle
     - JAVA_7_HOME=$(jdk_switcher home oraclejdk7)
     - JAVA_9_HOME=$(jdk_switcher home oraclejdk9)
     - PGP_KEY_ID="2887CE9B"

--- a/build.gradle
+++ b/build.gradle
@@ -179,23 +179,60 @@ task shadowTest {
   }
 }
 
-//// Java 9 support (for tests) //////////////////////////////////
-if (!hasProperty('java9Home') && System.env.containsKey('JAVA_9_HOME')) {
-  project.ext.java9Home = System.env['JAVA_9_HOME']
+//// Java 6/7/9 support //////////////////////////////////////////
+import org.gradle.internal.jvm.JavaInfo
+import org.gradle.internal.jvm.Jvm
+
+// Map Java version to JVM information, using $JAVA_x_HOME environment variables
+// and falling back to gradle properties as an extra option for devs.
+Map<Integer, Jvm> jvms = [:].withDefault { String versionString ->
+  JavaVersion version = JavaVersion.toVersion(versionString)
+  String propertyName = "java${version.majorVersion}Home"
+  String envName = "JAVA_${version.majorVersion}_HOME"
+  JavaInfo javaInfo
+  if (hasProperty(propertyName)) {
+    javaInfo = Jvm.forHome(file(getProperty(propertyName)))
+  } else if (System.env.containsKey(envName)) {
+    javaInfo = Jvm.forHome(file(System.env[envName]))
+  } else {
+    throw new RuntimeException("Set the property $propertyName in your gradle.properties"
+        + " pointing to a Java $version installation")
+  }
+  logger.info "Java ${versionString} found at ${javaInfo.javaHome}"
+  return javaInfo
 }
-assert hasProperty('java9Home') : "Set the property 'java9Home' in your your gradle.properties pointing to a Java 9 installation"
-def java9Path = new File(java9Home, 'bin')
-def java9 = [:].withDefault { execName ->
-  def executable = new File(java9Path, execName)
-  assert executable.exists() : "There is no ${execName} executable in ${java9Path}"
-  executable.toString()
+jvms[(JavaVersion.current().name)] = Jvm.current()
+
+// Fork the correct JVM version if installed.
+// Runs lazily so users lacking Java 9 can still run most tasks.
+tasks.withType(JavaCompile) {
+  doFirst{
+    if (targetCompatibility != JavaVersion.current().name) {
+      options.with {
+        try {
+          fork javaHome: jvms[targetCompatibility].javaHome
+        } catch (RuntimeException e) {
+          if (JavaVersion.toVersion(targetCompatibility).compareTo(JavaVersion.current()) < 0) {
+            logger.warn "Java ${targetCompatibility} not available, using ${JavaVersion.current()}"
+          } else {
+            throw e
+          }
+        }
+      }
+    }
+  }
 }
 
+// Sets the correct JVM executable path on tests.
+// Runs lazily so users lacking the correct version can run all other tasks.
 afterEvaluate {
-  tasks.withType(JavaCompile) {
-    if (targetCompatibility == "1.9") {
-      options.with {
-        fork javaHome: file(java9Home)
+  tasks.withType(Test) {
+    if (executable =~ /^\d+\.\d+$/) {
+      def version = executable
+      executable = new Object() {
+        @Override public String toString() {
+          return jvms[version].javaExecutable.toString()
+        }
       }
     }
   }
@@ -254,9 +291,7 @@ task vanillaTest {
     vanillaTest.dependsOn it
     testClassesDirs = sourceSets["vanilla${jdk}Test"].output.classesDirs
     classpath = sourceSets["vanilla${jdk}Test"].runtimeClasspath
-    if (jdk == 9) {
-      executable java9.java
-    }
+    executable "1.$jdk"
     reports {
       html {
         destination file("$reportsDir/vanilla${jdk}")

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ plugins {
   id 'com.github.johnrengelman.shadow' version '2.0.2'
 }
 
+apply from: "gradle/java-compatibility.gradle"
 apply from: "gradle/travis-keep-alive.gradle"
 
 repositories {
@@ -176,65 +177,6 @@ task shadowTest {
       throw new GradleException(message.toString())
     }
     report.write 'shadow.jar correct'
-  }
-}
-
-//// Java 6/7/9 support //////////////////////////////////////////
-import org.gradle.internal.jvm.JavaInfo
-import org.gradle.internal.jvm.Jvm
-
-// Map Java version to JVM information, using $JAVA_x_HOME environment variables
-// and falling back to gradle properties as an extra option for devs.
-Map<Integer, Jvm> jvms = [:].withDefault { String versionString ->
-  JavaVersion version = JavaVersion.toVersion(versionString)
-  String propertyName = "java${version.majorVersion}Home"
-  String envName = "JAVA_${version.majorVersion}_HOME"
-  JavaInfo javaInfo
-  if (hasProperty(propertyName)) {
-    javaInfo = Jvm.forHome(file(getProperty(propertyName)))
-  } else if (System.env.containsKey(envName)) {
-    javaInfo = Jvm.forHome(file(System.env[envName]))
-  } else {
-    throw new RuntimeException("Set the property $propertyName in your gradle.properties"
-        + " pointing to a Java $version installation")
-  }
-  logger.info "Java ${versionString} found at ${javaInfo.javaHome}"
-  return javaInfo
-}
-jvms[(JavaVersion.current().name)] = Jvm.current()
-
-// Fork the correct JVM version if installed.
-// Runs lazily so users lacking Java 9 can still run most tasks.
-tasks.withType(JavaCompile) {
-  doFirst{
-    if (targetCompatibility != JavaVersion.current().name) {
-      options.with {
-        try {
-          fork javaHome: jvms[targetCompatibility].javaHome
-        } catch (RuntimeException e) {
-          if (JavaVersion.toVersion(targetCompatibility).compareTo(JavaVersion.current()) < 0) {
-            logger.warn "Java ${targetCompatibility} not available, using ${JavaVersion.current()}"
-          } else {
-            throw e
-          }
-        }
-      }
-    }
-  }
-}
-
-// Sets the correct JVM executable path on tests.
-// Runs lazily so users lacking the correct version can run all other tasks.
-afterEvaluate {
-  tasks.withType(Test) {
-    if (executable =~ /^\d+\.\d+$/) {
-      def version = executable
-      executable = new Object() {
-        @Override public String toString() {
-          return jvms[version].javaExecutable.toString()
-        }
-      }
-    }
   }
 }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -28,7 +28,7 @@ https://github.com/google/auto/blob/0c06a2345f71f053714d37bb6549d3460c999f2d/che
 
     <!-- Space after 'for' and 'if' -->
     <module name="RegexpSingleline">
-        <property name="format" value="^\s*(for|if)[^ ]"/>
+        <property name="format" value="^\s*(for|if)[(]"/>
         <property name="message" value="Space needed before opening parenthesis."/>
     </module>
 

--- a/gradle/java-compatibility.gradle
+++ b/gradle/java-compatibility.gradle
@@ -1,0 +1,67 @@
+/**
+ * Enable Java compatibility support.
+ *
+ * Simply set sourceCompatibility (or targetCompatibility) to automatically fork the correct JDK.
+ * In tests, set the executable to the desired version, e.g. "1.7", and it will be pointed to the 
+ * correct executable. Executable lookup is done lazily when the task runs, so users lacking the
+ * right JDK can still run any other task, and (with a warning) any compile task using an older
+ * JDK.
+ */
+
+import org.gradle.internal.jvm.JavaInfo
+import org.gradle.internal.jvm.Jvm
+
+// Map Java version to JVM information, using $JAVA_x_HOME environment variables
+// and falling back to gradle properties as an extra option for devs.
+Map<Integer, Jvm> jvms = [:].withDefault { String versionString ->
+  JavaVersion version = JavaVersion.toVersion(versionString)
+  String propertyName = "java${version.majorVersion}Home"
+  String envName = "JAVA_${version.majorVersion}_HOME"
+  JavaInfo javaInfo
+  if (hasProperty(propertyName)) {
+    javaInfo = Jvm.forHome(file(getProperty(propertyName)))
+  } else if (System.env.containsKey(envName)) {
+    javaInfo = Jvm.forHome(file(System.env[envName]))
+  } else {
+    throw new RuntimeException("Set the property $propertyName in your gradle.properties"
+        + " pointing to a Java $version installation")
+  }
+  logger.info "Java ${versionString} found at ${javaInfo.javaHome}"
+  return javaInfo
+}
+jvms[(JavaVersion.current().name)] = Jvm.current()
+
+// Fork the correct JVM version if installed.
+// Runs lazily so users lacking Java 9 can still run most tasks.
+tasks.withType(JavaCompile) {
+  doFirst{
+    if (targetCompatibility != JavaVersion.current().name) {
+      options.with {
+        try {
+          fork javaHome: jvms[targetCompatibility].javaHome
+        } catch (RuntimeException e) {
+          if (JavaVersion.toVersion(targetCompatibility).compareTo(JavaVersion.current()) < 0) {
+            logger.warn "Java ${targetCompatibility} not available, using ${JavaVersion.current()}"
+          } else {
+            throw e
+          }
+        }
+      }
+    }
+  }
+}
+
+// Sets the correct JVM executable path on tests.
+// Runs lazily so users lacking the correct version can run all other tasks.
+afterEvaluate {
+  tasks.withType(Test) {
+    if (executable =~ /^\d+\.\d+$/) {
+      def version = executable
+      executable = new Object() {
+        @Override public String toString() {
+          return jvms[version].javaExecutable.toString()
+        }
+      }
+    }
+  }
+}

--- a/src/it/no-guava/src/test/java/org/inferred/freebuilder/ListPropertyTest.java
+++ b/src/it/no-guava/src/test/java/org/inferred/freebuilder/ListPropertyTest.java
@@ -17,8 +17,7 @@ package org.inferred.freebuilder;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,23 +35,14 @@ public class ListPropertyTest {
   public void testAllMethodInteractions() {
     ListProperty.Builder builder = new ListProperty.Builder();
     builder.addNames(NAME_1);
-    assertEquals(newArrayList(NAME_1), builder.build().getNames());
+    assertEquals(Arrays.asList(NAME_1), builder.build().getNames());
     builder.addNames(NAME_2, NAME_3);
-    assertEquals(newArrayList(NAME_1, NAME_2, NAME_3), builder.build().getNames());
+    assertEquals(Arrays.asList(NAME_1, NAME_2, NAME_3), builder.build().getNames());
     builder.clearNames();
-    assertEquals(newArrayList(), builder.build().getNames());
-    builder.addAllNames(newArrayList(NAME_2, NAME_1));
-    assertEquals(newArrayList(NAME_2, NAME_1), builder.build().getNames());
+    assertEquals(Arrays.asList(), builder.build().getNames());
+    builder.addAllNames(Arrays.asList(NAME_2, NAME_1));
+    assertEquals(Arrays.asList(NAME_2, NAME_1), builder.build().getNames());
     builder.clear();
-    assertEquals(newArrayList(), builder.build().getNames());
-  }
-
-  @SafeVarargs
-  private static <E> List<E> newArrayList(E... items) {
-    List<E> list = new ArrayList<E>();
-    for (E item : items) {
-      list.add(item);
-    }
-    return list;
+    assertEquals(Arrays.asList(), builder.build().getNames());
   }
 }

--- a/src/it/no-guava/src/test/java/org/inferred/freebuilder/SetPropertyTest.java
+++ b/src/it/no-guava/src/test/java/org/inferred/freebuilder/SetPropertyTest.java
@@ -49,10 +49,9 @@ public class SetPropertyTest {
     assertEquals(newHashSet(), builder.build().getNames());
   }
 
-  @SafeVarargs
-  private static <E> Set<E> newHashSet(E... items) {
-    Set<E> list = new HashSet<E>();
-    for (E item : items) {
+  private static Set<String> newHashSet(String... items) {
+    Set<String> list = new HashSet<String>();
+    for (String item : items) {
       list.add(item);
     }
     return list;

--- a/src/it/vanilla/src/test/java/org/inferred/freebuilder/NestedListGwtTypeTest.java
+++ b/src/it/vanilla/src/test/java/org/inferred/freebuilder/NestedListGwtTypeTest.java
@@ -17,8 +17,7 @@ package org.inferred.freebuilder;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,38 +36,29 @@ public class NestedListGwtTypeTest {
     NestedListGwtType.Builder builder = new NestedListGwtType.Builder();
     // getItemBuilder()
     builder.getItemBuilder().addNames(NAME_1);
-    assertEquals(newArrayList(NAME_1), builder.build().getItem().getNames());
+    assertEquals(Arrays.asList(NAME_1), builder.build().getItem().getNames());
     // setItem(Value)
     builder.setItem(new StringListGwtType.Builder()
         .addNames(NAME_2, NAME_3)
         .build());
-    assertEquals(newArrayList(NAME_2, NAME_3), builder.build().getItem().getNames());
+    assertEquals(Arrays.asList(NAME_2, NAME_3), builder.build().getItem().getNames());
     // setItem(Builder)
     builder.setItem(new StringListGwtType.Builder()
         .addNames(NAME_1, NAME_3));
-    assertEquals(newArrayList(NAME_1, NAME_3), builder.build().getItem().getNames());
+    assertEquals(Arrays.asList(NAME_1, NAME_3), builder.build().getItem().getNames());
     // Top-level clear()
     builder.clear();
-    assertEquals(newArrayList(), builder.build().getItem().getNames());
+    assertEquals(Arrays.asList(), builder.build().getItem().getNames());
     // mergeFrom(Value)
     builder.mergeFrom(new NestedListGwtType.Builder()
         .setItem(new StringListGwtType.Builder()
             .addNames(NAME_2))
         .build());
-    assertEquals(newArrayList(NAME_2), builder.build().getItem().getNames());
+    assertEquals(Arrays.asList(NAME_2), builder.build().getItem().getNames());
     // mergeFrom(Builder)
     builder.mergeFrom(new NestedListGwtType.Builder()
         .setItem(new StringListGwtType.Builder()
             .addNames(NAME_3)));
-    assertEquals(newArrayList(NAME_2, NAME_3), builder.build().getItem().getNames());
-  }
-
-  @SafeVarargs
-  private static <E> List<E> newArrayList(E... items) {
-    List<E> list = new ArrayList<E>();
-    for (E item : items) {
-      list.add(item);
-    }
-    return list;
+    assertEquals(Arrays.asList(NAME_2, NAME_3), builder.build().getItem().getNames());
   }
 }

--- a/src/it/vanilla/src/test/java/org/inferred/freebuilder/StringListGwtTypeTest.java
+++ b/src/it/vanilla/src/test/java/org/inferred/freebuilder/StringListGwtTypeTest.java
@@ -17,8 +17,7 @@ package org.inferred.freebuilder;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,23 +35,14 @@ public class StringListGwtTypeTest {
   public void testAllMethodInteractions() {
     StringListGwtType.Builder builder = new StringListGwtType.Builder();
     builder.addNames(NAME_1);
-    assertEquals(newArrayList(NAME_1), builder.build().getNames());
+    assertEquals(Arrays.asList(NAME_1), builder.build().getNames());
     builder.addNames(NAME_2, NAME_3);
-    assertEquals(newArrayList(NAME_1, NAME_2, NAME_3), builder.build().getNames());
+    assertEquals(Arrays.asList(NAME_1, NAME_2, NAME_3), builder.build().getNames());
     builder.clearNames();
-    assertEquals(newArrayList(), builder.build().getNames());
-    builder.addAllNames(newArrayList(NAME_2, NAME_1));
-    assertEquals(newArrayList(NAME_2, NAME_1), builder.build().getNames());
+    assertEquals(Arrays.asList(), builder.build().getNames());
+    builder.addAllNames(Arrays.asList(NAME_2, NAME_1));
+    assertEquals(Arrays.asList(NAME_2, NAME_1), builder.build().getNames());
     builder.clear();
-    assertEquals(newArrayList(), builder.build().getNames());
-  }
-
-  @SafeVarargs
-  private static <E> List<E> newArrayList(E... items) {
-    List<E> list = new ArrayList<E>();
-    for (E item : items) {
-      list.add(item);
-    }
-    return list;
+    assertEquals(Arrays.asList(), builder.build().getNames());
   }
 }


### PR DESCRIPTION
Rather than use JDK8 for compilation and integration tests, use the original version, to harden against regression.