### PR TITLE
Shorten wildcard bounds

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
@@ -19,30 +19,22 @@ import static com.google.common.collect.Iterables.addAll;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.inferred.freebuilder.processor.util.Shading.unshadedName;
 
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
+
+import org.inferred.freebuilder.processor.util.TypeShortener.AbstractTypeShortener;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.SimpleTypeVisitor6;
 
 /**
  * Manages the imports for a source file, and produces short type references by adding extra
@@ -51,8 +43,7 @@ import javax.lang.model.util.SimpleTypeVisitor6;
  * <p>To ensure we never import common names like 'Builder', nested classes are never directly
  * imported. This is necessarily less readable when types are used as namespaces, e.g. in proto2.
  */
-class ImportManager extends SimpleTypeVisitor6<String, Void>
-    implements Function<TypeMirror, String>, TypeShortener {
+class ImportManager extends AbstractTypeShortener {
 
   private static final String JAVA_LANG_PACKAGE = "java.lang";
   private static final String PACKAGE_PREFIX = "package ";
@@ -104,67 +95,46 @@ class ImportManager extends SimpleTypeVisitor6<String, Void>
   }
 
   @Override
-  public String shorten(TypeMirror mirror) {
-    return mirror.accept(this, null);
-  }
-
-  @Override
   public String shorten(QualifiedName type) {
-    String prefix = getPrefixForTopLevelClass(type.getPackage(), type.getSimpleNames().get(0));
-    return prefix + Joiner.on('.').join(type.getSimpleNames());
+    StringBuilder b = new StringBuilder();
+    appendPackageForTopLevelClass(b, type.getPackage(), type.getSimpleNames().get(0));
+    String prefix = "";
+    for (String simpleName : type.getSimpleNames()) {
+      b.append(prefix).append(simpleName);
+      prefix = ".";
+    }
+    return b.toString();
   }
 
   @Override
-  public String apply(TypeMirror mirror) {
-    return mirror.accept(this, null);
+  protected void appendShortened(StringBuilder b, TypeElement type) {
+    if (type.getNestingKind().isNested()) {
+      appendShortened(b, (TypeElement) type.getEnclosingElement());
+      b.append('.');
+    } else {
+      PackageElement pkg = (PackageElement) type.getEnclosingElement();
+      Name name = type.getSimpleName();
+      appendPackageForTopLevelClass(b, pkg.getQualifiedName().toString(), name);
+    }
+    b.append(type.getSimpleName());
   }
 
-  @Override
-  public String visitDeclared(DeclaredType mirror, Void p) {
-    Name name = mirror.asElement().getSimpleName();
-    final String prefix;
-    Element enclosingElement = mirror.asElement().getEnclosingElement();
-    if (mirror.getEnclosingType().getKind() != TypeKind.NONE) {
-      prefix = visit(mirror.getEnclosingType()) + ".";
-    } else if (enclosingElement.getKind() == ElementKind.PACKAGE) {
-      PackageElement pkg = (PackageElement) enclosingElement;
-      prefix = getPrefixForTopLevelClass(pkg.getQualifiedName().toString(), name);
-    } else if (enclosingElement.getKind().isClass() || enclosingElement.getKind().isInterface()) {
-      prefix = shorten(QualifiedName.of((TypeElement) enclosingElement)) + ".";
-    } else {
-      prefix = enclosingElement.toString() + ".";
-    }
-    final String suffix;
-    if (!mirror.getTypeArguments().isEmpty()) {
-      List<String> shortTypeArguments = Lists.transform(mirror.getTypeArguments(), this);
-      suffix = "<" + Joiner.on(", ").join(shortTypeArguments) + ">";
-    } else {
-      suffix = "";
-    }
-    return prefix + name + suffix;
-  }
-
-  private String getPrefixForTopLevelClass(String pkg, CharSequence name) {
+  private void appendPackageForTopLevelClass(StringBuilder b, String pkg, CharSequence name) {
     if (pkg.startsWith(PACKAGE_PREFIX)) {
       pkg = pkg.substring(PACKAGE_PREFIX.length());
     }
     pkg = unshadedName(pkg);
     String qualifiedName = pkg + "." + name;
     if (implicitImports.contains(qualifiedName) || explicitImports.contains(qualifiedName)) {
-      return "";
+      // Append nothing
     } else if (visibleSimpleNames.contains(name.toString())) {
-      return pkg + ".";
+      b.append(pkg).append(".");
     } else if (pkg.equals(JAVA_LANG_PACKAGE)) {
-      return "";
+      // Append nothing
     } else {
       visibleSimpleNames.add(name.toString());
       explicitImports.add(qualifiedName);
-      return "";
+      // Append nothing
     }
-  }
-
-  @Override
-  protected String defaultAction(TypeMirror mirror, Void p) {
-    return mirror.toString();
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceStringBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceStringBuilder.java
@@ -29,8 +29,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 /**
@@ -131,8 +129,8 @@ public class SourceStringBuilder implements SourceBuilder {
       }
     } else if (arg instanceof Class<?>) {
       return shortener.shorten(QualifiedName.of((Class<?>) arg));
-    } else if ((arg instanceof TypeMirror) && (((TypeMirror) arg).getKind() == TypeKind.DECLARED)) {
-      DeclaredType mirror = (DeclaredType) arg;
+    } else if (arg instanceof TypeMirror) {
+      TypeMirror mirror = (TypeMirror) arg;
       checkArgument(isLegalType(mirror), "Cannot write unknown type %s", mirror);
       return shortener.shorten(mirror);
     } else if (arg instanceof QualifiedName) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/TypeShortener.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/TypeShortener.java
@@ -15,17 +15,15 @@
  */
 package org.inferred.freebuilder.processor.util;
 
-import com.google.common.base.Function;
+import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
+
 import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 
-import java.util.List;
-
-import javax.lang.model.element.Name;
-import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.SimpleTypeVisitor6;
 
 /**
@@ -33,18 +31,70 @@ import javax.lang.model.util.SimpleTypeVisitor6;
  */
 interface TypeShortener {
 
+  String shorten(TypeElement type);
   String shorten(TypeMirror mirror);
   String shorten(QualifiedName type);
 
-  /** A {@link TypeShortener} that never shortens types. */
-  class NeverShorten
-      extends SimpleTypeVisitor6<String, Void>
-      implements Function<TypeMirror, String>, TypeShortener {
+  abstract class AbstractTypeShortener
+      extends SimpleTypeVisitor6<StringBuilder, StringBuilder>
+      implements TypeShortener {
+
+    protected abstract void appendShortened(StringBuilder b, TypeElement type);
+
+    @Override
+    public String shorten(TypeElement type) {
+      StringBuilder b = new StringBuilder();
+      appendShortened(b, type);
+      return b.toString();
+    }
 
     @Override
     public String shorten(TypeMirror mirror) {
-      return mirror.accept(this, null);
+      return mirror.accept(this, new StringBuilder()).toString();
     }
+
+    @Override
+    public StringBuilder visitDeclared(DeclaredType mirror, StringBuilder b) {
+      if (mirror.getEnclosingType().getKind() == TypeKind.NONE) {
+        appendShortened(b, asElement(mirror));
+      } else {
+        mirror.getEnclosingType().accept(this, b);
+        b.append('.').append(mirror.asElement().getSimpleName());
+      }
+      if (!mirror.getTypeArguments().isEmpty()) {
+        String prefix = "<";
+        for (TypeMirror typeArgument : mirror.getTypeArguments()) {
+          b.append(prefix);
+          typeArgument.accept(this, b);
+          prefix = ", ";
+        }
+        b.append(">");
+      }
+      return b;
+    }
+
+    @Override
+    public StringBuilder visitWildcard(WildcardType t, StringBuilder b) {
+      b.append("?");
+      if (t.getSuperBound() != null) {
+        b.append(" super ");
+        t.getSuperBound().accept(this, b);
+      }
+      if (t.getExtendsBound() != null) {
+        b.append(" extends ");
+        t.getExtendsBound().accept(this, b);
+      }
+      return b;
+    }
+
+    @Override
+    protected StringBuilder defaultAction(TypeMirror mirror, StringBuilder b) {
+      return b.append(mirror);
+    }
+  }
+
+  /** A {@link TypeShortener} that never shortens types. */
+  class NeverShorten extends AbstractTypeShortener {
 
     @Override
     public String shorten(QualifiedName type) {
@@ -52,78 +102,26 @@ interface TypeShortener {
     }
 
     @Override
-    public String apply(TypeMirror mirror) {
-      return mirror.accept(this, null);
-    }
-
-    @Override
-    public String visitDeclared(DeclaredType mirror, Void p) {
-      Name name = mirror.asElement().getSimpleName();
-      final String prefix;
-      if (mirror.getEnclosingType().getKind() == TypeKind.NONE) {
-        prefix = ((PackageElement) mirror.asElement().getEnclosingElement()).getQualifiedName()
-            + ".";
-      } else {
-        prefix = visit(mirror.getEnclosingType()) + ".";
-      }
-      final String suffix;
-      if (!mirror.getTypeArguments().isEmpty()) {
-        List<String> shortTypeArguments = Lists.transform(mirror.getTypeArguments(), this);
-        suffix = "<" + Joiner.on(", ").join(shortTypeArguments) + ">";
-      } else {
-        suffix = "";
-      }
-      return prefix + name + suffix;
-    }
-
-    @Override
-    protected String defaultAction(TypeMirror mirror, Void p) {
-      return mirror.toString();
+    protected void appendShortened(StringBuilder b, TypeElement type) {
+      b.append(type);
     }
   }
 
   /** A {@link TypeShortener} that always shortens types, even if that causes conflicts. */
-  class AlwaysShorten
-      extends SimpleTypeVisitor6<String, Void>
-      implements Function<TypeMirror, String>, TypeShortener {
-
-    @Override
-    public String shorten(TypeMirror mirror) {
-      return mirror.accept(this, null);
-    }
+  class AlwaysShorten extends AbstractTypeShortener {
 
     @Override
     public String shorten(QualifiedName type) {
-      return type.toString().substring(type.getPackage().length() + 1);
+      return Joiner.on('.').join(type.getSimpleNames());
     }
 
     @Override
-    public String apply(TypeMirror mirror) {
-      return mirror.accept(this, null);
-    }
-
-    @Override
-    public String visitDeclared(DeclaredType mirror, Void p) {
-      Name name = mirror.asElement().getSimpleName();
-      final String prefix;
-      if (mirror.getEnclosingType().getKind() == TypeKind.NONE) {
-        prefix = "";
-      } else {
-        prefix = visit(mirror.getEnclosingType()) + ".";
+    protected void appendShortened(StringBuilder b, TypeElement type) {
+      if (type.getNestingKind().isNested()) {
+        appendShortened(b, (TypeElement) type.getEnclosingElement());
+        b.append('.');
       }
-      final String suffix;
-      if (!mirror.getTypeArguments().isEmpty()) {
-        List<String> shortTypeArguments = Lists.transform(mirror.getTypeArguments(), this);
-        suffix = "<" + Joiner.on(", ").join(shortTypeArguments) + ">";
-      } else {
-        suffix = "";
-      }
-      return prefix + name + suffix;
-    }
-
-    @Override
-    protected String defaultAction(TypeMirror mirror, Void p) {
-      return mirror.toString();
+      b.append(type.getSimpleName());
     }
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
@@ -124,11 +124,12 @@ public class ImportManagerTest {
     createModel();
     ImportManager manager = new ImportManager.Builder().build();
 
-    // Wildcards work differently between Java versions. We make no attempt to shorten them.
-    assertEquals("Map<Name, ? extends java.util.logging.Logger>",
+    assertEquals("Map<Name, ? extends Logger>",
         manager.shorten(model.typeMirror(new TypeToken<Map<Name, ? extends Logger>>() {})));
     assertThat(manager.getClassImports())
-        .containsExactly("java.util.Map", "javax.lang.model.element.Name").inOrder();
+        .containsExactly(
+            "java.util.Map", "java.util.logging.Logger", "javax.lang.model.element.Name")
+        .inOrder();
   }
 
   @Test

--- a/src/test/java/org/inferred/freebuilder/processor/util/TypeVariableImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/TypeVariableImpl.java
@@ -17,6 +17,11 @@ package org.inferred.freebuilder.processor.util;
 
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
@@ -60,5 +65,17 @@ public abstract class TypeVariableImpl implements TypeVariable {
   @Override
   public String toString() {
     return variableName;
+  }
+
+  @Override
+  public TypeParameterElement asElement() {
+    return Partial.of(ElementImpl.class, this);
+  }
+
+  abstract class ElementImpl implements TypeParameterElement {
+    @Override
+    public List<? extends TypeMirror> getBounds() {
+      return ImmutableList.of();
+    }
   }
 }


### PR DESCRIPTION
Extend ImportManager to drill down into wildcard bounds. (I thought they were more complicated than this, but I was getting confused with TypeVariable.)

In the process, refactor out a lot of common TypeShortener code into an AbstractTypeShortener class, reducing the implementation signature to two methods, to shorten a QualifiedName and a TypeElement. The refactored code also passes around a StringBuilder, rather than creating a torrent of throw-away String instances.

Ideally I'd follow https://codingantihero.wordpress.com/2016/04/08/refactoring-designforextension/ at this point, but this PR is enough improvement for now.