### PR TITLE
Parameterize remaining mapper method tests

### DIFF
--- a/src/test/java/org/inferred/freebuilder/processor/ElementFactory.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ElementFactory.java
@@ -27,6 +27,7 @@ public enum ElementFactory {
       null,
       CharSequence.class,
       true,
+      "%s.intern()",
       "!%s.isEmpty()",
       "!element.toString().isEmpty()",
       "Cannot add empty string",
@@ -44,6 +45,7 @@ public enum ElementFactory {
       null,
       Number.class,
       true,
+      "Integer.valueOf((int) %s)",
       "%s >= 0",
       "element.intValue() >= 0",
       "Items must be non-negative",
@@ -61,23 +63,25 @@ public enum ElementFactory {
       AbstractNonComparable.ReverseIdComparator.class,
       AbstractNonComparable.class,
       false,
+      "%s.intern()",
       "%s.id() >= 0",
       "element.id() >= 0",
       "ID must be non-negative",
-      new NonComparable(-2, "broken"),
+      NonComparable.of(-2, "broken"),
       new OtherNonComparable(88, "other"),
-      new NonComparable(10, "alpha"),
-      new NonComparable(9, "cappa"),
-      new NonComparable(8, "echo"),
-      new NonComparable(7, "golf"),
-      new NonComparable(6, "beta"),
-      new NonComparable(5, "delta"),
-      new NonComparable(4, "foxtrot"));
+      NonComparable.of(10, "alpha"),
+      NonComparable.of(9, "cappa"),
+      NonComparable.of(8, "echo"),
+      NonComparable.of(7, "golf"),
+      NonComparable.of(6, "beta"),
+      NonComparable.of(5, "delta"),
+      NonComparable.of(4, "foxtrot"));
 
   private final Class<?> type;
   @Nullable private final Class<?> comparator;
   private Class<?> supertype;
   private final boolean serializableAsMapKey;
+  private final String intern;
   private final String validation;
   private final String supertypeValidation;
   private final String errorMessage;
@@ -90,6 +94,7 @@ public enum ElementFactory {
       @Nullable Class<? extends Comparator<?>> comparator,
       Class<?> supertype,
       boolean serializableAsMapKey,
+      String intern,
       String validation,
       String supertypeValidation,
       String errorMessage,
@@ -100,6 +105,7 @@ public enum ElementFactory {
     this.comparator = comparator;
     this.supertype = supertype;
     this.serializableAsMapKey = serializableAsMapKey;
+    this.intern = intern;
     this.validation = validation;
     this.supertypeValidation = supertypeValidation;
     this.errorMessage = errorMessage;
@@ -165,6 +171,10 @@ public enum ElementFactory {
     return IntStream.of(ids).mapToObj(this::example).collect(Collectors.joining(", "));
   }
 
+  public Object intern(String variableName) {
+    return String.format(intern, variableName);
+  }
+
   @Override
   public String toString() {
     return type.getSimpleName();
@@ -177,7 +187,7 @@ public enum ElementFactory {
       return "new " + NameImpl.class.getName() + "(\"" + example + "\")";
     } else if (example instanceof NonComparable) {
       NonComparable nonComparable = (NonComparable) example;
-      return "new " + NonComparable.class.getName() + "(" + nonComparable.id() + ", \""
+      return NonComparable.class.getName() + ".of(" + nonComparable.id() + ", \""
           + nonComparable.name() + "\")";
     } else if (example instanceof OtherNonComparable) {
       OtherNonComparable otherNonComparable = (OtherNonComparable) example;

--- a/src/test/java/org/inferred/freebuilder/processor/ElementFactory.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ElementFactory.java
@@ -30,7 +30,7 @@ public enum ElementFactory {
       "%s.intern()",
       "!%s.isEmpty()",
       "!element.toString().isEmpty()",
-      "Cannot add empty string",
+      "%s cannot be empty",
       "",
       new NameImpl("echo"),
       "alpha",
@@ -48,7 +48,7 @@ public enum ElementFactory {
       "Integer.valueOf((int) %s)",
       "%s >= 0",
       "element.intValue() >= 0",
-      "Items must be non-negative",
+      "%s must be non-negative",
       -4,
       2.7,
       1,
@@ -66,7 +66,7 @@ public enum ElementFactory {
       "%s.intern()",
       "%s.id() >= 0",
       "element.id() >= 0",
-      "ID must be non-negative",
+      "%s must be non-negative",
       NonComparable.of(-2, "broken"),
       new OtherNonComparable(88, "other"),
       NonComparable.of(10, "alpha"),
@@ -152,7 +152,11 @@ public enum ElementFactory {
   }
 
   public String errorMessage() {
-    return errorMessage;
+    return errorMessage("element");
+  }
+
+  public String errorMessage(String variableName) {
+    return String.format(errorMessage, variableName);
   }
 
   public String invalidExample() {

--- a/src/test/java/org/inferred/freebuilder/processor/OptionalPropertyTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/OptionalPropertyTest.java
@@ -56,14 +56,14 @@ import javax.tools.JavaFileObject;
 public class OptionalPropertyTest {
 
   @SuppressWarnings("unchecked")
-  @Parameters(name = "Optional<{0}>, {1}, {2}")
+  @Parameters(name = "{0}<{1}>, {2}, {3}")
   public static Iterable<Object[]> parameters() {
     List<Class<?>> optionals = Arrays.asList(
         java.util.Optional.class,
         com.google.common.base.Optional.class);
     List<ElementFactory> elements = Arrays.asList(INTEGERS, STRINGS);
     List<NamingConvention> conventions = Arrays.asList(NamingConvention.values());
-    List<FeatureSet> features = FeatureSets.WITH_GUAVA;
+    List<FeatureSet> features = FeatureSets.ALL;
     return () -> Lists
         .cartesianProduct(optionals, elements, conventions, features)
         .stream()

--- a/src/test/java/org/inferred/freebuilder/processor/SetMultimapMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetMultimapMutateMethodTest.java
@@ -15,28 +15,35 @@
  */
 package org.inferred.freebuilder.processor;
 
+import static org.inferred.freebuilder.processor.ElementFactory.INTEGERS;
+import static org.inferred.freebuilder.processor.ElementFactory.STRINGS;
+import static org.junit.Assume.assumeTrue;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.SetMultimap;
 
 import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.testtype.NonComparable;
 import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.testing.BehaviorTester;
 import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory;
 import org.inferred.freebuilder.processor.util.testing.ParameterizedBehaviorTestFactory.Shared;
 import org.inferred.freebuilder.processor.util.testing.SourceBuilder;
 import org.inferred.freebuilder.processor.util.testing.TestBuilder;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -46,94 +53,89 @@ import javax.tools.JavaFileObject;
 @UseParametersRunnerFactory(ParameterizedBehaviorTestFactory.class)
 public class SetMultimapMutateMethodTest {
 
-  @Parameters(name = "{0}")
-  public static List<FeatureSet> featureSets() {
-    return FeatureSets.WITH_GUAVA_AND_LAMBDAS;
+  @SuppressWarnings("unchecked")
+  @Parameters(name = "SetMultimap<{0}, {1}>, checked={2}, {3}, {4}")
+  public static Iterable<Object[]> featureSets() {
+    List<ElementFactory> elements = Arrays.asList(INTEGERS, STRINGS);
+    List<Boolean> checkedAndInterned = ImmutableList.of(false, true);
+    List<NamingConvention> conventions = Arrays.asList(NamingConvention.values());
+    List<FeatureSet> features = FeatureSets.WITH_GUAVA_AND_LAMBDAS;
+    return () -> Lists
+        .cartesianProduct(elements, elements, checkedAndInterned, conventions, features)
+        .stream()
+        .map(List::toArray)
+        .iterator();
   }
-
-  private static final JavaFileObject UNCHECKED_PROPERTY = new SourceBuilder()
-      .addLine("package com.example;")
-      .addLine("@%s", FreeBuilder.class)
-      .addLine("public abstract class DataType {")
-      .addLine("  public abstract %s<String, String> getItems();", SetMultimap.class)
-      .addLine("")
-      .addLine("  public static class Builder extends DataType_Builder {}")
-      .addLine("}")
-      .build();
-
-  private static final JavaFileObject CHECKED_PROPERTY = new SourceBuilder()
-      .addLine("package com.example;")
-      .addLine("@%s", FreeBuilder.class)
-      .addLine("public abstract class DataType {")
-      .addLine("  public abstract %s<String, String> getItems();", SetMultimap.class)
-      .addLine("")
-      .addLine("  public static class Builder extends DataType_Builder {")
-      .addLine("    @Override public Builder putItems(String key, String value) {")
-      .addLine("      %s.checkArgument(!key.isEmpty(), \"key may not be empty\");",
-          Preconditions.class)
-      .addLine("      %s.checkArgument(!value.isEmpty(), \"value may not be empty\");",
-          Preconditions.class)
-      .addLine("      return super.putItems(key, value);")
-      .addLine("    }")
-      .addLine("  }")
-      .addLine("}")
-      .build();
-
-  private static final JavaFileObject INTERNED_PROPERTY = new SourceBuilder()
-      .addLine("package com.example;")
-      .addLine("@%s", FreeBuilder.class)
-      .addLine("public abstract class DataType {")
-      .addLine("  public abstract %s<String, String> getItems();", SetMultimap.class)
-      .addLine("")
-      .addLine("  public static class Builder extends DataType_Builder {")
-      .addLine("    @Override public Builder putItems(String key, String value) {")
-      .addLine("      return super.putItems(key.intern(), value.intern());")
-      .addLine("    }")
-      .addLine("  }")
-      .addLine("}")
-      .build();
-
-  @Parameter public FeatureSet features;
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
   @Shared public BehaviorTester behaviorTester;
 
-  @Test
-  public void mutateAndPutModifiesUnderlyingProperty_whenUnchecked() {
+  private final ElementFactory key;
+  private final ElementFactory value;
+  private final boolean checked;
+  private final boolean interned;
+  private final NamingConvention convention;
+  private final FeatureSet features;
+  private final JavaFileObject dataType;
+
+  public SetMultimapMutateMethodTest(
+      ElementFactory key,
+      ElementFactory value,
+      boolean checkedAndInterned,
+      NamingConvention convention,
+      FeatureSet features) {
+    this.key = key;
+    this.value = value;
+    this.checked = checkedAndInterned;
+    this.interned = checkedAndInterned;
+    this.convention = convention;
+    this.features = features;
+
+    SourceBuilder dataType = new SourceBuilder()
+        .addLine("package com.example;")
+        .addLine("@%s", FreeBuilder.class)
+        .addLine("public interface DataType {")
+        .addLine("  %s<%s, %s> %s;", SetMultimap.class, key.type(), value.type(), convention.get())
+        .addLine("")
+        .addLine("  class Builder extends DataType_Builder {");
+    if (checkedAndInterned) {
+      dataType
+          .addLine("    @Override public Builder putItems(%s key, %s value) {",
+              key.unwrappedType(), value.unwrappedType())
+          .addLine("      %s.checkArgument(%s, \"%s\");",
+              Preconditions.class, key.validation("key"), key.errorMessage("key"))
+          .addLine("      %s.checkArgument(%s, \"%s\");",
+              Preconditions.class, value.validation("value"), value.errorMessage("value"))
+          .addLine("      return super.putItems(%s, %s);", key.intern("key"), value.intern("value"))
+          .addLine("    }");
+    }
+    dataType
+        .addLine("  }")
+        .addLine("}");
+    this.dataType = dataType.build();
+  }
+
+  @Before
+  public void before() {
     behaviorTester
         .with(new Processor(features))
-        .with(UNCHECKED_PROPERTY)
-        .with(testBuilder()
-            .addLine("DataType value = new DataType.Builder()")
-            .addLine("    .mutateItems(items -> {")
-            .addLine("      items.put(\"one\", \"A\");")
-            .addLine("      items.put(\"two\", \"B\");")
-            .addLine("    })")
-            .addLine("    .build();")
-            .addLine("assertThat(value.getItems())")
-            .addLine("    .contains(\"one\", \"A\")")
-            .addLine("    .and(\"two\", \"B\")")
-            .addLine("    .andNothingElse()")
-            .addLine("    .inOrder();")
-            .build())
-        .runTest();
+        .withPermittedPackage(NonComparable.class.getPackage());
   }
 
   @Test
-  public void mutateAndPutModifiesUnderlyingProperty_whenChecked() {
+  public void mutateAndPutModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
             .addLine("    .mutateItems(items -> {")
-            .addLine("      items.put(\"one\", \"A\");")
-            .addLine("      items.put(\"two\", \"B\");")
+            .addLine("      items.put(%s, %s);", key.example(0), value.example(1))
+            .addLine("      items.put(%s, %s);", key.example(2), value.example(3))
             .addLine("    })")
             .addLine("    .build();")
-            .addLine("assertThat(value.getItems())")
-            .addLine("    .contains(\"one\", \"A\")")
-            .addLine("    .and(\"two\", \"B\")")
+            .addLine("assertThat(value.%s)", convention.get())
+            .addLine("    .contains(%s, %s)", key.example(0), value.example(1))
+            .addLine("    .and(%s, %s)", key.example(2), value.example(3))
             .addLine("    .andNothingElse()")
             .addLine("    .inOrder();")
             .build())
@@ -142,30 +144,33 @@ public class SetMultimapMutateMethodTest {
 
   @Test
   public void mutateAndPutChecksArguments() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("value may not be empty");
+    if (checked) {
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage(value.errorMessage("value"));
+    }
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
-            .addLine("new DataType.Builder().mutateItems(items -> items.put(\"one\", \"\"));")
+            .addLine("new DataType.Builder().mutateItems(items -> items.put(%s, %s));",
+                key.example(0), value.invalidExample())
             .build())
         .runTest();
   }
 
   @Test
   public void mutateAndPutKeepsSubstitute() {
+    assumeTrue(interned);
     behaviorTester
-        .with(new Processor(features))
-        .with(INTERNED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
-            .addLine("String s = new String(\"foobar\");")
-            .addLine("String i = s.intern();")
+            .addLine("%1$s s = new %1$s(%2$s);", value.type(), value.example(0))
+            .addLine("%s i = %s;", value.type(), value.intern("s"))
             .addLine("assertThat(s).isNotSameAs(i);")
             .addLine("DataType value = new DataType.Builder()")
-            .addLine("    .mutateItems(items -> items.put(\"one\", s))")
+            .addLine("    .mutateItems(items -> items.put(%s, s))", key.example(0))
             .addLine("    .build();")
-            .addLine("assertThat(value.getItems().values().iterator().next()).isSameAs(i);")
+            .addLine("assertThat(value.%s.values().iterator().next()).isSameAs(i);",
+                convention.get())
             .build())
         .runTest();
   }
@@ -173,18 +178,19 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndPutAllValuesModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
             .addLine("    .mutateItems(items -> {")
-            .addLine("      items.putAll(\"one\", ImmutableList.of(\"A\", \"a\"));")
-            .addLine("      items.putAll(\"two\", ImmutableList.of(\"B\", \"b\"));")
+            .addLine("      items.putAll(%s, ImmutableList.of(%s));",
+                key.example(0), value.examples(1, 2))
+            .addLine("      items.putAll(%s, ImmutableList.of(%s));",
+                key.example(3), value.examples(4, 5))
             .addLine("    })")
             .addLine("    .build();")
-            .addLine("assertThat(value.getItems())")
-            .addLine("    .contains(\"one\", \"A\", \"a\")")
-            .addLine("    .and(\"two\", \"B\", \"b\")")
+            .addLine("assertThat(value.%s)", convention.get())
+            .addLine("    .contains(%s, %s)", key.example(0), value.examples(1, 2))
+            .addLine("    .and(%s, %s)", key.example(3), value.examples(4, 5))
             .addLine("    .andNothingElse()")
             .addLine("    .inOrder();")
             .build())
@@ -193,32 +199,36 @@ public class SetMultimapMutateMethodTest {
 
   @Test
   public void mutateAndPutAllValuesChecksArguments() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("value may not be empty");
+    if (checked) {
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage(value.errorMessage("value"));
+    }
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("new DataType.Builder().mutateItems(items -> items")
-            .addLine("    .putAll(\"one\", ImmutableList.of(\"A\", \"\")));")
+            .addLine("    .putAll(%s, ImmutableList.of(%s, %s)));",
+                key.example(0), value.example(1), value.invalidExample())
             .build())
         .runTest();
   }
 
   @Test
   public void mutateAndPutAllValuesKeepsSubstitute() {
+    assumeTrue(interned);
     behaviorTester
-        .with(new Processor(features))
-        .with(INTERNED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
-            .addLine("String s = new String(\"foobar\");")
-            .addLine("String i = s.intern();")
+            .addLine("%1$s s = new %1$s(%2$s);", value.type(), value.example(0))
+            .addLine("%s i = %s;", value.type(), value.intern("s"))
             .addLine("assertThat(s).isNotSameAs(i);")
             .addLine("DataType value = new DataType.Builder()")
             .addLine("    .mutateItems(items -> items")
-            .addLine("        .putAll(\"one\", ImmutableList.of(s, \"bazbam\")))")
+            .addLine("        .putAll(%s, ImmutableList.of(s, %s)))",
+                key.example(0), value.example(1))
             .addLine("    .build();")
-            .addLine("assertThat(value.getItems().values().iterator().next()).isSameAs(i);")
+            .addLine("assertThat(value.%s.values().iterator().next()).isSameAs(i);",
+                convention.get())
             .build())
         .runTest();
   }
@@ -226,16 +236,16 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndPutAllMultimapModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
             .addLine("    .mutateItems(items -> items")
-            .addLine("        .putAll(ImmutableMultimap.of(\"one\", \"A\", \"two\", \"B\")))")
+            .addLine("        .putAll(ImmutableMultimap.of(%s, %s, %s, %s)))",
+                key.example(0), value.example(1), key.example(2), value.example(3))
             .addLine("    .build();")
-            .addLine("assertThat(value.getItems())")
-            .addLine("    .contains(\"one\", \"A\")")
-            .addLine("    .and(\"two\", \"B\")")
+            .addLine("assertThat(value.%s)", convention.get())
+            .addLine("    .contains(%s, %s)", key.example(0), value.example(1))
+            .addLine("    .and(%s, %s)", key.example(2), value.example(3))
             .addLine("    .andNothingElse()")
             .addLine("    .inOrder();")
             .build())
@@ -244,32 +254,36 @@ public class SetMultimapMutateMethodTest {
 
   @Test
   public void mutateAndPutAllMultimapChecksArguments() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("value may not be empty");
+    if (checked) {
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage(value.errorMessage("value"));
+    }
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("new DataType.Builder().mutateItems(items -> items")
-            .addLine("    .putAll(ImmutableMultimap.of(\"one\", \"A\", \"two\", \"\")));")
+            .addLine("        .putAll(ImmutableMultimap.of(%s, %s, %s, %s)));",
+                key.example(0), value.example(1), key.example(2), value.invalidExample())
             .build())
         .runTest();
   }
 
   @Test
   public void mutateAndPutAllMultimapKeepsSubstitute() {
+    assumeTrue(interned);
     behaviorTester
-        .with(new Processor(features))
-        .with(INTERNED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
-            .addLine("String s = new String(\"foobar\");")
-            .addLine("String i = s.intern();")
+            .addLine("%1$s s = new %1$s(%2$s);", value.type(), value.example(0))
+            .addLine("%s i = %s;", value.type(), value.intern("s"))
             .addLine("assertThat(s).isNotSameAs(i);")
             .addLine("DataType value = new DataType.Builder()")
             .addLine("    .mutateItems(items -> items")
-            .addLine("        .putAll(ImmutableMultimap.of(\"one\", s, \"two\", \"bazbam\")))")
+            .addLine("        .putAll(ImmutableMultimap.of(%s, s, %s, %s)))",
+                key.example(0), key.example(1), value.example(2))
             .addLine("    .build();")
-            .addLine("assertThat(value.getItems().values().iterator().next()).isSameAs(i);")
+            .addLine("assertThat(value.%s.values().iterator().next()).isSameAs(i);",
+                convention.get())
             .build())
         .runTest();
   }
@@ -277,16 +291,16 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndReplaceValuesModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
-            .addLine("    .putItems(\"one\", \"i\")")
+            .addLine("    .putItems(%s, %s)", key.example(0), value.example(1))
             .addLine("    .mutateItems(items -> items")
-            .addLine("        .replaceValues(\"one\", ImmutableList.of(\"A\", \"a\")))")
+            .addLine("        .replaceValues(%s, ImmutableList.of(%s)))",
+                key.example(0), value.examples(2, 3))
             .addLine("    .build();")
-            .addLine("assertThat(value.getItems())")
-            .addLine("    .contains(\"one\", \"A\", \"a\")")
+            .addLine("assertThat(value.%s)", convention.get())
+            .addLine("    .contains(%s, %s)", key.example(0), value.examples(2, 3))
             .addLine("    .andNothingElse()")
             .addLine("    .inOrder();")
             .build())
@@ -295,35 +309,39 @@ public class SetMultimapMutateMethodTest {
 
   @Test
   public void mutateAndReplaceValuesChecksArguments() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("value may not be empty");
+    if (checked) {
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage(value.errorMessage("value"));
+    }
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
-            .addLine("    .putItems(\"one\", \"i\")")
+            .addLine("    .putItems(%s, %s)", key.example(0), value.example(1))
             .addLine("    .mutateItems(items -> items")
-            .addLine("        .replaceValues(\"one\", ImmutableList.of(\"A\", \"\")));")
+            .addLine("        .replaceValues(%s, ImmutableList.of(%s, %s)));",
+                key.example(0), value.example(2), value.invalidExample())
             .build())
         .runTest();
   }
 
   @Test
   public void mutateAndReplaceValuesKeepsSubstitute() {
+    assumeTrue(interned);
     behaviorTester
-        .with(new Processor(features))
-        .with(INTERNED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
-            .addLine("String s = new String(\"foobar\");")
-            .addLine("String i = s.intern();")
+            .addLine("%1$s s = new %1$s(%2$s);", value.type(), value.example(0))
+            .addLine("%s i = %s;", value.type(), value.intern("s"))
             .addLine("assertThat(s).isNotSameAs(i);")
             .addLine("DataType value = new DataType.Builder()")
-            .addLine("    .putItems(\"one\", \"i\")")
+            .addLine("    .putItems(%s, %s)", key.example(0), value.example(1))
             .addLine("    .mutateItems(items -> items")
-            .addLine("        .replaceValues(\"one\", ImmutableList.of(s, \"a\")))")
+            .addLine("        .replaceValues(%s, ImmutableList.of(s, %s)))",
+                key.example(0), value.example(2))
             .addLine("    .build();")
-            .addLine("assertThat(value.getItems().values().iterator().next()).isSameAs(i);")
+            .addLine("assertThat(value.%s.values().iterator().next()).isSameAs(i);",
+                convention.get())
             .build())
         .runTest();
   }
@@ -331,15 +349,15 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndAddViaGetModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
-            .addLine("    .putItems(\"one\", \"A\")")
-            .addLine("    .mutateItems(items -> items.get(\"one\").add(\"a\"))")
+            .addLine("    .putItems(%s, %s)", key.example(0), value.example(1))
+            .addLine("    .mutateItems(items -> items.get(%s).add(%s))",
+                key.example(0), value.example(2))
             .addLine("    .build();")
-            .addLine("assertThat(value.getItems())")
-            .addLine("    .contains(\"one\", \"A\", \"a\")")
+            .addLine("assertThat(value.%s)", convention.get())
+            .addLine("    .contains(%s, %s)", key.example(0), value.examples(1, 2))
             .addLine("    .andNothingElse()")
             .addLine("    .inOrder();")
             .build())
@@ -348,33 +366,36 @@ public class SetMultimapMutateMethodTest {
 
   @Test
   public void mutateAndAddViaGetChecksArguments() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("value may not be empty");
+    if (checked) {
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage(value.errorMessage("value"));
+    }
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
-            .addLine("    .putItems(\"one\", \"A\")")
-            .addLine("    .mutateItems(items -> items.get(\"one\").add(\"\"));")
+            .addLine("    .putItems(%s, %s)", key.example(0), value.example(1))
+            .addLine("    .mutateItems(items -> items.get(%s).add(%s));",
+                key.example(0), value.invalidExample())
             .build())
         .runTest();
   }
 
   @Test
   public void mutateAndAddViaGetKeepsSubstitute() {
+    assumeTrue(interned);
     behaviorTester
-        .with(new Processor(features))
-        .with(INTERNED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
-            .addLine("String s = new String(\"foobar\");")
-            .addLine("String i = s.intern();")
+            .addLine("%1$s s = new %1$s(%2$s);", value.type(), value.example(0))
+            .addLine("%s i = %s;", value.type(), value.intern("s"))
             .addLine("assertThat(s).isNotSameAs(i);")
             .addLine("DataType value = new DataType.Builder()")
-            .addLine("    .putItems(\"one\", \"A\")")
-            .addLine("    .mutateItems(items -> items.get(\"one\").add(s))")
+            .addLine("    .putItems(%s, %s)", key.example(1), value.example(2))
+            .addLine("    .mutateItems(items -> items.get(%s).add(s))", key.example(1))
             .addLine("    .build();")
-            .addLine("Iterator<? extends String> it = value.getItems().values().iterator();")
+            .addLine("Iterator<? extends %s> it = value.%s.values().iterator();",
+                value.type(), convention.get())
             .addLine("it.next();")
             .addLine("assertThat(it.next()).isSameAs(i);")
             .build())
@@ -384,15 +405,15 @@ public class SetMultimapMutateMethodTest {
   @Test
   public void mutateAndAddViaAsMapModifiesUnderlyingProperty() {
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("DataType value = new DataType.Builder()")
-            .addLine("    .putItems(\"one\", \"A\")")
-            .addLine("    .mutateItems(items -> items.asMap().get(\"one\").add(\"a\"))")
+            .addLine("    .putItems(%s, %s)", key.example(0), value.example(1))
+            .addLine("    .mutateItems(items -> items.asMap().get(%s).add(%s))",
+                key.example(0), value.example(2))
             .addLine("    .build();")
-            .addLine("assertThat(value.getItems())")
-            .addLine("    .contains(\"one\", \"A\", \"a\")")
+            .addLine("assertThat(value.%s)", convention.get())
+            .addLine("    .contains(%s, %s)", key.example(0), value.examples(1, 2))
             .addLine("    .andNothingElse()")
             .addLine("    .inOrder();")
             .build())
@@ -401,99 +422,36 @@ public class SetMultimapMutateMethodTest {
 
   @Test
   public void mutateAndAddViaAsMapChecksArguments() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("value may not be empty");
+    if (checked) {
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage(value.errorMessage("value"));
+    }
     behaviorTester
-        .with(new Processor(features))
-        .with(CHECKED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
             .addLine("new DataType.Builder()")
-            .addLine("    .putItems(\"one\", \"A\")")
-            .addLine("    .mutateItems(items -> items.asMap().get(\"one\").add(\"\"));")
+            .addLine("    .putItems(%s, %s)", key.example(0), value.example(1))
+            .addLine("    .mutateItems(items -> items.asMap().get(%s).add(%s));",
+                key.example(0), value.invalidExample())
             .build())
         .runTest();
   }
 
   @Test
   public void mutateAndAddViaAsMapKeepsSubstitute() {
+    assumeTrue(interned);
     behaviorTester
-        .with(new Processor(features))
-        .with(INTERNED_PROPERTY)
+        .with(dataType)
         .with(testBuilder()
-            .addLine("String s = new String(\"foobar\");")
-            .addLine("String i = s.intern();")
+            .addLine("%1$s s = new %1$s(%2$s);", value.type(), value.example(0))
+            .addLine("%s i = %s;", value.type(), value.intern("s"))
             .addLine("assertThat(s).isNotSameAs(i);")
             .addLine("DataType value = new DataType.Builder()")
-            .addLine("    .putItems(\"one\", \"A\")")
-            .addLine("    .mutateItems(items -> items.asMap().get(\"one\").add(s))")
+            .addLine("    .putItems(%s, %s)", key.example(1), value.example(2))
+            .addLine("    .mutateItems(items -> items.asMap().get(%s).add(s))", key.example(1))
             .addLine("    .build();")
-            .addLine("assertThat(Iterables.get(value.getItems().get(\"one\"), 1)).isSameAs(i);")
-            .build())
-        .runTest();
-  }
-
-  @Test
-  public void mutateAndPutModifiesUnderlyingProperty_whenUnchecked_prefixless() {
-    behaviorTester
-        .with(new Processor(features))
-        .with(new SourceBuilder()
-            .addLine("package com.example;")
-            .addLine("@%s", FreeBuilder.class)
-            .addLine("public abstract class DataType {")
-            .addLine("  public abstract %s<String, String> items();", SetMultimap.class)
-            .addLine("")
-            .addLine("  public static class Builder extends DataType_Builder {}")
-            .addLine("}")
-            .build())
-        .with(testBuilder()
-            .addLine("DataType value = new DataType.Builder()")
-            .addLine("    .mutateItems(items -> {")
-            .addLine("      items.put(\"one\", \"A\");")
-            .addLine("      items.put(\"two\", \"B\");")
-            .addLine("    })")
-            .addLine("    .build();")
-            .addLine("assertThat(value.items())")
-            .addLine("    .contains(\"one\", \"A\")")
-            .addLine("    .and(\"two\", \"B\")")
-            .addLine("    .andNothingElse()")
-            .addLine("    .inOrder();")
-            .build())
-        .runTest();
-  }
-
-  @Test
-  public void mutateAndPutModifiesUnderlyingProperty_whenChecked_prefixless() {
-    behaviorTester
-        .with(new Processor(features))
-        .with(new SourceBuilder()
-            .addLine("package com.example;")
-            .addLine("@%s", FreeBuilder.class)
-            .addLine("public abstract class DataType {")
-            .addLine("  public abstract %s<String, String> items();", SetMultimap.class)
-            .addLine("")
-            .addLine("  public static class Builder extends DataType_Builder {")
-            .addLine("    @Override public Builder putItems(String key, String value) {")
-            .addLine("      %s.checkArgument(!key.isEmpty(), \"key may not be empty\");",
-                Preconditions.class)
-            .addLine("      %s.checkArgument(!value.isEmpty(), \"value may not be empty\");",
-                Preconditions.class)
-            .addLine("      return super.putItems(key, value);")
-            .addLine("    }")
-            .addLine("  }")
-            .addLine("}")
-            .build())
-        .with(testBuilder()
-            .addLine("DataType value = new DataType.Builder()")
-            .addLine("    .mutateItems(items -> {")
-            .addLine("      items.put(\"one\", \"A\");")
-            .addLine("      items.put(\"two\", \"B\");")
-            .addLine("    })")
-            .addLine("    .build();")
-            .addLine("assertThat(value.items())")
-            .addLine("    .contains(\"one\", \"A\")")
-            .addLine("    .and(\"two\", \"B\")")
-            .addLine("    .andNothingElse()")
-            .addLine("    .inOrder();")
+            .addLine("assertThat(Iterables.get(value.%s.get(%s), 1)).isSameAs(i);",
+                convention.get(), key.example(1))
             .build())
         .runTest();
   }
@@ -507,5 +465,4 @@ public class SetMultimapMutateMethodTest {
         .addImport(Iterables.class)
         .addImport(Iterator.class);
   }
-
 }

--- a/src/test/java/org/inferred/freebuilder/processor/testtype/NonComparable.java
+++ b/src/test/java/org/inferred/freebuilder/processor/testtype/NonComparable.java
@@ -21,16 +21,33 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class NonComparable extends AbstractNonComparable {
+
+  private static final ConcurrentMap<NonComparable, NonComparable> interned =
+      new ConcurrentHashMap<>();
 
   private final int id;
   private final String name;
 
   @JsonCreator
-  public NonComparable(@JsonProperty("id") int id, @JsonProperty("name") String name) {
+  public static NonComparable of(@JsonProperty("id") int id, @JsonProperty("name") String name) {
+    return new NonComparable(id, name).intern();
+  }
+
+  private NonComparable(int id, String name) {
     this.id = requireNonNull(id);
     this.name = requireNonNull(name);
+  }
+
+  public NonComparable(NonComparable other) {
+    this(other.id, other.name);
+  }
+
+  public NonComparable intern() {
+    return interned.computeIfAbsent(this, k -> k);
   }
 
   @Override


### PR DESCRIPTION
Reduce test code duplication and increase coverage by parameterizing the remaining mapper method tests.

