### PR TITLE
Use tools.jar instead of sorcerer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
   compile guava
   compile jsr305
   compileOnly autoService
-  compileOnly sorcerer
+  compileOnly files(org.gradle.internal.jvm.Jvm.current().toolsJar)
 
   testCompile guavaTestlib
   testCompile gwtUser
@@ -557,17 +557,6 @@ pom {
 
 //// Eclipse /////////////////////////////////////////////////////
 eclipse.classpath {
-  // We include sorceror so we can link against internal JVM classes.
-  // Eclipse doesn't handle that well; instead, we just mark those classes as accessible.
-  // Note: this requires you to have JDK 6 installed, as later JDKs don't seem to expose
-  // the internal classes at all (hence the workaroud with sorceror).
-  minusConfigurations += [ configurations.detachedConfiguration(dependencies.create(sorcerer)) ]
-  file.withXml { xml ->
-    xml.asNode().findAll { it.@kind == 'con' }.each { node ->
-        node.appendNode('accessrules')
-            .appendNode('accessrule', [kind: 'accessible', pattern: 'com/sun/source/**'])
-    }
-  }
   // Only src/main/java is compiled with JDK 6
   file.withXml { xml ->
     node = xml.asNode()

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,4 @@ javassist=org.javassist:javassist:3.19.0-GA
 jsr305=com.google.code.findbugs:jsr305:3.0.0
 junit=junit:junit:4.12
 mockito=org.mockito:mockito-core:1.10.8
-sorcerer=org.jvnet.sorcerer:sorcerer-javac:0.8
 truth=com.google.truth:truth:0.24


### PR DESCRIPTION
We have been using sorcerer for ages to access com.sun.source classes; turns out we just needed to include tools.jar.

This is a compile-only dependency so shouldn't result in any binary changes. The fix removes the requirement that Eclipse use a Java 6 SDK, which is very hard to do these days.