### PR TITLE
Custom functional interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ _Automatic generation of the Builder pattern for Java 1.6+_
   - [Collections and Maps](#collections-and-maps)
   - [Nested buildable types](#nested-buildable-types)
   - [Custom toString method](#custom-tostring-method)
+  - [Custom functional interfaces](#custom-functional-interfaces)
   - [Builder construction](#builder-construction)
   - [Partials](#partials)
   - [Jackson](#jackson)
@@ -459,6 +460,22 @@ Note that it is a compile error to leave hashCode abstract if equals is implemen
 It is rarely a good idea to redefine equality on a value type, as it makes testing very hard.
 For instance, `assertEquals` in JUnit relies on equality; it will not know to check individual fields, and as a result, tests may be failing to catch bugs that, on the face of it, they looks like they should be.
 If you are only testing a subset of your fields for equality, consider separating your class in two, as you may have accidentally combined the key and the value of a map into a single object, and you may find your code becomes healthier after the separation.
+
+### Custom functional interfaces
+
+FreeBuilder's generated map and mutate methods take [UnaryOperator] or [Consumer] functional interfaces. If you need to use a different functional interface, you can override the generated methods in your Builder and change the parameter type. FreeBuilder will spot the incompatible override and change the code it generates to match:
+
+```java
+public interface MyType {
+  String property();
+
+  class Builder extends MyType_Builder {
+    @Override public Builder mapProperty(
+        com.google.common.base.Function<Integer, Integer> mapper) {
+      return super.mapProperty(mapper);
+    }
+  }
+}
 
 ### Builder construction
 

--- a/src/main/java/org/inferred/freebuilder/processor/ListProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListProperty.java
@@ -125,8 +125,8 @@ class ListProperty extends PropertyCodeGenerator {
         TypeMirror elementType,
         Elements elements,
         Types types) {
-      TypeElement arrayListType = elements.getTypeElement(List.class.getName());
-      return types.getWildcardType(null, types.getDeclaredType(arrayListType, elementType));
+      TypeElement listType = elements.getTypeElement(List.class.getName());
+      return types.getWildcardType(null, types.getDeclaredType(listType, elementType));
     }
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/FunctionalType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/FunctionalType.java
@@ -1,0 +1,212 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static javax.lang.model.element.Modifier.ABSTRACT;
+import static org.inferred.freebuilder.processor.util.MethodFinder.methodsOn;
+import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
+import static org.inferred.freebuilder.processor.util.ModelUtils.only;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+import org.inferred.freebuilder.processor.util.MethodFinder.ErrorTypeHandling;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ErrorType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+/**
+ * Metadata about a functional interface.
+ */
+public class FunctionalType extends ValueType {
+
+  private static final String FUNCTION_PACKAGE = "java.util.function";
+  private static final QualifiedName CONSUMER =
+      QualifiedName.of(FUNCTION_PACKAGE, "Consumer");
+
+  public static final QualifiedName UNARY_OPERATOR =
+      QualifiedName.of(FUNCTION_PACKAGE, "UnaryOperator");
+
+  private static final ErrorTypeHandling<RuntimeException> IGNORE_ERROR_TYPES =
+      new ErrorTypeHandling<RuntimeException>() {
+        @Override public void handleErrorType(ErrorType type) { }
+      };
+
+  public static FunctionalType consumer(TypeMirror type) {
+    checkState(!type.getKind().isPrimitive(), "Unexpected primitive type %s", type);
+    return new FunctionalType(
+        CONSUMER.withParameters(type),
+        "accept",
+        ImmutableList.of(type),
+        null);
+  }
+
+  public static FunctionalType unaryOperator(TypeMirror type) {
+    checkState(!type.getKind().isPrimitive(), "Unexpected primitive type %s", type);
+    return new FunctionalType(
+        UNARY_OPERATOR.withParameters(type),
+        "apply",
+        ImmutableList.of(type),
+        type);
+  }
+
+  /**
+   * Returns the functional type accepted by {@code methodName} on {@code type}, assignable to
+   * {@code prototype}, or {@code prototype} itself if no such method has been declared.
+   *
+   * <p>Used to allow the user to override the functional interface used on builder methods,
+   * e.g. to force boxing, or to use Guava types.
+   */
+  public static FunctionalType functionalTypeAcceptedByMethod(
+      DeclaredType type,
+      String methodName,
+      FunctionalType prototype,
+      Elements elements,
+      Types types) {
+    TypeElement typeElement = asElement(type);
+    for (ExecutableElement method : methodsOn(typeElement, elements, IGNORE_ERROR_TYPES)) {
+      if (!method.getSimpleName().contentEquals(methodName)
+          || method.getParameters().size() != 1) {
+        continue;
+      }
+      ExecutableType methodType = (ExecutableType) types.asMemberOf(type, method);
+      TypeMirror parameter = getOnlyElement(methodType.getParameterTypes());
+      FunctionalType functionalType = maybeFunctionalType(parameter, elements, types).orNull();
+      if (functionalType == null || !isAssignable(functionalType, prototype, types)) {
+        continue;
+      }
+      return functionalType;
+    }
+    return prototype;
+  }
+
+  public static Optional<FunctionalType> maybeFunctionalType(
+      TypeMirror type,
+      Elements elements,
+      Types types) {
+    DeclaredType declaredType = maybeDeclared(type).orNull();
+    if (declaredType == null) {
+      return Optional.absent();
+    }
+    return maybeFunctionalType(declaredType, elements, types);
+  }
+
+  public static Optional<FunctionalType> maybeFunctionalType(
+      DeclaredType type,
+      Elements elements,
+      Types types) {
+    TypeElement typeElement = asElement(type);
+    if (!typeElement.getKind().isInterface()) {
+      return Optional.absent();
+    }
+    Set<ExecutableElement> abstractMethods =
+        only(ABSTRACT, methodsOn(typeElement, elements, IGNORE_ERROR_TYPES));
+    if (abstractMethods.size() != 1) {
+      return Optional.absent();
+    }
+    ExecutableElement method = getOnlyElement(abstractMethods);
+    ExecutableType methodType = (ExecutableType) types.asMemberOf(type, method);
+    return Optional.of(new FunctionalType(
+        ParameterizedType.from(type),
+        method.getSimpleName().toString(),
+        methodType.getParameterTypes(),
+        methodType.getReturnType()));
+  }
+
+  @VisibleForTesting static boolean isAssignable(
+      FunctionalType fromType,
+      FunctionalType toType,
+      Types types) {
+    if (toType.getParameters().size() != fromType.getParameters().size()) {
+      return false;
+    }
+    for (int i = 0; i < toType.getParameters().size(); ++i) {
+      TypeMirror fromParam = fromType.getParameters().get(i);
+      TypeMirror toParam = toType.getParameters().get(i);
+      if (!isAssignable(fromParam, toParam, types)) {
+        return false;
+      }
+    }
+    return isAssignable(fromType.getReturnType(), toType.getReturnType(), types);
+  }
+
+  private static boolean isAssignable(
+      @Nullable TypeMirror fromParam, @Nullable TypeMirror toParam, Types types) {
+    if (isVoid(fromParam) || isVoid(toParam)) {
+      return isVoid(fromParam) && isVoid(toParam);
+    }
+    return types.isAssignable(fromParam, toParam);
+  }
+
+  private static boolean isVoid(@Nullable TypeMirror type) {
+    return type == null || type.getKind() == TypeKind.VOID;
+  }
+
+  private final ParameterizedType functionalInterface;
+  private final String methodName;
+  private final List<TypeMirror> parameters;
+  private final TypeMirror returnType;
+
+  private FunctionalType(
+      ParameterizedType functionalInterface,
+      String methodName,
+      Collection<? extends TypeMirror> parameters,
+      TypeMirror returnType) {
+    this.functionalInterface = functionalInterface;
+    this.methodName = methodName;
+    this.parameters = ImmutableList.copyOf(parameters);
+    this.returnType = returnType;
+  }
+
+  public ParameterizedType getFunctionalInterface() {
+    return functionalInterface;
+  }
+
+  public String getMethodName() {
+    return methodName;
+  }
+
+  public List<TypeMirror> getParameters() {
+    return parameters;
+  }
+
+  public TypeMirror getReturnType() {
+    return returnType;
+  }
+
+  public boolean canReturnNull() {
+    return !returnType.getKind().isPrimitive();
+  }
+
+  @Override
+  protected void addFields(FieldReceiver fields) {
+    fields.add("functionalInterface", functionalInterface);
+    fields.add("methodName", methodName);
+    List<String> parametersAsStrings = new ArrayList<String>();
+    for (TypeMirror parameter : parameters) {
+      parametersAsStrings.add(parameter.toString());
+    }
+    fields.add("parameters", parametersAsStrings);
+    fields.add("returnType", returnType.toString());
+  }
+
+  @Override
+  public String toString() {
+    return functionalInterface.toString();
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ModelUtils.java
@@ -18,14 +18,17 @@ package org.inferred.freebuilder.processor.util;
 import static javax.lang.model.util.ElementFilter.methodsIn;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
 
 import java.lang.annotation.Annotation;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
@@ -172,6 +175,16 @@ public class ModelUtils {
         return false;
       }
     }, null);
+  }
+
+  public static Set<ExecutableElement> only(Modifier modifier, Set<ExecutableElement> methods) {
+    ImmutableSet.Builder<ExecutableElement> result = ImmutableSet.builder();
+    for (ExecutableElement method : methods) {
+      if (method.getModifiers().contains(modifier)) {
+        result.add(method);
+      }
+    }
+    return result.build();
   }
 
   private static boolean isPlainWildcard(TypeMirror type) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.TypeMirror;
 
 /**
  * The qualified name of a type. Lets us pass a type to a {@link TypeShortener} without a Class or
@@ -115,6 +116,10 @@ public class QualifiedName extends ValueType {
 
   public ParameterizedType withParameters(String... typeParameters) {
     return new ParameterizedType(this, ImmutableList.copyOf(typeParameters));
+  }
+
+  public ParameterizedType withParameters(TypeMirror first, TypeMirror... rest) {
+    return new ParameterizedType(this, ImmutableList.builder().add(first).add(rest).build());
   }
 
   public ParameterizedType withParameters(Iterable<? extends TypeParameterElement> typeParameters) {

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedMapperMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedMapperMethodTest.java
@@ -15,6 +15,9 @@
  */
 package org.inferred.freebuilder.processor;
 
+import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
+import static org.junit.Assume.assumeTrue;
+
 import com.google.common.collect.Lists;
 
 import org.inferred.freebuilder.FreeBuilder;
@@ -34,6 +37,8 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.IntUnaryOperator;
+import java.util.function.UnaryOperator;
 
 import javax.tools.JavaFileObject;
 
@@ -144,6 +149,104 @@ public class DefaultedMapperMethodTest {
             .addLine("    .mapProperty(a -> -3);")
             .build())
         .runTest();
+  }
+
+  @Test
+  public void mapCanAcceptPrimitiveFunctionalInterface() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  int %s;", convention.get("property"))
+            .addLine("")
+            .addLine("  public static class Builder extends DataType_Builder {")
+            .addLine("    public Builder() {")
+            .addLine("      %s(11);", convention.set("property"))
+            .addLine("    }")
+            .addLine("")
+            .addLine("    @Override public Builder mapProperty(%s mapper) {",
+                IntUnaryOperator.class)
+            .addLine("      return super.mapProperty(mapper);")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}")
+            .build())
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mapProperty(a -> a + 3)")
+            .addLine("    .build();")
+            .addLine("assertEquals(14, value.%s);", convention.get("property"))
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mapCanAcceptGenericFunctionalInterface() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  int %s;", convention.get("property"))
+            .addLine("")
+            .addLine("  public static class Builder extends DataType_Builder {")
+            .addLine("    public Builder() {")
+            .addLine("      %s(11);", convention.set("property"))
+            .addLine("    }")
+            .addLine("")
+            .addLine("    @Override public Builder mapProperty(%s<Integer> mapper) {",
+                UnaryOperator.class)
+            .addLine("      return super.mapProperty(mapper);")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}")
+            .build())
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mapProperty(a -> a + 3)")
+            .addLine("    .build();")
+            .addLine("assertEquals(14, value.%s);", convention.get("property"))
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void mapCanAcceptOtherFunctionalInterface() {
+    assumeGuavaAvailable();
+    behaviorTester
+        .with(new Processor(features))
+        .with(new SourceBuilder()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  int %s;", convention.get("property"))
+            .addLine("")
+            .addLine("  public static class Builder extends DataType_Builder {")
+            .addLine("    public Builder() {")
+            .addLine("      %s(11);", convention.set("property"))
+            .addLine("    }")
+            .addLine("")
+            .addLine("    @Override public Builder mapProperty(%s<Integer, Integer> mapper) {",
+                com.google.common.base.Function.class)
+            .addLine("      return super.mapProperty(mapper);")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}")
+            .build())
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mapProperty(a -> a + 3)")
+            .addLine("    .build();")
+            .addLine("assertEquals(14, value.%s);", convention.get("property"))
+            .build())
+        .runTest();
+  }
+
+  private void assumeGuavaAvailable() {
+    assumeTrue("Guava available", features.get(GUAVA).isAvailable());
   }
 
   private static TestBuilder testBuilder() {

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
@@ -18,6 +18,7 @@ package org.inferred.freebuilder.processor;
 import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
+import static org.inferred.freebuilder.processor.util.FunctionalType.unaryOperator;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
@@ -692,13 +693,14 @@ public class DefaultedPropertiesSourceTest {
     Metadata metadataWithCodeGenerators = metadata.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, name, false))
+            .setCodeGenerator(new DefaultProperty(metadata, name, false, unaryOperator(STRING)))
             .build())
         .addProperties(age.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, age, true))
+            .setCodeGenerator(new DefaultProperty(metadata, age, true, unaryOperator(INTEGER)))
             .build())
         .addProperties(shoeSize.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, shoeSize, false))
+            .setCodeGenerator(new DefaultProperty(
+                metadata, shoeSize, false, unaryOperator(INTEGER)))
             .build())
         .build();
 
@@ -1719,10 +1721,10 @@ public class DefaultedPropertiesSourceTest {
     return metadata.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, name, true))
+            .setCodeGenerator(new DefaultProperty(metadata, name, true, unaryOperator(STRING)))
             .build())
         .addProperties(age.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, age, true))
+            .setCodeGenerator(new DefaultProperty(metadata, age, true, unaryOperator(INTEGER)))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
@@ -16,7 +16,8 @@
 package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
@@ -34,8 +35,6 @@ import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import javax.lang.model.type.TypeMirror;
 
 @RunWith(JUnit4.class)
 public class DefaultedPropertiesSourceTest {
@@ -646,21 +645,20 @@ public class DefaultedPropertiesSourceTest {
   @Test
   public void testJ6_noGuava_oneDefaultProperty() {
     QualifiedName person = QualifiedName.of("com.example", "Person");
-    TypeMirror string = newTopLevelClass("java.lang.String");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
-        .setBoxedType(string)
+        .setBoxedType(STRING)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName("getName")
         .setName("name")
-        .setType(string)
+        .setType(STRING)
         .setUsingBeanConvention(true)
         .build();
     Property age = new Property.Builder()
         .setAllCapsName("AGE")
-        .setBoxedType(newTopLevelClass("java.lang.Integer"))
+        .setBoxedType(INTEGER)
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName("getAge")
@@ -670,7 +668,7 @@ public class DefaultedPropertiesSourceTest {
         .build();
     Property shoeSize = new Property.Builder()
         .setAllCapsName("SHOE_SIZE")
-        .setBoxedType(newTopLevelClass("java.lang.Integer"))
+        .setBoxedType(INTEGER)
         .setCapitalizedName("ShoeSize")
         .setFullyCheckedCast(true)
         .setGetterName("getShoeSize")
@@ -1684,21 +1682,20 @@ public class DefaultedPropertiesSourceTest {
 
   private static Metadata createMetadata(boolean bean) {
     QualifiedName person = QualifiedName.of("com.example", "Person");
-    TypeMirror string = newTopLevelClass("java.lang.String");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
-        .setBoxedType(string)
+        .setBoxedType(STRING)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName(bean ? "getName" : "name")
         .setName("name")
-        .setType(string)
+        .setType(STRING)
         .setUsingBeanConvention(bean)
         .build();
     Property age = new Property.Builder()
         .setAllCapsName("AGE")
-        .setBoxedType(newTopLevelClass("java.lang.Integer"))
+        .setBoxedType(INTEGER)
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName(bean ? "getAge" : "age")

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
@@ -16,6 +16,7 @@
 package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.inferred.freebuilder.processor.util.FunctionalType.unaryOperator;
 import static org.inferred.freebuilder.processor.util.TypeParameterElementImpl.newTypeParameterElement;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
@@ -901,10 +902,12 @@ public class GenericTypeSourceTest {
     return metadata.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, name, false))
+            .setCodeGenerator(new DefaultProperty(
+                metadata, name, false, unaryOperator(paramA.asType())))
             .build())
         .addProperties(age.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, age, false))
+            .setCodeGenerator(new DefaultProperty(
+                metadata, age, false, unaryOperator(paramB.asType())))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
+import static org.inferred.freebuilder.processor.util.FunctionalType.unaryOperator;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
@@ -1316,11 +1317,23 @@ public class GuavaOptionalSourceTest {
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata, name, OptionalType.GUAVA, STRING, Optional.<TypeMirror>absent(), false))
+                metadata,
+                name,
+                OptionalType.GUAVA,
+                STRING,
+                Optional.<TypeMirror>absent(),
+                unaryOperator(STRING),
+                false))
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata, age, OptionalType.GUAVA, INTEGER, Optional.<TypeMirror>of(INT), false))
+                metadata,
+                age,
+                OptionalType.GUAVA,
+                INTEGER,
+                Optional.<TypeMirror>of(INT),
+                unaryOperator(INTEGER),
+                false))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
@@ -17,7 +17,8 @@ package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
-import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
@@ -30,7 +31,6 @@ import com.google.googlejavaformat.java.FormatterException;
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.OptionalProperty.OptionalType;
-import org.inferred.freebuilder.processor.util.ClassTypeImpl;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
@@ -1275,10 +1275,8 @@ public class GuavaOptionalSourceTest {
 
   private static Metadata createMetadataWithOptionalProperties(boolean bean) {
     GenericTypeElementImpl optional = newTopLevelGenericType("com.google.common.base.Optional");
-    ClassTypeImpl integer = newTopLevelClass("java.lang.Integer");
-    GenericTypeMirrorImpl optionalInteger = optional.newMirror(integer);
-    ClassTypeImpl string = newTopLevelClass("java.lang.String");
-    GenericTypeMirrorImpl optionalString = optional.newMirror(string);
+    GenericTypeMirrorImpl optionalInteger = optional.newMirror(INTEGER);
+    GenericTypeMirrorImpl optionalString = optional.newMirror(STRING);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     Property name = new Property.Builder()
@@ -1318,11 +1316,11 @@ public class GuavaOptionalSourceTest {
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata, name, OptionalType.GUAVA, string, Optional.<TypeMirror>absent(), false))
+                metadata, name, OptionalType.GUAVA, STRING, Optional.<TypeMirror>absent(), false))
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata, age, OptionalType.GUAVA, integer, Optional.<TypeMirror>of(INT), false))
+                metadata, age, OptionalType.GUAVA, INTEGER, Optional.<TypeMirror>of(INT), false))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
+import static org.inferred.freebuilder.processor.util.FunctionalType.unaryOperator;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
@@ -1032,11 +1033,23 @@ public class JavaUtilOptionalSourceTest {
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata, name, OptionalType.JAVA8, STRING, Optional.<TypeMirror>absent(), false))
+                metadata,
+                name,
+                OptionalType.JAVA8,
+                STRING,
+                Optional.<TypeMirror>absent(),
+                unaryOperator(STRING),
+                false))
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata, age, OptionalType.JAVA8, INTEGER, Optional.<TypeMirror>of(INT), false))
+                metadata,
+                age,
+                OptionalType.JAVA8,
+                INTEGER,
+                Optional.<TypeMirror>of(INT),
+                unaryOperator(INTEGER),
+                false))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
@@ -17,7 +17,8 @@ package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
-import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
@@ -29,7 +30,6 @@ import com.google.googlejavaformat.java.FormatterException;
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.OptionalProperty.OptionalType;
-import org.inferred.freebuilder.processor.util.ClassTypeImpl;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
@@ -991,10 +991,8 @@ public class JavaUtilOptionalSourceTest {
 
   private static Metadata createMetadataWithOptionalProperties(boolean bean) {
     GenericTypeElementImpl optional = newTopLevelGenericType("com.google.common.base.Optional");
-    ClassTypeImpl integer = newTopLevelClass("java.lang.Integer");
-    GenericTypeMirrorImpl optionalInteger = optional.newMirror(integer);
-    ClassTypeImpl string = newTopLevelClass("java.lang.String");
-    GenericTypeMirrorImpl optionalString = optional.newMirror(string);
+    GenericTypeMirrorImpl optionalInteger = optional.newMirror(INTEGER);
+    GenericTypeMirrorImpl optionalString = optional.newMirror(STRING);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     Property name = new Property.Builder()
@@ -1034,11 +1032,11 @@ public class JavaUtilOptionalSourceTest {
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata, name, OptionalType.JAVA8, string, Optional.<TypeMirror>absent(), false))
+                metadata, name, OptionalType.JAVA8, STRING, Optional.<TypeMirror>absent(), false))
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata, age, OptionalType.JAVA8, integer, Optional.<TypeMirror>of(INT), false))
+                metadata, age, OptionalType.JAVA8, INTEGER, Optional.<TypeMirror>of(INT), false))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/ListMultimapMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMultimapMutateMethodTest.java
@@ -43,6 +43,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -510,6 +511,41 @@ public class ListMultimapMutateMethodTest {
             .addLine("    .build();")
             .addLine("assertThat(value.%s.get(%s).get(2)).isSameAs(i);",
                 convention.get(), key.example(0))
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void canUseCustomFunctionalInterface() throws IOException {
+    SourceBuilder customMutatorType = new SourceBuilder();
+    for (String line : dataType.getCharContent(true).toString().split("\n")) {
+      customMutatorType.addLine("%s", line);
+      if (line.contains("extends DataType_Builder")) {
+        customMutatorType
+            .addLine("    public interface Mutator {")
+            .addLine("      void mutate(%s<%s, %s> multimap);",
+                ListMultimap.class, key.type(), value.type())
+            .addLine("    }")
+            .addLine("    @Override public Builder mutateItems(Mutator mutator) {")
+            .addLine("      return super.mutateItems(mutator);")
+            .addLine("    }");
+      }
+    }
+
+    behaviorTester
+        .with(customMutatorType.build())
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> {")
+            .addLine("      items.put(%s, %s);", key.example(0), value.example(1))
+            .addLine("      items.put(%s, %s);", key.example(2), value.example(3))
+            .addLine("    })")
+            .addLine("    .build();")
+            .addLine("assertThat(value.%s)", convention.get())
+            .addLine("    .contains(%s, %s)", key.example(0), value.example(1))
+            .addLine("    .and(%s, %s)", key.example(2), value.example(3))
+            .addLine("    .andNothingElse()")
+            .addLine("    .inOrder();")
             .build())
         .runTest();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/ListMutateMethodTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListMutateMethodTest.java
@@ -37,6 +37,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -455,6 +456,64 @@ public class ListMutateMethodTest {
             .addLine("    .build();")
             .addLine("assertThat(value.%s).containsExactly(%s).inOrder();",
                 convention.get(), elements.examples(0, 5, 6))
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void canUseCustomFunctionalInterface() throws IOException {
+    String defaultsTypeCode = listPropertyType.getCharContent(true).toString();
+    SourceBuilder customMutatorType = new SourceBuilder();
+    for (String line : defaultsTypeCode.split("\n")) {
+      customMutatorType.addLine("%s", line);
+      if (line.contains("extends DataType_Builder")) {
+        customMutatorType
+            .addLine("    public interface Mutator {")
+            .addLine("      void mutate(%s<%s> list);", List.class, elements.type())
+            .addLine("    }")
+            .addLine("    @Override public Builder mutateItems(Mutator mutator) {")
+            .addLine("      return super.mutateItems(mutator);")
+            .addLine("    }");
+      }
+    }
+    behaviorTester
+        .with(new Processor(features))
+        .with(customMutatorType.build())
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .mutateItems(items -> items.add(%s))", elements.example(0))
+            .addLine("    .build();")
+            .addLine("assertThat(value.%s).containsExactly(%s).inOrder();",
+                convention.get(), elements.example(0))
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void canUseCustomGenericFunctionalInterface() throws IOException {
+    String defaultsTypeCode = genericType.getCharContent(true).toString();
+    SourceBuilder customMutatorType = new SourceBuilder();
+    for (String line : defaultsTypeCode.split("\n")) {
+      customMutatorType.addLine("%s", line);
+      if (line.contains("extends DataType_Builder")) {
+        customMutatorType
+            .addLine("    public interface Mutator<T> {")
+            .addLine("      void mutate(%s<T> list);", List.class)
+            .addLine("    }")
+            .addLine("    @Override public Builder mutateItems(Mutator<T> mutator) {")
+            .addLine("      return super.mutateItems(mutator);")
+            .addLine("    }");
+      }
+    }
+    behaviorTester
+        .with(new Processor(features))
+        .with(customMutatorType.build())
+        .with(testBuilder()
+            .addLine("DataType<%1$s> value = new DataType.Builder<%1$s>()", elements.type())
+            .addLine("    .mutateItems(items -> items.add(%s))", elements.example(0))
+            .addLine("    .build();")
+            .addLine("assertThat(value.%s).containsExactly(%s).inOrder();",
+                convention.get(), elements.example(0))
             .build())
         .runTest();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -17,6 +17,8 @@ package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
@@ -1967,10 +1969,8 @@ public class ListSourceTest {
    */
   private static Metadata createMetadata(boolean bean) {
     GenericTypeElementImpl list = newTopLevelGenericType("java.util.List");
-    ClassTypeImpl integer = newTopLevelClass("java.lang.Integer");
-    GenericTypeMirrorImpl listInteger = list.newMirror(integer);
-    ClassTypeImpl string = newTopLevelClass("java.lang.String");
-    GenericTypeMirrorImpl listString = list.newMirror(string);
+    GenericTypeMirrorImpl listInteger = list.newMirror(INTEGER);
+    GenericTypeMirrorImpl listString = list.newMirror(STRING);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     Property name = new Property.Builder()
@@ -2010,11 +2010,11 @@ public class ListSourceTest {
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new ListProperty(
-                metadata, name, false, false, false, string, Optional.<TypeMirror>absent()))
+                metadata, name, false, false, false, STRING, Optional.<TypeMirror>absent()))
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new ListProperty(
-                metadata, age, false, false, false, integer, Optional.<TypeMirror>of(INT)))
+                metadata, age, false, false, false, INTEGER, Optional.<TypeMirror>of(INT)))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -20,6 +20,7 @@ import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLe
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
+import static org.inferred.freebuilder.processor.util.WildcardTypeImpl.wildcardSuper;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
@@ -29,6 +30,7 @@ import com.google.common.base.Optional;
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.CompilationUnitBuilder;
+import org.inferred.freebuilder.processor.util.FunctionalType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
@@ -2008,11 +2010,25 @@ public class ListSourceTest {
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new ListProperty(
-                metadata, name, false, false, false, STRING, Optional.<TypeMirror>absent()))
+                metadata,
+                name,
+                false,
+                false,
+                false,
+                STRING,
+                Optional.<TypeMirror>absent(),
+                FunctionalType.consumer(wildcardSuper(listString))))
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new ListProperty(
-                metadata, age, false, false, false, INTEGER, Optional.<TypeMirror>of(INT)))
+                metadata,
+                age,
+                false,
+                false,
+                false,
+                INTEGER,
+                Optional.<TypeMirror>of(INT),
+                FunctionalType.consumer(wildcardSuper(listInteger))))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -19,7 +19,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
-import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
@@ -29,7 +28,6 @@ import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.Metadata.Property;
-import org.inferred.freebuilder.processor.util.ClassTypeImpl;
 import org.inferred.freebuilder.processor.util.CompilationUnitBuilder;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -19,7 +19,9 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
+import static org.inferred.freebuilder.processor.util.FunctionalType.consumer;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
+import static org.inferred.freebuilder.processor.util.WildcardTypeImpl.wildcardSuper;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 
 import com.google.common.base.Joiner;
@@ -1092,7 +1094,8 @@ public class MapSourceTest {
                 INTEGER,
                 Optional.<TypeMirror>of(INT),
                 STRING,
-                Optional.<TypeMirror>absent()))
+                Optional.<TypeMirror>absent(),
+                consumer(wildcardSuper(mapIntString))))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -17,7 +17,8 @@ package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
-import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 
@@ -26,7 +27,6 @@ import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.Metadata.Property;
-import org.inferred.freebuilder.processor.util.ClassTypeImpl;
 import org.inferred.freebuilder.processor.util.CompilationUnitBuilder;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
@@ -1056,9 +1056,7 @@ public class MapSourceTest {
    */
   private static Metadata createMetadata(boolean bean) {
     GenericTypeElementImpl map = newTopLevelGenericType("java.util.Map");
-    ClassTypeImpl integer = newTopLevelClass("java.lang.Integer");
-    ClassTypeImpl string = newTopLevelClass("java.lang.String");
-    GenericTypeMirrorImpl mapIntString = map.newMirror(integer, string);
+    GenericTypeMirrorImpl mapIntString = map.newMirror(INTEGER, STRING);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     Property name = new Property.Builder()
@@ -1091,9 +1089,9 @@ public class MapSourceTest {
                 metadata,
                 name,
                 false,
-                integer,
+                INTEGER,
                 Optional.<TypeMirror>of(INT),
-                string,
+                STRING,
                 Optional.<TypeMirror>absent()))
             .build())
         .build();

--- a/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.inferred.freebuilder.processor.util.FunctionalType.unaryOperator;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
@@ -961,10 +962,12 @@ public class NullableSourceTest {
     return metadata.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
-            .setCodeGenerator(new NullableProperty(metadata, name, ImmutableSet.of(nullable)))
+            .setCodeGenerator(new NullableProperty(
+                metadata, name, ImmutableSet.of(nullable), unaryOperator(STRING)))
             .build())
         .addProperties(age.toBuilder()
-            .setCodeGenerator(new NullableProperty(metadata, age, ImmutableSet.of(nullable)))
+            .setCodeGenerator(new NullableProperty(
+                metadata, age, ImmutableSet.of(nullable), unaryOperator(INTEGER)))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
@@ -16,6 +16,8 @@
 package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
@@ -24,7 +26,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.Metadata.Property;
-import org.inferred.freebuilder.processor.util.ClassTypeImpl;
 import org.inferred.freebuilder.processor.util.ClassTypeImpl.ClassElementImpl;
 import org.inferred.freebuilder.processor.util.CompilationUnitBuilder;
 import org.inferred.freebuilder.processor.util.QualifiedName;
@@ -921,29 +922,27 @@ public class NullableSourceTest {
   }
 
   private static Metadata metadata(boolean bean) {
-    ClassTypeImpl integer = newTopLevelClass("java.lang.Integer");
-    ClassTypeImpl string = newTopLevelClass("java.lang.String");
     ClassElementImpl nullable = newTopLevelClass("javax.annotation.Nullable").asElement();
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
-        .setBoxedType(string)
+        .setBoxedType(STRING)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName(bean ? "getName" : "name")
         .setName("name")
-        .setType(string)
+        .setType(STRING)
         .setUsingBeanConvention(bean)
         .build();
     Property age = new Property.Builder()
         .setAllCapsName("AGE")
-        .setBoxedType(integer)
+        .setBoxedType(INTEGER)
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName(bean ? "getAge" : "age")
         .setName("age")
-        .setType(integer)
+        .setType(INTEGER)
         .setUsingBeanConvention(bean)
         .build();
     Metadata metadata = new Metadata.Builder()

--- a/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
@@ -16,7 +16,9 @@
 package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.INTEGER;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
+import static org.inferred.freebuilder.processor.util.FunctionalType.unaryOperator;
 import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
@@ -34,8 +36,6 @@ import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import javax.lang.model.type.TypeMirror;
 
 @RunWith(JUnit4.class)
 public class RequiredPropertiesSourceTest {
@@ -1660,21 +1660,20 @@ public class RequiredPropertiesSourceTest {
 
   private static Metadata createMetadata(boolean bean) {
     QualifiedName person = QualifiedName.of("com.example", "Person");
-    TypeMirror string = newTopLevelClass("java.lang.String");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
-        .setBoxedType(string)
+        .setBoxedType(STRING)
         .setCapitalizedName("Name")
         .setFullyCheckedCast(true)
         .setGetterName(bean ? "getName" : "name")
         .setName("name")
-        .setType(string)
+        .setType(STRING)
         .setUsingBeanConvention(bean)
         .build();
     Property age = new Property.Builder()
         .setAllCapsName("AGE")
-        .setBoxedType(newTopLevelClass("java.lang.Integer"))
+        .setBoxedType(INTEGER)
         .setCapitalizedName("Age")
         .setFullyCheckedCast(true)
         .setGetterName(bean ? "getAge" : "age")
@@ -1698,10 +1697,10 @@ public class RequiredPropertiesSourceTest {
     return metadata.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, name, false))
+            .setCodeGenerator(new DefaultProperty(metadata, name, false, unaryOperator(STRING)))
             .build())
         .addProperties(age.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, age, false))
+            .setCodeGenerator(new DefaultProperty(metadata, age, false, unaryOperator(INTEGER)))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -17,7 +17,7 @@ package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
-import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
@@ -26,7 +26,6 @@ import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.Metadata.Property;
-import org.inferred.freebuilder.processor.util.ClassTypeImpl;
 import org.inferred.freebuilder.processor.util.CompilationUnitBuilder;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
@@ -1435,8 +1434,7 @@ public class SetSourceTest {
    */
   private static Metadata createMetadata(boolean bean) {
     GenericTypeElementImpl set = newTopLevelGenericType("java.util.Set");
-    ClassTypeImpl string = newTopLevelClass("java.lang.String");
-    GenericTypeMirrorImpl setString = set.newMirror(string);
+    GenericTypeMirrorImpl setString = set.newMirror(STRING);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     Property name = new Property.Builder()
@@ -1466,7 +1464,7 @@ public class SetSourceTest {
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new SetProperty(
-                metadata, name, string, Optional.<TypeMirror>absent(), false, false, false))
+                metadata, name, STRING, Optional.<TypeMirror>absent(), false, false, false))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -18,6 +18,8 @@ package org.inferred.freebuilder.processor;
 import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.GenericTypeElementImpl.newTopLevelGenericType;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
+import static org.inferred.freebuilder.processor.util.FunctionalType.consumer;
+import static org.inferred.freebuilder.processor.util.WildcardTypeImpl.wildcardSuper;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
@@ -1464,7 +1466,14 @@ public class SetSourceTest {
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new SetProperty(
-                metadata, name, STRING, Optional.<TypeMirror>absent(), false, false, false))
+                metadata,
+                name,
+                STRING,
+                Optional.<TypeMirror>absent(),
+                consumer(wildcardSuper(setString)),
+                false,
+                false,
+                false))
             .build())
         .build();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/util/ClassTypeImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ClassTypeImpl.java
@@ -37,6 +37,9 @@ import javax.lang.model.type.TypeVisitor;
  */
 public abstract class ClassTypeImpl implements DeclaredType {
 
+  public static final ClassTypeImpl INTEGER = newTopLevelClass(Integer.class.getName());
+  public static final ClassTypeImpl STRING = newTopLevelClass(String.class.getName());
+
   private final Element enclosingElement;
   private final TypeMirror enclosingType;
   private final String simpleName;

--- a/src/test/java/org/inferred/freebuilder/processor/util/FunctionalTypeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/FunctionalTypeTest.java
@@ -1,0 +1,210 @@
+package org.inferred.freebuilder.processor.util;
+
+import static org.inferred.freebuilder.processor.util.FunctionalType.maybeFunctionalType;
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeDeclared;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.reflect.TypeToken;
+
+import org.inferred.freebuilder.processor.util.testing.ModelRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.LongConsumer;
+import java.util.function.LongUnaryOperator;
+import java.util.function.UnaryOperator;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
+
+public class FunctionalTypeTest {
+
+  public interface MyFunction {
+    int doSomething(long a, String b);
+  }
+
+  @Rule public final ModelRule model = new ModelRule();
+
+  @Test
+  public void testDetectsBasicFunctionalInterface() {
+    FunctionalType myFunction = functionalType(MyFunction.class);
+
+    assertNotNull(myFunction);
+    assertEquals("doSomething", myFunction.getMethodName());
+    assertEquals(2, myFunction.getParameters().size());
+    assertEquals("long", myFunction.getParameters().get(0).toString());
+    assertEquals("java.lang.String", myFunction.getParameters().get(1).toString());
+    assertEquals("int", myFunction.getReturnType().toString());
+  }
+
+  @Test
+  public void testReturnsAbsentIfGivenNonFunctionalInterface() {
+    FunctionalType iterator = functionalType(Iterator.class);
+
+    assertNull(iterator);
+  }
+
+  @Test
+  public void testHandlesGenericTypes() {
+    FunctionalType unaryOperator = functionalType(new TypeToken<UnaryOperator<Boolean>>() {});
+
+    assertNotNull(unaryOperator);
+    assertEquals("apply", unaryOperator.getMethodName());
+    assertEquals(1, unaryOperator.getParameters().size());
+    assertEquals("java.lang.Boolean", unaryOperator.getParameters().get(0).toString());
+    assertEquals("java.lang.Boolean", unaryOperator.getReturnType().toString());
+  }
+
+  @Test
+  public void testIsAssignableAllowsBoxingAndUnboxing() {
+    FunctionalType myFunction = functionalType(MyFunction.class);
+    FunctionalType biFunction = functionalType(
+        new TypeToken<BiFunction<Long, String, Integer>>() {});
+
+    assertTrue(FunctionalType.isAssignable(biFunction, myFunction, model.typeUtils()));
+  }
+
+  @Test
+  public void testIsAssignablePreventsTypeMismatches() {
+    FunctionalType myFunction = functionalType(MyFunction.class);
+    FunctionalType biFunction = functionalType(
+        new TypeToken<BiFunction<String, Long, Integer>>() {});
+
+    assertFalse(FunctionalType.isAssignable(biFunction, myFunction, model.typeUtils()));
+  }
+
+  @Test
+  public void testUsesPrototypeIfMethodNotFound() {
+    TypeElement myBuilder = model.newType(
+        "package com.example;",
+        "public class MyBuilder extends NotYetMade {",
+        "  @Override public MyBuilder mapBar(" + LongUnaryOperator.class.getName() + " mapper) {",
+        "    return super.mapBar(mapper);",
+        "  }",
+        "}");
+    FunctionalType unaryOperator = functionalType(new TypeToken<UnaryOperator<Long>>() {});
+
+    FunctionalType result = FunctionalType.functionalTypeAcceptedByMethod(
+        (DeclaredType) myBuilder.asType(),
+        "mapFoo",
+        unaryOperator,
+        model.elementUtils(),
+        model.typeUtils());
+
+    assertEquals(unaryOperator, result);
+  }
+
+  @Test
+  public void testUsesUserChosenTypeIfPresent() {
+    TypeElement myBuilder = model.newType(
+        "package com.example;",
+        "public class MyBuilder extends NotYetMade {",
+        "  @Override public MyBuilder mapFoo(" + LongUnaryOperator.class.getName() + " mapper) {",
+        "    return super.mapBar(mapper);",
+        "  }",
+        "}");
+    FunctionalType unaryOperator = functionalType(new TypeToken<UnaryOperator<Long>>() {});
+    FunctionalType longUnaryOperator = functionalType(new TypeToken<LongUnaryOperator>() {});
+
+    FunctionalType result = FunctionalType.functionalTypeAcceptedByMethod(
+        (DeclaredType) myBuilder.asType(),
+        "mapFoo",
+        unaryOperator,
+        model.elementUtils(),
+        model.typeUtils());
+
+    assertEquals(longUnaryOperator, result);
+  }
+
+  @Test
+  public void testHandlesVoidFunctions() {
+    TypeElement myBuilder = model.newType(
+        "package com.example;",
+        "public class MyBuilder extends NotYetMade {",
+        "  @Override public MyBuilder mutateFoo(" + LongConsumer.class.getName() + " mutator) {",
+        "    return super.mapBar(mapper);",
+        "  }",
+        "}");
+    FunctionalType consumer = functionalType(new TypeToken<Consumer<Long>>() {});
+    FunctionalType longConsumer = functionalType(new TypeToken<LongConsumer>() {});
+
+    FunctionalType result = FunctionalType.functionalTypeAcceptedByMethod(
+        (DeclaredType) myBuilder.asType(),
+        "mutateFoo",
+        consumer,
+        model.elementUtils(),
+        model.typeUtils());
+
+    assertEquals(longConsumer, result);
+  }
+
+  private interface IntListConsumer {
+    void take(List<Integer> stuff);
+  }
+
+  private interface Foo {
+    Foo mutate(IntListConsumer mutator);
+  }
+
+  @Test
+  public void testHandlesWildcards() {
+    // Get a functional type representing Consumer<? super List<Integer>>
+    TypeElement list = model.elementUtils().getTypeElement(List.class.getName());
+    TypeMirror integer = model.elementUtils().getTypeElement(Integer.class.getName()).asType();
+    DeclaredType intList = model.typeUtils().getDeclaredType(list, integer);
+    WildcardType superIntList = model.typeUtils().getWildcardType(null, intList);
+    FunctionalType consumerSuperIntList = FunctionalType.consumer(superIntList);
+
+    FunctionalType result = FunctionalType.functionalTypeAcceptedByMethod(
+        (DeclaredType) model.typeElement(Foo.class).asType(),
+        "mutate",
+        consumerSuperIntList,
+        model.elementUtils(),
+        model.typeUtils());
+
+    assertEquals(
+        QualifiedName.of(IntListConsumer.class).withParameters(),
+        result.getFunctionalInterface());
+  }
+
+  private interface Bar<T> {
+    Bar<T> mutate(Consumer<List<T>> stuff);
+  }
+
+  @Test
+  public void testPreservesGenericTypeInformation() {
+    DeclaredType barInteger = model.typeUtils().getDeclaredType(
+        model.typeElement(Bar.class), model.typeMirror(Integer.class));
+    FunctionalType result = FunctionalType.functionalTypeAcceptedByMethod(
+        barInteger,
+        "mutate",
+        functionalType(IntListConsumer.class),
+        model.elementUtils(),
+        model.typeUtils());
+
+
+    assertEquals(
+        QualifiedName.of(Consumer.class),
+        result.getFunctionalInterface().getQualifiedName());
+  }
+
+  private FunctionalType functionalType(Class<?> cls) {
+    DeclaredType declaredType = maybeDeclared(model.typeMirror(cls)).get();
+    return maybeFunctionalType(declaredType, model.elementUtils(), model.typeUtils()).orNull();
+  }
+
+  private FunctionalType functionalType(TypeToken<?> type) {
+    DeclaredType declaredType = maybeDeclared(model.typeMirror(type)).get();
+    return maybeFunctionalType(declaredType, model.elementUtils(), model.typeUtils()).orNull();
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
@@ -16,6 +16,7 @@
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newNestedClass;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.junit.Assert.assertEquals;
@@ -58,7 +59,7 @@ public class ImportManagerTest {
   @Test
   public void testTypeMirrorShortening() {
     ImportManager manager = new ImportManager.Builder().build();
-    assertEquals("String", manager.shorten(newTopLevelClass("java.lang.String")));
+    assertEquals("String", manager.shorten(STRING));
     assertEquals("List", manager.shorten(newTopLevelClass("java.util.List")));
     assertEquals("java.awt.List", manager.shorten(newTopLevelClass("java.awt.List")));
     ClassTypeImpl mapType = newTopLevelClass("java.util.Map");
@@ -77,7 +78,7 @@ public class ImportManagerTest {
         .addImplicitImport(QualifiedName.of(stringType))
         .build();
     assertEquals("java.lang.String",
-        manager.shorten(newTopLevelClass("java.lang.String")));
+        manager.shorten(ClassTypeImpl.STRING));
     assertEquals("java.util.List", manager.shorten(newTopLevelClass("java.util.List")));
     ClassTypeImpl awtListType = newTopLevelClass("java.awt.List");
     assertEquals("java.awt.List", manager.shorten(awtListType));

--- a/src/test/java/org/inferred/freebuilder/processor/util/WildcardTypeImpl.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/WildcardTypeImpl.java
@@ -1,0 +1,55 @@
+package org.inferred.freebuilder.processor.util;
+
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVisitor;
+import javax.lang.model.type.WildcardType;
+
+public abstract class WildcardTypeImpl extends ValueType implements WildcardType {
+
+  public static WildcardType wildcard() {
+    return Partial.of(WildcardTypeImpl.class, null, null);
+  }
+
+  public static WildcardType wildcardSuper(TypeMirror superBound) {
+    return Partial.of(WildcardTypeImpl.class, superBound, null);
+  }
+
+  public static WildcardType wildcardExtends(TypeMirror extendsBound) {
+    return Partial.of(WildcardTypeImpl.class, null, extendsBound);
+  }
+
+  private final TypeMirror superBound;
+  private final TypeMirror extendsBound;
+
+  WildcardTypeImpl(TypeMirror superBound, TypeMirror extendsBound) {
+    this.superBound = superBound;
+    this.extendsBound = extendsBound;
+  }
+
+  @Override
+  public TypeKind getKind() {
+    return TypeKind.WILDCARD;
+  }
+
+  @Override
+  public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+    return v.visitWildcard(this, p);
+  }
+
+  @Override
+  public TypeMirror getExtendsBound() {
+    return extendsBound;
+  }
+
+  @Override
+  public TypeMirror getSuperBound() {
+    return superBound;
+  }
+
+  @Override
+  protected void addFields(FieldReceiver fields) {
+    fields.add("superBound", superBound);
+    fields.add("extendsBound", extendsBound);
+  }
+}


### PR DESCRIPTION
Allow users to change the functional interface used in map/mutate methods with an override:

```java
@FreeBuilder
interface MyType {
    long value();
    static class Builder extends MyType_Builder {
        @Override public Builder mapValue(LongUnaryOperator mapper) {
            return super.mapValue(mapper);
        }
    }
}
```

This enables a temporary work-around for #287, but also gives us a way to change the default in v2 while allowing users to keep their types binary compatible if they need to.

Another option would be to allow users to specify functional interfaces with an annotation at the class, method or package level.

The new `FunctionalType` class encapsulates detecting functional interfaces accepted by methods, including checking their type signatures match, and finding the right method to invoke on them.