### PR TITLE
#302 Make tests run in parallel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ test {
   testLogging {
     exceptionFormat = 'full'
   }
+  maxParallelForks = Runtime.runtime.availableProcessors()
 }
 check.dependsOn javadoc
 tasks.withType(Javadoc) {

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ test {
   testLogging {
     exceptionFormat = 'full'
   }
-  maxParallelForks = Runtime.runtime.availableProcessors()
+  maxParallelForks = Integer.min(Runtime.runtime.availableProcessors(), 2)
 }
 check.dependsOn javadoc
 tasks.withType(Javadoc) {


### PR DESCRIPTION
By settings `maxParallelForks` to the number of available CPU, we can observe that build time reduce from 14 minutes to 11 minutes in travis. This is not a big deal but on my local computer it's 16 -> 10 minutes which is great when hacking and check our changes.