### PR TITLE
Make Metadata.getBuilder not Nullable

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -27,7 +27,6 @@ import static javax.lang.model.util.ElementFilter.constructorsIn;
 import static javax.lang.model.util.ElementFilter.typesIn;
 import static javax.tools.Diagnostic.Kind.ERROR;
 import static javax.tools.Diagnostic.Kind.NOTE;
-import static org.inferred.freebuilder.processor.BuilderFactory.NO_ARGS_CONSTRUCTOR;
 import static org.inferred.freebuilder.processor.GwtSupport.gwtMetadata;
 import static org.inferred.freebuilder.processor.naming.NamingConventions.determineNamingConvention;
 import static org.inferred.freebuilder.processor.util.MethodFinder.methodsOn;
@@ -145,15 +144,21 @@ class Analyser {
   GeneratedType analyse(TypeElement type) throws CannotGenerateCodeException {
     PackageElement pkg = elements.getPackageOf(type);
     verifyType(type, pkg);
-    ImmutableSet<ExecutableElement> methods = methodsOn(type, elements, CANNOT_GENERATE_ON_ERROR);
     QualifiedName generatedBuilder = QualifiedName.of(
         pkg.getQualifiedName().toString(), generatedBuilderSimpleName(type));
-    Optional<DeclaredType> builder = tryFindBuilder(generatedBuilder, type);
+    List<? extends TypeParameterElement> typeParameters = type.getTypeParameters();
+    DeclaredType builder = tryFindBuilder(generatedBuilder, type).orNull();
+    if (builder == null) {
+      return new GeneratedStub(
+        QualifiedName.of(type),
+        generatedBuilder.withParameters(typeParameters));
+    }
+
+    ImmutableSet<ExecutableElement> methods = methodsOn(type, elements, CANNOT_GENERATE_ON_ERROR);
     Metadata.Builder constructionAndExtension = constructionAndExtension(builder);
     QualifiedName valueType = generatedBuilder.nestedType("Value");
     QualifiedName partialType = generatedBuilder.nestedType("Partial");
     QualifiedName propertyType = generatedBuilder.nestedType("Property");
-    List<? extends TypeParameterElement> typeParameters = type.getTypeParameters();
     Map<ExecutableElement, Property> properties =
         findProperties(type, removeNonGetterMethods(builder, methods));
     Metadata.Builder metadataBuilder = new Metadata.Builder()
@@ -172,17 +177,13 @@ class Analyser {
         .setHasToBuilderMethod(hasToBuilderMethod(
             builder, constructionAndExtension.isExtensible(), methods))
         .setBuilderSerializable(shouldBuilderBeSerializable(builder))
-        .addAllProperties(properties.values());
-    if (builder.isPresent()) {
-      metadataBuilder.setBuilder(ParameterizedType.from(builder.get()));
-    }
+        .addAllProperties(properties.values())
+        .setBuilder(ParameterizedType.from(builder));
     Metadata baseMetadata = metadataBuilder.build();
     metadataBuilder.mergeFrom(gwtMetadata(type, baseMetadata));
-    if (builder.isPresent()) {
-      metadataBuilder
-          .clearProperties()
-          .addAllProperties(codeGenerators(properties, baseMetadata, builder.get()));
-    }
+    metadataBuilder
+        .clearProperties()
+        .addAllProperties(codeGenerators(properties, baseMetadata, builder));
     return new CodeGenerator(metadataBuilder.build());
   }
 
@@ -324,14 +325,11 @@ class Analyser {
 
   /** Find a toBuilder method, if the user has provided one. */
   private boolean hasToBuilderMethod(
-      Optional<DeclaredType> builder,
+      DeclaredType builder,
       boolean isExtensible,
       Iterable<ExecutableElement> methods) {
-    if (!builder.isPresent()) {
-      return false;
-    }
     for (ExecutableElement method : methods) {
-      if (isToBuilderMethod(builder.get(), method)) {
+      if (isToBuilderMethod(builder, method)) {
         if (!isExtensible) {
           messager.printMessage(ERROR,
               "No accessible no-args Builder constructor available to implement toBuilder",
@@ -351,12 +349,12 @@ class Analyser {
   }
 
   private Set<ExecutableElement> removeNonGetterMethods(
-      Optional<DeclaredType> builder, Iterable<ExecutableElement> methods) {
+      DeclaredType builder, Iterable<ExecutableElement> methods) {
     ImmutableSet.Builder<ExecutableElement> nonUnderriddenMethods = ImmutableSet.builder();
     for (ExecutableElement method : methods) {
       boolean isAbstract = method.getModifiers().contains(Modifier.ABSTRACT);
       boolean isStandardMethod = maybeStandardMethod(method).isPresent();
-      boolean isToBuilderMethod = builder.isPresent() && isToBuilderMethod(builder.get(), method);
+      boolean isToBuilderMethod = isToBuilderMethod(builder, method);
       if (isAbstract && !isStandardMethod && !isToBuilderMethod) {
         nonUnderriddenMethods.add(method);
       }
@@ -433,13 +431,8 @@ class Analyser {
     return Optional.of(declaredBuilderType);
   }
 
-  private Metadata.Builder constructionAndExtension(Optional<DeclaredType> builder) {
-    if (!builder.isPresent()) {
-      return new Metadata.Builder()
-          .setExtensible(false)
-          .setBuilderFactory(NO_ARGS_CONSTRUCTOR);
-    }
-    TypeElement builderElement = ModelUtils.asElement(builder.get());
+  private Metadata.Builder constructionAndExtension(DeclaredType builder) {
+    TypeElement builderElement = ModelUtils.asElement(builder);
     if (!builderElement.getModifiers().contains(Modifier.STATIC)) {
       messager.printMessage(ERROR, "Builder must be static on @FreeBuilder types", builderElement);
       return new Metadata.Builder().setExtensible(false);
@@ -646,14 +639,10 @@ class Analyser {
     return String.format(BUILDER_SIMPLE_NAME_TEMPLATE, nameWithoutPackage.replaceAll("\\.", "_"));
   }
 
-  private boolean shouldBuilderBeSerializable(Optional<DeclaredType> builder) {
-    if (!builder.isPresent()) {
-      // If there's no user-provided subclass, make the builder serializable.
-      return true;
-    }
+  private boolean shouldBuilderBeSerializable(DeclaredType builder) {
     // If there is a user-provided subclass, only make its generated superclass serializable if
     // it is itself; otherwise, tools may complain about missing a serialVersionUID field.
-    return any(asElement(builder.get()).getInterfaces(), isEqualTo(Serializable.class));
+    return any(asElement(builder).getInterfaces(), isEqualTo(Serializable.class));
   }
 
   /** Returns whether a method is one of the {@link StandardMethod}s, and if so, which. */

--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -79,11 +79,11 @@ import javax.lang.model.util.SimpleTypeVisitor6;
 import javax.lang.model.util.Types;
 
 /**
- * Analyses a {@link org.inferred.freebuilder.FreeBuilder FreeBuilder}
- * type, returning metadata about it in a format amenable to code generation.
+ * Analyses a {@link org.inferred.freebuilder.FreeBuilder FreeBuilder} metadata type, returning
+ * a {@link GeneratedType} for a Builder superclass derived from its API.
  *
  * <p>Any deviations from the FreeBuilder spec in the user's class will result in errors being
- * issued, but unless code generation is totally impossible, metadata will still be returned.
+ * issued, but unless code generation is totally impossible, a type will still be returned.
  * This allows the user to extend an existing type without worrying that a mistake will cause
  * compiler errors in all dependent code&mdash;which would make it very hard to find the real
  * error.
@@ -138,11 +138,11 @@ class Analyser {
   }
 
   /**
-   * Returns a {@link Metadata} metadata object for {@code type}.
+   * Returns a Builder {@link GeneratedType} for {@code type}.
    *
    * @throws CannotGenerateCodeException if code cannot be generated, e.g. if the type is private
    */
-  Metadata analyse(TypeElement type) throws CannotGenerateCodeException {
+  GeneratedType analyse(TypeElement type) throws CannotGenerateCodeException {
     PackageElement pkg = elements.getPackageOf(type);
     verifyType(type, pkg);
     ImmutableSet<ExecutableElement> methods = methodsOn(type, elements, CANNOT_GENERATE_ON_ERROR);
@@ -183,7 +183,7 @@ class Analyser {
           .clearProperties()
           .addAllProperties(codeGenerators(properties, baseMetadata, builder.get()));
     }
-    return metadataBuilder.build();
+    return new CodeGenerator(metadataBuilder.build());
   }
 
   private static Set<QualifiedName> visibleTypesIn(TypeElement type) {

--- a/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
@@ -90,11 +90,6 @@ class CodeGenerator extends GeneratedType {
 
   @Override
   public void addTo(SourceBuilder code) {
-    if (!metadata.hasBuilder()) {
-      writeStubSource(code, metadata);
-      return;
-    }
-
     addBuilderTypeDeclaration(code);
     code.addLine(" {");
     addStaticFromMethod(code);
@@ -599,15 +594,6 @@ class CodeGenerator extends GeneratedType {
     }
     code.add(body)
         .addLine("  }");
-  }
-
-  private void writeStubSource(SourceBuilder code, Metadata metadata) {
-    code.addLine("/**")
-        .addLine(" * Placeholder. Create {@code %s.Builder} and subclass this type.",
-            metadata.getType())
-        .addLine(" */")
-        .add(Excerpts.generated(getClass()))
-        .addLine("abstract class %s {}", metadata.getGeneratedBuilder().declaration());
   }
 
   private static Nullability nullabilityOf(Property property, boolean inPartial) {

--- a/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
@@ -57,7 +57,7 @@ import java.util.List;
 /**
  * Code generation for the &#64;{@link FreeBuilder} annotation.
  */
-class CodeGenerator {
+class CodeGenerator extends Excerpt {
 
   static final FieldAccess UNSET_PROPERTIES = new FieldAccess("_unsetProperties");
 
@@ -67,8 +67,13 @@ class CodeGenerator {
     this.metadata = metadata;
   }
 
-  /** Write the source code for a generated builder. */
-  void writeBuilderSource(SourceBuilder code) {
+  @Override
+  protected void addFields(FieldReceiver fields) {
+    throw new UnsupportedOperationException("TODO");
+  }
+
+  @Override
+  public void addTo(SourceBuilder code) {
     if (!metadata.hasBuilder()) {
       writeStubSource(code, metadata);
       return;

--- a/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
@@ -46,6 +46,7 @@ import org.inferred.freebuilder.processor.util.FieldAccess;
 import org.inferred.freebuilder.processor.util.ObjectsExcerpts;
 import org.inferred.freebuilder.processor.util.ObjectsExcerpts.Nullability;
 import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
+import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.Variable;
 
@@ -53,23 +54,38 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Code generation for the &#64;{@link FreeBuilder} annotation.
  */
-class CodeGenerator extends Excerpt {
+class CodeGenerator extends GeneratedType {
 
   static final FieldAccess UNSET_PROPERTIES = new FieldAccess("_unsetProperties");
 
   private final Metadata metadata;
 
-  public CodeGenerator(Metadata metadata) {
+  CodeGenerator(Metadata metadata) {
     this.metadata = metadata;
+  }
+
+  Metadata getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  public QualifiedName getName() {
+    return metadata.getGeneratedBuilder().getQualifiedName();
+  }
+
+  @Override
+  public Set<QualifiedName> getVisibleNestedTypes() {
+    return metadata.getVisibleNestedTypes();
   }
 
   @Override
   protected void addFields(FieldReceiver fields) {
-    throw new UnsupportedOperationException("TODO");
+    fields.add("metadata", metadata);
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/CodeGenerator.java
@@ -57,35 +57,41 @@ import java.util.List;
 /**
  * Code generation for the &#64;{@link FreeBuilder} annotation.
  */
-public class CodeGenerator {
+class CodeGenerator {
 
   static final FieldAccess UNSET_PROPERTIES = new FieldAccess("_unsetProperties");
 
+  private final Metadata metadata;
+
+  public CodeGenerator(Metadata metadata) {
+    this.metadata = metadata;
+  }
+
   /** Write the source code for a generated builder. */
-  void writeBuilderSource(SourceBuilder code, Metadata metadata) {
+  void writeBuilderSource(SourceBuilder code) {
     if (!metadata.hasBuilder()) {
       writeStubSource(code, metadata);
       return;
     }
 
-    addBuilderTypeDeclaration(code, metadata);
+    addBuilderTypeDeclaration(code);
     code.addLine(" {");
-    addStaticFromMethod(code, metadata);
+    addStaticFromMethod(code);
     if (any(metadata.getProperties(), IS_REQUIRED)) {
-      addPropertyEnum(metadata, code);
+      addPropertyEnum(code);
     }
 
-    addFieldDeclarations(code, metadata);
+    addFieldDeclarations(code);
 
-    addAccessors(metadata, code);
-    addMergeFromValueMethod(code, metadata);
-    addMergeFromBuilderMethod(code, metadata);
-    addClearMethod(code, metadata);
-    addBuildMethod(code, metadata);
-    addBuildPartialMethod(code, metadata);
+    addAccessors(code);
+    addMergeFromValueMethod(code);
+    addMergeFromBuilderMethod(code);
+    addClearMethod(code);
+    addBuildMethod(code);
+    addBuildPartialMethod(code);
 
-    addValueType(code, metadata);
-    addPartialType(code, metadata);
+    addValueType(code);
+    addPartialType(code);
     for (Function<Metadata, Excerpt> nestedClass : metadata.getNestedClasses()) {
       code.add(nestedClass.apply(metadata));
     }
@@ -93,7 +99,7 @@ public class CodeGenerator {
     code.addLine("}");
   }
 
-  private void addBuilderTypeDeclaration(SourceBuilder code, Metadata metadata) {
+  private void addBuilderTypeDeclaration(SourceBuilder code) {
     code.addLine("/**")
         .addLine(" * Auto-generated superclass of %s,", metadata.getBuilder().javadocLink())
         .addLine(" * derived from the API of %s.", metadata.getType().javadocLink())
@@ -108,7 +114,7 @@ public class CodeGenerator {
     }
   }
 
-  private static void addStaticFromMethod(SourceBuilder code, Metadata metadata) {
+  private void addStaticFromMethod(SourceBuilder code) {
     BuilderFactory builderFactory = metadata.getBuilderFactory().orNull();
     if (builderFactory == null) {
       return;
@@ -126,7 +132,7 @@ public class CodeGenerator {
         .addLine("}");
   }
 
-  private static void addFieldDeclarations(SourceBuilder code, Metadata metadata) {
+  private void addFieldDeclarations(SourceBuilder code) {
     code.addLine("");
     for (Property property : metadata.getProperties()) {
       PropertyCodeGenerator codeGenerator = property.getCodeGenerator();
@@ -140,13 +146,13 @@ public class CodeGenerator {
     }
   }
 
-  private static void addAccessors(Metadata metadata, SourceBuilder body) {
+  private void addAccessors(SourceBuilder body) {
     for (Property property : metadata.getProperties()) {
       property.getCodeGenerator().addBuilderFieldAccessors(body);
     }
   }
 
-  private static void addBuildMethod(SourceBuilder code, Metadata metadata) {
+  private void addBuildMethod(SourceBuilder code) {
     boolean hasRequiredProperties = any(metadata.getProperties(), IS_REQUIRED);
     code.addLine("")
         .addLine("/**")
@@ -166,7 +172,7 @@ public class CodeGenerator {
         .addLine("}");
   }
 
-  private static void addMergeFromValueMethod(SourceBuilder code, Metadata metadata) {
+  private void addMergeFromValueMethod(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets all property values using the given {@code %s} as a template.",
@@ -182,7 +188,7 @@ public class CodeGenerator {
         .addLine("}");
   }
 
-  private static void addMergeFromBuilderMethod(SourceBuilder code, Metadata metadata) {
+  private void addMergeFromBuilderMethod(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Copies values from the given {@code %s}.",
@@ -199,7 +205,7 @@ public class CodeGenerator {
         .addLine("}");
   }
 
-  private static void addClearMethod(SourceBuilder code, Metadata metadata) {
+  private void addClearMethod(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Resets the state of this builder.")
@@ -223,7 +229,7 @@ public class CodeGenerator {
         .addLine("}");
   }
 
-  private static void addBuildPartialMethod(SourceBuilder code, Metadata metadata) {
+  private void addBuildPartialMethod(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns a newly-created partial %s", metadata.getType().javadocLink())
@@ -256,7 +262,7 @@ public class CodeGenerator {
         .addLine("}");
   }
 
-  private static void addPropertyEnum(Metadata metadata, SourceBuilder code) {
+  private void addPropertyEnum(SourceBuilder code) {
     code.addLine("")
         .addLine("private enum %s {", metadata.getPropertyEnum().getSimpleName());
     for (Property property : metadata.getProperties()) {
@@ -279,7 +285,7 @@ public class CodeGenerator {
         .addLine("}");
   }
 
-  private static void addValueType(SourceBuilder code, Metadata metadata) {
+  private void addValueType(SourceBuilder code) {
     code.addLine("");
     for (Excerpt annotation : metadata.getValueTypeAnnotations()) {
       code.add(annotation);
@@ -333,7 +339,7 @@ public class CodeGenerator {
     // Equals
     switch (metadata.standardMethodUnderride(StandardMethod.EQUALS)) {
       case ABSENT:
-        addValueTypeEquals(code, metadata);
+        addValueTypeEquals(code);
         break;
 
       case OVERRIDEABLE:
@@ -371,7 +377,7 @@ public class CodeGenerator {
     code.addLine("}");
   }
 
-  private static void addValueTypeEquals(SourceBuilder code, Metadata metadata) {
+  private void addValueTypeEquals(SourceBuilder code) {
     // Default implementation if no user implementation exists.
     code.addLine("")
         .addLine("  @%s", Override.class)
@@ -411,7 +417,7 @@ public class CodeGenerator {
         .addLine("  }");
   }
 
-  private static void addPartialType(SourceBuilder code, Metadata metadata) {
+  private void addPartialType(SourceBuilder code) {
     boolean hasRequiredProperties = any(metadata.getProperties(), IS_REQUIRED);
     code.addLine("")
         .addLine("private static final class %s %s {",
@@ -445,7 +451,7 @@ public class CodeGenerator {
       code.add(";\n");
       code.addLine("  }");
     }
-    addPartialToBuilderMethod(code, metadata);
+    addPartialToBuilderMethod(code);
     // Equals
     if (metadata.standardMethodUnderride(StandardMethod.EQUALS) != FINAL) {
       code.addLine("")
@@ -542,7 +548,7 @@ public class CodeGenerator {
         .addLine("  }");
   }
 
-  private static void addPartialToBuilderMethod(SourceBuilder code, Metadata metadata) {
+  private void addPartialToBuilderMethod(SourceBuilder code) {
     if (!metadata.getHasToBuilderMethod()) {
       return;
     }

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedStub.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedStub.java
@@ -1,0 +1,46 @@
+package org.inferred.freebuilder.processor;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.inferred.freebuilder.processor.util.Excerpts;
+import org.inferred.freebuilder.processor.util.ParameterizedType;
+import org.inferred.freebuilder.processor.util.QualifiedName;
+import org.inferred.freebuilder.processor.util.SourceBuilder;
+
+import java.util.Set;
+
+class GeneratedStub extends GeneratedType {
+
+  private final QualifiedName datatype;
+  private final ParameterizedType stub;
+
+  GeneratedStub(QualifiedName datatype, ParameterizedType stub) {
+    this.datatype = datatype;
+    this.stub = stub;
+  }
+
+  @Override
+  public QualifiedName getName() {
+    return stub.getQualifiedName();
+  }
+
+  @Override
+  public Set<QualifiedName> getVisibleNestedTypes() {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public void addTo(SourceBuilder code) {
+    code.addLine("/**")
+        .addLine(" * Placeholder. Create {@code %s.Builder} and subclass this type.", datatype)
+        .addLine(" */")
+        .add(Excerpts.generated(Processor.class))
+        .addLine("abstract class %s {}", stub.declaration());
+  }
+
+  @Override
+  protected void addFields(FieldReceiver fields) {
+    fields.add("datatype", datatype);
+    fields.add("stub", stub);
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedType.java
@@ -1,0 +1,11 @@
+package org.inferred.freebuilder.processor;
+
+import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.QualifiedName;
+
+import java.util.Set;
+
+abstract class GeneratedType extends Excerpt {
+  public abstract QualifiedName getName();
+  public abstract Set<QualifiedName> getVisibleNestedTypes();
+}

--- a/src/main/java/org/inferred/freebuilder/processor/Metadata.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Metadata.java
@@ -94,23 +94,12 @@ public abstract class Metadata {
   /** Returns true if the type is an interface. */
   public abstract boolean isInterfaceType();
 
-  abstract Optional<ParameterizedType> getOptionalBuilder();
-
-  /**
-   * Returns true if there is a user-visible Builder subclass defined.
-   */
-  public boolean hasBuilder() {
-    return getOptionalBuilder().isPresent();
-  }
-
   /**
    * Returns the builder type that users will see.
    *
    * @throws IllegalStateException if {@link #hasBuilder} returns false.
    */
-  public ParameterizedType getBuilder() {
-    return getOptionalBuilder().get();
-  }
+  public abstract ParameterizedType getBuilder();
 
   /** Whether there is a package-visible, no-args constructor so we can subclass the Builder. */
   public abstract boolean isExtensible();
@@ -253,16 +242,6 @@ public abstract class Metadata {
     public Builder setValueTypeVisibility(Visibility visibility) {
       return super.setValueTypeVisibility(
           Visibility.mostVisible(getValueTypeVisibility(), visibility));
-    }
-
-    /** Sets the builder class that users will see, if any. */
-    public Builder setBuilder(Optional<ParameterizedType> builder) {
-      return setOptionalBuilder(builder);
-    }
-
-    /** Sets the builder class that users will see. */
-    public Builder setBuilder(ParameterizedType builder) {
-      return setOptionalBuilder(builder);
     }
 
     /**

--- a/src/main/java/org/inferred/freebuilder/processor/Processor.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Processor.java
@@ -113,16 +113,16 @@ public class Processor extends AbstractProcessor {
     }
     for (TypeElement type : typesIn(annotatedElementsIn(roundEnv, FreeBuilder.class))) {
       try {
-        Metadata metadata = analyser.analyse(type);
+        GeneratedType builder = analyser.analyse(type);
         CompilationUnitBuilder code = new CompilationUnitBuilder(
             processingEnv,
-            metadata.getGeneratedBuilder().getQualifiedName(),
-            metadata.getVisibleNestedTypes(),
+            builder.getName(),
+            builder.getVisibleNestedTypes(),
             firstNonNull(features, environmentFeatures));
-        code.add(new CodeGenerator(metadata));
+        code.add(builder);
         FilerUtils.writeCompilationUnit(
             processingEnv.getFiler(),
-            metadata.getGeneratedBuilder().getQualifiedName(),
+            builder.getName(),
             type,
             code.toString());
       } catch (Analyser.CannotGenerateCodeException e) {

--- a/src/main/java/org/inferred/freebuilder/processor/Processor.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Processor.java
@@ -119,7 +119,7 @@ public class Processor extends AbstractProcessor {
             metadata.getGeneratedBuilder().getQualifiedName(),
             metadata.getVisibleNestedTypes(),
             firstNonNull(features, environmentFeatures));
-        new CodeGenerator(metadata).writeBuilderSource(code);
+        code.add(new CodeGenerator(metadata));
         FilerUtils.writeCompilationUnit(
             processingEnv.getFiler(),
             metadata.getGeneratedBuilder().getQualifiedName(),

--- a/src/main/java/org/inferred/freebuilder/processor/Processor.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Processor.java
@@ -64,7 +64,6 @@ public class Processor extends AbstractProcessor {
       new MapMaker().weakKeys().weakValues().concurrencyLevel(1).initialCapacity(1).makeMap();
 
   private Analyser analyser;
-  private final CodeGenerator codeGenerator = new CodeGenerator();
   private final FeatureSet features;
 
   private transient FeatureSet environmentFeatures;
@@ -120,7 +119,7 @@ public class Processor extends AbstractProcessor {
             metadata.getGeneratedBuilder().getQualifiedName(),
             metadata.getVisibleNestedTypes(),
             firstNonNull(features, environmentFeatures));
-        codeGenerator.writeBuilderSource(code, metadata);
+        new CodeGenerator(metadata).writeBuilderSource(code);
         FilerUtils.writeCompilationUnit(
             processingEnv.getFiler(),
             metadata.getGeneratedBuilder().getQualifiedName(),

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -76,18 +76,17 @@ public class AnalyserTest {
 
   @Test
   public void emptyDataType() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    GeneratedType builder = analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
-        "}");
-
-    Metadata metadata = analyser.analyse(dataType);
+        "}"));
 
     QualifiedName expectedBuilder = QualifiedName.of("com.example", "DataType_Builder");
     QualifiedName partialType = expectedBuilder.nestedType("Partial");
     QualifiedName propertyType = expectedBuilder.nestedType("Property");
     QualifiedName valueType = expectedBuilder.nestedType("Value");
-    Metadata expectedMetadata = new Metadata.Builder()
+
+    assertThat(builder).isEqualTo(new CodeGenerator(new Metadata.Builder()
         .setExtensible(false)
         .setBuilderFactory(NO_ARGS_CONSTRUCTOR)
         .setBuilderSerializable(true)
@@ -101,26 +100,24 @@ public class AnalyserTest {
         .addVisibleNestedTypes(partialType)
         .addVisibleNestedTypes(propertyType)
         .addVisibleNestedTypes(valueType)
-        .build();
+        .build()));
 
-    assertEquals(expectedMetadata, metadata);
     messager.verifyNote("DataType", addBuilderToClassMessage("DataType_Builder"));
   }
 
   @Test
   public void emptyInterface() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    GeneratedType builder = analyser.analyse(model.newType(
         "package com.example;",
         "public interface DataType {",
-        "}");
-
-    Metadata metadata = analyser.analyse(dataType);
+        "}"));
 
     QualifiedName expectedBuilder = QualifiedName.of("com.example", "DataType_Builder");
     QualifiedName partialType = expectedBuilder.nestedType("Partial");
     QualifiedName propertyType = expectedBuilder.nestedType("Property");
     QualifiedName valueType = expectedBuilder.nestedType("Value");
-    Metadata expectedMetadata = new Metadata.Builder()
+
+    assertThat(builder).isEqualTo(new CodeGenerator(new Metadata.Builder()
         .setExtensible(false)
         .setBuilderFactory(NO_ARGS_CONSTRUCTOR)
         .setBuilderSerializable(true)
@@ -134,98 +131,104 @@ public class AnalyserTest {
         .addVisibleNestedTypes(partialType)
         .addVisibleNestedTypes(propertyType)
         .addVisibleNestedTypes(valueType)
-        .build();
+        .build()));
 
-    assertEquals(expectedMetadata, metadata);
     messager.verifyNote("DataType", addBuilderToInterfaceMessage("DataType_Builder"));
   }
 
   @Test
   public void nestedDataType() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse((TypeElement) model.newElementWithMarker(
-        "package com.example;",
-        "public class OuterClass {",
-        "  ---> public static class DataType {",
-        "  }",
-        "}"));
+    CodeGenerator builder = (CodeGenerator) analyser.analyse((TypeElement)
+        model.newElementWithMarker(
+            "package com.example;",
+            "public class OuterClass {",
+            "  ---> public static class DataType {",
+            "  }",
+            "}"));
+
     assertEquals("com.example.OuterClass.DataType",
-        dataType.getType().getQualifiedName().toString());
+        builder.getMetadata().getType().getQualifiedName().toString());
     assertEquals(QualifiedName.of("com.example", "OuterClass_DataType_Builder").withParameters(),
-        dataType.getGeneratedBuilder());
+        builder.getMetadata().getGeneratedBuilder());
     messager.verifyNote("DataType", addBuilderToClassMessage("OuterClass_DataType_Builder"));
   }
 
   @Test
   public void twiceNestedDataType() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse((TypeElement) model.newElementWithMarker(
-        "package com.example;",
-        "public class OuterClass {",
-        "  public static class InnerClass {",
-        "    ---> public static class DataType {",
-        "    }",
-        "  }",
-        "}"));
+    CodeGenerator builder = (CodeGenerator) analyser.analyse((TypeElement)
+        model.newElementWithMarker(
+            "package com.example;",
+            "public class OuterClass {",
+            "  public static class InnerClass {",
+            "    ---> public static class DataType {",
+            "    }",
+            "  }",
+            "}"));
+
     assertEquals("com.example.OuterClass.InnerClass.DataType",
-        dataType.getType().getQualifiedName().toString());
+        builder.getMetadata().getType().getQualifiedName().toString());
     assertEquals(
         QualifiedName.of("com.example", "OuterClass_InnerClass_DataType_Builder").withParameters(),
-        dataType.getGeneratedBuilder());
+        builder.getMetadata().getGeneratedBuilder());
     messager.verifyNote(
         "DataType", addBuilderToClassMessage("OuterClass_InnerClass_DataType_Builder"));
   }
 
   @Test
   public void builderSubclass() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public static class Builder extends DataType_Builder { }",
         "}"));
+
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        dataType.getGeneratedBuilder());
+        builder.getMetadata().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        dataType.getBuilder().getQualifiedName().toString());
-    assertThat(dataType.isExtensible()).isTrue();
-    assertThat(dataType.getBuilderFactory()).hasValue(NO_ARGS_CONSTRUCTOR);
-    assertFalse(dataType.isBuilderSerializable());
+        builder.getMetadata().getBuilder().getQualifiedName().toString());
+    assertThat(builder.getMetadata().isExtensible()).isTrue();
+    assertThat(builder.getMetadata().getBuilderFactory()).hasValue(NO_ARGS_CONSTRUCTOR);
+    assertFalse(builder.getMetadata().isBuilderSerializable());
   }
 
   @Test
   public void serializableBuilderSubclass() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public static class Builder ",
         "      extends DataType_Builder implements java.io.Serializable { }",
         "}"));
+
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        dataType.getGeneratedBuilder());
+        builder.getMetadata().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        dataType.getBuilder().getQualifiedName().toString());
-    assertTrue(dataType.isBuilderSerializable());
+        builder.getMetadata().getBuilder().getQualifiedName().toString());
+    assertTrue(builder.getMetadata().isBuilderSerializable());
   }
 
   @Test
   public void builderSubclass_publicBuilderMethod() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public static class Builder extends DataType_Builder { }",
         "  public static Builder builder() { return new Builder(); }",
         "}"));
+
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        dataType.getGeneratedBuilder());
+        builder.getMetadata().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        dataType.getBuilder().getQualifiedName().toString());
-    assertThat(dataType.isExtensible()).isTrue();
-    assertThat(dataType.getBuilderFactory()).hasValue(BUILDER_METHOD);
-    assertFalse(dataType.isBuilderSerializable());
+        builder.getMetadata().getBuilder().getQualifiedName().toString());
+    assertThat(builder.getMetadata().isExtensible()).isTrue();
+    assertThat(builder.getMetadata().getBuilderFactory()).hasValue(BUILDER_METHOD);
+    assertFalse(builder.getMetadata().isBuilderSerializable());
   }
 
   @Test
   public void builderSubclass_publicBuilderMethod_protectedConstructor()
       throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public static class Builder extends DataType_Builder {",
@@ -233,19 +236,20 @@ public class AnalyserTest {
         "  }",
         "  public static Builder builder() { return new Builder(); }",
         "}"));
+
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        dataType.getGeneratedBuilder());
+        builder.getMetadata().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        dataType.getBuilder().getQualifiedName().toString());
-    assertThat(dataType.isExtensible()).isTrue();
-    assertThat(dataType.getBuilderFactory()).hasValue(BUILDER_METHOD);
-    assertFalse(dataType.isBuilderSerializable());
+        builder.getMetadata().getBuilder().getQualifiedName().toString());
+    assertThat(builder.getMetadata().isExtensible()).isTrue();
+    assertThat(builder.getMetadata().getBuilderFactory()).hasValue(BUILDER_METHOD);
+    assertFalse(builder.getMetadata().isBuilderSerializable());
   }
 
   @Test
   public void builderSubclass_publicBuilderMethod_privateConstructor()
       throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public static class Builder extends DataType_Builder {",
@@ -253,54 +257,58 @@ public class AnalyserTest {
         "  }",
         "  public static Builder builder() { return new Builder(); }",
         "}"));
+
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        dataType.getGeneratedBuilder());
+        builder.getMetadata().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        dataType.getBuilder().getQualifiedName().toString());
-    assertThat(dataType.isExtensible()).isFalse();
-    assertThat(dataType.getBuilderFactory()).hasValue(BUILDER_METHOD);
-    assertFalse(dataType.isBuilderSerializable());
+        builder.getMetadata().getBuilder().getQualifiedName().toString());
+    assertThat(builder.getMetadata().isExtensible()).isFalse();
+    assertThat(builder.getMetadata().getBuilderFactory()).hasValue(BUILDER_METHOD);
+    assertFalse(builder.getMetadata().isBuilderSerializable());
   }
 
   @Test
   public void builderSubclass_publicNewBuilderMethod() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public static class Builder extends DataType_Builder { }",
         "  public static Builder newBuilder() { return new Builder(); }",
         "}"));
+
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        dataType.getGeneratedBuilder());
+        builder.getMetadata().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        dataType.getBuilder().getQualifiedName().toString());
-    assertThat(dataType.isExtensible()).isTrue();
-    assertThat(dataType.getBuilderFactory()).hasValue(NEW_BUILDER_METHOD);
-    assertFalse(dataType.isBuilderSerializable());
+        builder.getMetadata().getBuilder().getQualifiedName().toString());
+    assertThat(builder.getMetadata().isExtensible()).isTrue();
+    assertThat(builder.getMetadata().getBuilderFactory()).hasValue(NEW_BUILDER_METHOD);
+    assertFalse(builder.getMetadata().isBuilderSerializable());
   }
 
   @Test
   public void toBuilderMethod() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public interface DataType {",
         "  Builder toBuilder();",
         "  class Builder extends DataType_Builder { }",
         "}"));
-    assertTrue(dataType.getHasToBuilderMethod());
-    assertThat(dataType.getProperties()).isEmpty();
+
+    assertTrue(builder.getMetadata().getHasToBuilderMethod());
+    assertThat(builder.getMetadata().getProperties()).isEmpty();
   }
 
   @Test
   public void toBuilderMethod_genericInterface() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public interface DataType<K, V> {",
         "  Builder<K, V> toBuilder();",
         "  class Builder<K, V> extends DataType_Builder<K, V> { }",
         "}"));
-    assertTrue(dataType.getHasToBuilderMethod());
-    assertThat(dataType.getProperties()).isEmpty();
+
+    assertTrue(builder.getMetadata().getHasToBuilderMethod());
+    assertThat(builder.getMetadata().getProperties()).isEmpty();
   }
 
   @Test
@@ -313,6 +321,7 @@ public class AnalyserTest {
         "    public Builder(String unused) {}",
         "  }",
         "}"));
+
     messager.verifyError(
         "toBuilder", "No accessible no-args Builder constructor available to implement toBuilder");
   }
@@ -328,20 +337,22 @@ public class AnalyserTest {
         "    private Builder() {}",
         "  }",
         "}"));
+
     messager.verifyError(
         "toBuilder", "No accessible no-args Builder constructor available to implement toBuilder");
   }
 
   @Test
   public void twoBeanGetters() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String getName();",
         "  public abstract int getAge();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
 
     Property age = properties.get("age");
@@ -363,14 +374,15 @@ public class AnalyserTest {
 
   @Test
   public void twoPrefixlessGetters() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String name();",
         "  public abstract int age();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
 
     Property age = properties.get("age");
@@ -392,14 +404,15 @@ public class AnalyserTest {
 
   @Test
   public void complexGetterNames() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String getCustomURLTemplate();",
         "  public abstract String getTop50Sites();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("customURLTemplate", "top50Sites");
     assertEquals("CUSTOM_URL_TEMPLATE", properties.get("customURLTemplate").getAllCapsName());
     assertEquals("TOP50_SITES", properties.get("top50Sites").getAllCapsName());
@@ -407,14 +420,15 @@ public class AnalyserTest {
 
   @Test
   public void twoGetters_interface() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "interface DataType {",
         "  String getName();",
         "  int getAge();",
         "  class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals(model.typeMirror(int.class), properties.get("age").getType());
     assertEquals("Age", properties.get("age").getCapitalizedName());
@@ -426,13 +440,14 @@ public class AnalyserTest {
 
   @Test
   public void booleanGetter() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract boolean isAvailable();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("available");
     assertEquals(model.typeMirror(boolean.class), properties.get("available").getType());
     assertEquals("Available", properties.get("available").getCapitalizedName());
@@ -442,7 +457,7 @@ public class AnalyserTest {
 
   @Test
   public void finalGetter() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public final String getName() {",
@@ -450,24 +465,26 @@ public class AnalyserTest {
         "  }",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).isEmpty();
+
+    assertThat(builder.getMetadata().getProperties()).isEmpty();
   }
 
   @Test
   public void defaultCodeGenerator() throws CannotGenerateCodeException {
-    Metadata metadata = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "interface DataType {",
         "  String getName();",
         "  class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(metadata.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertEquals(DefaultProperty.class, properties.get("name").getCodeGenerator().getClass());
   }
 
   @Test
   public void nonAbstractGetter() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public String getName() {",
@@ -475,12 +492,13 @@ public class AnalyserTest {
         "  }",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).isEmpty();
+
+    assertThat(builder.getMetadata().getProperties()).isEmpty();
   }
 
   @Test
   public void nonAbstractMethodNamedIssue() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public boolean issue() {",
@@ -488,55 +506,60 @@ public class AnalyserTest {
         "  }",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).isEmpty();
+
+    assertThat(builder.getMetadata().getProperties()).isEmpty();
   }
 
   @Test
   public void voidGetter() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract void getName();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).isEmpty();
+
+    assertThat(builder.getMetadata().getProperties()).isEmpty();
     messager.verifyError("getName", "Getter methods must not be void on @FreeBuilder types");
   }
 
   @Test
   public void nonBooleanIsMethod() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String isName();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).isEmpty();
+
+    assertThat(builder.getMetadata().getProperties()).isEmpty();
     messager.verifyError(
         "isName", "Getter methods starting with 'is' must return a boolean on @FreeBuilder types");
   }
 
   @Test
   public void getterWithArgument() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String getName(boolean capitalized);",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).isEmpty();
+
+    assertThat(builder.getMetadata().getProperties()).isEmpty();
     messager.verifyError("getName", "Getter methods cannot take parameters on @FreeBuilder types");
   }
 
   @Test
   public void abstractMethodNamedGet() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String get();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("get");
     assertEquals("Get", properties.get("get").getCapitalizedName());
     assertEquals("get", properties.get("get").getGetterName());
@@ -545,13 +568,14 @@ public class AnalyserTest {
 
   @Test
   public void abstractMethodNamedGetter() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String getter();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("getter");
     assertEquals("Getter", properties.get("getter").getCapitalizedName());
     assertEquals("getter", properties.get("getter").getGetterName());
@@ -560,13 +584,14 @@ public class AnalyserTest {
 
   @Test
   public void abstractMethodNamedIssue() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String issue();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("issue");
     assertEquals("ISSUE", properties.get("issue").getAllCapsName());
     assertEquals("Issue", properties.get("issue").getCapitalizedName());
@@ -576,13 +601,14 @@ public class AnalyserTest {
 
   @Test
   public void abstractMethodWithNonAsciiName() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String getürkt();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("getürkt");
     assertEquals("GETÜRKT", properties.get("getürkt").getAllCapsName());
     assertEquals("Getürkt", properties.get("getürkt").getCapitalizedName());
@@ -592,13 +618,14 @@ public class AnalyserTest {
 
   @Test
   public void abstractMethodNamedIs() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract boolean is();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("is");
     assertEquals("IS", properties.get("is").getAllCapsName());
     assertEquals("Is", properties.get("is").getCapitalizedName());
@@ -608,7 +635,7 @@ public class AnalyserTest {
 
   @Test
   public void mixedValidAndInvalidGetters() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String getName();",
@@ -617,7 +644,8 @@ public class AnalyserTest {
         "  public abstract float isDoubleBarrelled();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals("AGE", properties.get("age").getAllCapsName());
     assertEquals("Age", properties.get("age").getCapitalizedName());
@@ -634,7 +662,7 @@ public class AnalyserTest {
 
   @Test
   public void noDefaults() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String getName();",
@@ -644,7 +672,8 @@ public class AnalyserTest {
         "    }",
         "  }",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertEquals(Type.REQUIRED, properties.get("name").getCodeGenerator().getType());
     assertEquals(Type.REQUIRED, properties.get("age").getCodeGenerator().getType());
   }
@@ -657,12 +686,13 @@ public class AnalyserTest {
         "  public abstract String getName();",
         "  public abstract int getAge();",
         "}");
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType implements IDataType {",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
   }
 
@@ -673,70 +703,71 @@ public class AnalyserTest {
         "public interface IDataType<T> {",
         "  public abstract T getProperty();",
         "}");
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType implements IDataType<String> {",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("property");
     assertEquals("java.lang.String", properties.get("property").getType().toString());
   }
 
   @Test
   public void notGwtSerializable() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "@" + GwtCompatible.class.getName() + "(serializable = false)",
         "public interface DataType {",
         "  class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getGeneratedBuilderAnnotations()).hasSize(1);
-    assertThat(asSource(dataType.getGeneratedBuilderAnnotations().get(0)))
+
+    assertThat(builder.getMetadata().getGeneratedBuilderAnnotations()).hasSize(1);
+    assertThat(asSource(builder.getMetadata().getGeneratedBuilderAnnotations().get(0)))
         .isEqualTo("@GwtCompatible");
-    assertThat(dataType.getValueTypeVisibility()).isEqualTo(PRIVATE);
-    assertThat(dataType.getValueTypeAnnotations()).isEmpty();
-    assertThat(dataType.getNestedClasses()).isEmpty();
-    assertThat(dataType.getVisibleNestedTypes()).containsNoneOf(
+    assertThat(builder.getMetadata().getValueTypeVisibility()).isEqualTo(PRIVATE);
+    assertThat(builder.getMetadata().getValueTypeAnnotations()).isEmpty();
+    assertThat(builder.getMetadata().getNestedClasses()).isEmpty();
+    assertThat(builder.getMetadata().getVisibleNestedTypes()).containsNoneOf(
         QualifiedName.of("com.example", "DataType", "Value_CustomFieldSerializer"),
         QualifiedName.of("com.example", "DataType", "GwtWhitelist"));
   }
 
   @Test
   public void gwtSerializable() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "@" + GwtCompatible.class.getName() + "(serializable = true)",
         "public interface DataType {",
         "  class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getGeneratedBuilderAnnotations()).hasSize(1);
-    assertThat(asSource(dataType.getGeneratedBuilderAnnotations().get(0)))
+
+    assertThat(builder.getMetadata().getGeneratedBuilderAnnotations()).hasSize(1);
+    assertThat(asSource(builder.getMetadata().getGeneratedBuilderAnnotations().get(0)))
         .isEqualTo("@GwtCompatible");
-    assertThat(dataType.getValueTypeVisibility()).isEqualTo(PACKAGE);
-    assertThat(dataType.getValueTypeAnnotations()).hasSize(1);
-    assertThat(asSource(dataType.getValueTypeAnnotations().get(0)))
+    assertThat(builder.getMetadata().getValueTypeVisibility()).isEqualTo(PACKAGE);
+    assertThat(builder.getMetadata().getValueTypeAnnotations()).hasSize(1);
+    assertThat(asSource(builder.getMetadata().getValueTypeAnnotations().get(0)))
         .isEqualTo("@GwtCompatible(serializable = true)");
-    assertThat(dataType.getNestedClasses()).hasSize(2);
-    assertThat(dataType.getVisibleNestedTypes()).containsAllOf(
+    assertThat(builder.getMetadata().getNestedClasses()).hasSize(2);
+    assertThat(builder.getMetadata().getVisibleNestedTypes()).containsAllOf(
         QualifiedName.of("com.example", "DataType_Builder", "Value_CustomFieldSerializer"),
         QualifiedName.of("com.example", "DataType_Builder", "GwtWhitelist"));
   }
 
   @Test
   public void underriddenEquals() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  @Override public boolean equals(Object obj) {",
         "    return (obj instanceof DataType);",
         "  }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.OVERRIDEABLE));
     messager.verifyError(
         "equals", "hashCode and equals must be implemented together on @FreeBuilder types");
@@ -744,18 +775,16 @@ public class AnalyserTest {
 
   @Test
   public void underriddenHashCode() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  @Override public int hashCode() {",
         "    return DataType.class.hashCode();",
         "  }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.HASH_CODE, UnderrideLevel.OVERRIDEABLE));
     messager.verifyError(
         "hashCode", "hashCode and equals must be implemented together on @FreeBuilder types");
@@ -763,7 +792,7 @@ public class AnalyserTest {
 
   @Test
   public void underriddenHashCodeAndEquals() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  @Override public int hashCode() {",
@@ -773,35 +802,31 @@ public class AnalyserTest {
         "    return (obj instanceof DataType);",
         "  }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.OVERRIDEABLE,
         StandardMethod.HASH_CODE, UnderrideLevel.OVERRIDEABLE));
   }
 
   @Test
   public void underriddenToString() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  @Override public String toString() {",
         "    return \"DataType{}\";",
         "  }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.TO_STRING, UnderrideLevel.OVERRIDEABLE));
   }
 
   @Test
   public void underriddenTriad() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  @Override public boolean equals(Object obj) {",
@@ -814,11 +839,9 @@ public class AnalyserTest {
         "    return \"DataType{}\";",
         "  }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.OVERRIDEABLE,
         StandardMethod.HASH_CODE, UnderrideLevel.OVERRIDEABLE,
         StandardMethod.TO_STRING, UnderrideLevel.OVERRIDEABLE));
@@ -826,18 +849,16 @@ public class AnalyserTest {
 
   @Test
   public void finalEquals() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  @Override public final boolean equals(Object obj) {",
         "    return (obj instanceof DataType);",
         "  }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.FINAL));
     messager.verifyError(
         "equals", "hashCode and equals must be implemented together on @FreeBuilder types");
@@ -845,18 +866,16 @@ public class AnalyserTest {
 
   @Test
   public void finalHashCode() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  @Override public final int hashCode() {",
         "    return DataType.class.hashCode();",
         "  }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.HASH_CODE, UnderrideLevel.FINAL));
     messager.verifyError(
         "hashCode", "hashCode and equals must be implemented together on @FreeBuilder types");
@@ -864,7 +883,7 @@ public class AnalyserTest {
 
   @Test
   public void finalHashCodeAndEquals() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  @Override public final int hashCode() {",
@@ -874,35 +893,31 @@ public class AnalyserTest {
         "    return (obj instanceof DataType);",
         "  }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.FINAL,
         StandardMethod.HASH_CODE, UnderrideLevel.FINAL));
   }
 
   @Test
   public void finalToString() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  @Override public final String toString() {",
         "    return \"DataType{}\";",
         "  }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.TO_STRING, UnderrideLevel.FINAL));
   }
 
   @Test
   public void finalTriad() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  @Override public final boolean equals(Object obj) {",
@@ -915,11 +930,9 @@ public class AnalyserTest {
         "    return \"DataType{}\";",
         "  }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.FINAL,
         StandardMethod.HASH_CODE, UnderrideLevel.FINAL,
         StandardMethod.TO_STRING, UnderrideLevel.FINAL));
@@ -927,60 +940,52 @@ public class AnalyserTest {
 
   @Test
   public void abstractEquals() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  /** Some comment about value-based equality. */",
         "  @Override public abstract boolean equals(Object obj);",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEmpty();
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEmpty();
   }
 
   @Test
   public void abstractHashCode() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  /** Some comment about value-based equality. */",
         "  @Override public abstract int hashCode();",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEmpty();
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEmpty();
   }
 
   @Test
   public void abstractToString() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  /** Some comment about how this is a useful toString implementation. */",
         "  @Override public abstract String toString();",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getStandardMethodUnderrides()).isEmpty();
+    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEmpty();
   }
 
   @Test
   public void privateNestedType() {
-    TypeElement privateType = (TypeElement) model.newElementWithMarker(
-        "package com.example;",
-        "public class DataType {",
-        "  ---> private static class PrivateType {",
-        "  }",
-        "}");
-
     try {
-      analyser.analyse(privateType);
+      analyser.analyse((TypeElement) model.newElementWithMarker(
+          "package com.example;",
+          "public class DataType {",
+          "  ---> private static class PrivateType {",
+          "  }",
+          "}"));
       fail("Expected CannotGenerateCodeException");
     } catch (CannotGenerateCodeException expected) { }
 
@@ -989,17 +994,15 @@ public class AnalyserTest {
 
   @Test
   public void indirectlyPrivateNestedType() {
-    TypeElement nestedType = (TypeElement) model.newElementWithMarker(
-        "package com.example;",
-        "public class DataType {",
-        "  private static class PrivateType {",
-        "    ---> static class NestedType {",
-        "    }",
-        "  }",
-        "}");
-
     try {
-      analyser.analyse(nestedType);
+      analyser.analyse((TypeElement) model.newElementWithMarker(
+          "package com.example;",
+          "public class DataType {",
+          "  private static class PrivateType {",
+          "    ---> static class NestedType {",
+          "    }",
+          "  }",
+          "}"));
       fail("Expected CannotGenerateCodeException");
     } catch (CannotGenerateCodeException expected) { }
 
@@ -1010,15 +1013,13 @@ public class AnalyserTest {
 
   @Test
   public void innerType() {
-    TypeElement innerType = (TypeElement) model.newElementWithMarker(
-        "package com.example;",
-        "public class DataType {",
-        "  ---> public class InnerType {",
-        "  }",
-        "}");
-
     try {
-      analyser.analyse(innerType);
+      analyser.analyse((TypeElement) model.newElementWithMarker(
+          "package com.example;",
+          "public class DataType {",
+          "  ---> public class InnerType {",
+          "  }",
+          "}"));
       fail("Expected CannotGenerateCodeException");
     } catch (CannotGenerateCodeException expected) { }
 
@@ -1029,43 +1030,50 @@ public class AnalyserTest {
 
   @Test
   public void nonStaticBuilder() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String getName();",
         "  public class Builder extends DataType_Builder {}",
         "}"));
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name");
     assertEquals("java.lang.String", properties.get("name").getType().toString());
     assertNull(properties.get("name").getBoxedType());
     assertEquals("NAME", properties.get("name").getAllCapsName());
     assertEquals("Name", properties.get("name").getCapitalizedName());
     assertEquals("getName", properties.get("name").getGetterName());
-    assertThat(dataType.isExtensible()).isFalse();
-    assertThat(dataType.getBuilderFactory()).isAbsent();
+    assertThat(builder.getMetadata().isExtensible()).isFalse();
+    assertThat(builder.getMetadata().getBuilderFactory()).isAbsent();
     messager.verifyError("Builder", "Builder must be static on @FreeBuilder types");
   }
 
   @Test
   public void genericType() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType<A, B> {",
         "  public abstract A getName();",
         "  public abstract B getAge();",
         "  public static class Builder<Q, R> extends DataType_Builder<Q, R> {}",
         "}"));
-    assertEquals("com.example.DataType.Builder<A, B>", dataType.getBuilder().toString());
-    assertThat(dataType.isExtensible()).isTrue();
-    assertEquals(Optional.of(BuilderFactory.NO_ARGS_CONSTRUCTOR), dataType.getBuilderFactory());
-    assertEquals("com.example.DataType_Builder<A, B>", dataType.getGeneratedBuilder().toString());
+
+    assertEquals("com.example.DataType.Builder<A, B>",
+        builder.getMetadata().getBuilder().toString());
+    assertThat(builder.getMetadata().isExtensible()).isTrue();
+    assertEquals(Optional.of(BuilderFactory.NO_ARGS_CONSTRUCTOR),
+        builder.getMetadata().getBuilderFactory());
+    assertEquals("com.example.DataType_Builder<A, B>",
+        builder.getMetadata().getGeneratedBuilder().toString());
     assertEquals("com.example.DataType_Builder.Partial<A, B>",
-        dataType.getPartialType().toString());
-    assertEquals("com.example.DataType_Builder.Property", dataType.getPropertyEnum().toString());
-    assertEquals("com.example.DataType<A, B>", dataType.getType().toString());
-    assertEquals("com.example.DataType_Builder.Value<A, B>", dataType.getValueType().toString());
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+        builder.getMetadata().getPartialType().toString());
+    assertEquals("com.example.DataType_Builder.Property",
+        builder.getMetadata().getPropertyEnum().toString());
+    assertEquals("com.example.DataType<A, B>", builder.getMetadata().getType().toString());
+    assertEquals("com.example.DataType_Builder.Value<A, B>",
+        builder.getMetadata().getValueType().toString());
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals("B", properties.get("age").getType().toString());
     assertNull(properties.get("age").getBoxedType());
@@ -1081,7 +1089,7 @@ public class AnalyserTest {
 
   @Test
   public void genericTypeWithBounds() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType<A extends CharSequence, B extends " + Temporal.class.getName()
             + "> {",
@@ -1089,34 +1097,42 @@ public class AnalyserTest {
         "  public abstract B getAge();",
         "  public static class Builder<Q, R> extends DataType_Builder<Q, R> {}",
         "}"));
-    assertEquals("com.example.DataType.Builder<A, B>", dataType.getBuilder().toString());
+
+    assertEquals("com.example.DataType.Builder<A, B>",
+        builder.getMetadata().getBuilder().toString());
     assertEquals("DataType<A extends CharSequence, B extends Temporal>",
-        SourceStringBuilder.simple().add(dataType.getType().declaration()).toString());
+        SourceStringBuilder.simple().add(builder.getMetadata().getType().declaration()).toString());
   }
 
-  /** @see <a href="https://github.com/google/FreeBuilder/issues/111">Issue 111</a> */
   @Test
   public void genericType_rebuilt() throws CannotGenerateCodeException {
+    // See also https://github.com/inferred/FreeBuilder/issues/111
     model.newType(
         "package com.example;",
         "abstract class DataType_Builder<A, B> {}");
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType<A, B> {",
         "  public abstract A getName();",
         "  public abstract B getAge();",
         "  public static class Builder<A, B> extends DataType_Builder<A, B> {}",
         "}"));
-    assertEquals("com.example.DataType.Builder<A, B>", dataType.getBuilder().toString());
-    assertThat(dataType.isExtensible()).isTrue();
-    assertEquals(Optional.of(BuilderFactory.NO_ARGS_CONSTRUCTOR), dataType.getBuilderFactory());
-    assertEquals("com.example.DataType_Builder<A, B>", dataType.getGeneratedBuilder().toString());
+
+    assertEquals("com.example.DataType.Builder<A, B>",
+        builder.getMetadata().getBuilder().toString());
+    assertThat(builder.getMetadata().isExtensible()).isTrue();
+    assertEquals(Optional.of(BuilderFactory.NO_ARGS_CONSTRUCTOR),
+        builder.getMetadata().getBuilderFactory());
+    assertEquals("com.example.DataType_Builder<A, B>",
+        builder.getMetadata().getGeneratedBuilder().toString());
     assertEquals("com.example.DataType_Builder.Partial<A, B>",
-        dataType.getPartialType().toString());
-    assertEquals("com.example.DataType_Builder.Property", dataType.getPropertyEnum().toString());
-    assertEquals("com.example.DataType<A, B>", dataType.getType().toString());
-    assertEquals("com.example.DataType_Builder.Value<A, B>", dataType.getValueType().toString());
-    Map<String, Property> properties = uniqueIndex(dataType.getProperties(), GET_NAME);
+        builder.getMetadata().getPartialType().toString());
+    assertEquals("com.example.DataType_Builder.Property",
+        builder.getMetadata().getPropertyEnum().toString());
+    assertEquals("com.example.DataType<A, B>", builder.getMetadata().getType().toString());
+    assertEquals("com.example.DataType_Builder.Value<A, B>",
+        builder.getMetadata().getValueType().toString());
+    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals("B", properties.get("age").getType().toString());
     assertNull(properties.get("age").getBoxedType());
@@ -1132,13 +1148,11 @@ public class AnalyserTest {
 
   @Test
   public void wrongBuilderSuperclass_errorType() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    analyser.analyse(model.newType(
         "package com.example;",
         "public interface DataType {",
         "  class Builder extends SomeOther_Builder { }",
-        "}");
-
-    analyser.analyse(dataType);
+        "}"));
 
     messager.verifyError("Builder", "Builder extends the wrong type (should be DataType_Builder)");
   }
@@ -1149,27 +1163,23 @@ public class AnalyserTest {
         "package com.example;",
         "@" + Generated.class.getCanonicalName() + "(\"FreeBuilder FTW!\")",
         "class SomeOther_Builder { }");
-    TypeElement dataType = model.newType(
+    analyser.analyse(model.newType(
         "package com.example;",
         "public interface DataType {",
         "  class Builder extends SomeOther_Builder { }",
-        "}");
-
-    analyser.analyse(dataType);
+        "}"));
 
     messager.verifyError("Builder", "Builder extends the wrong type (should be DataType_Builder)");
   }
 
   @Test
   public void explicitPackageScopeNoArgsConstructor() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  DataType() { }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
-
-    Metadata metadata = analyser.analyse(dataType);
+        "}"));
 
     TypeElement concreteBuilder = model.typeElement("com.example.DataType.Builder");
     QualifiedName expectedBuilder = QualifiedName.of("com.example", "DataType_Builder");
@@ -1194,21 +1204,19 @@ public class AnalyserTest {
         .addVisibleNestedTypes(valueType)
         .build();
 
-    assertEquals(expectedMetadata, metadata);
+    assertEquals(expectedMetadata, builder.getMetadata());
   }
 
   @Test
   public void multipleConstructors() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  DataType(int i) { }",
         "  DataType() { }",
         "  DataType(String s) { }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
-
-    Metadata metadata = analyser.analyse(dataType);
+        "}"));
 
     TypeElement concreteBuilder = model.typeElement("com.example.DataType.Builder");
     QualifiedName expectedBuilder = QualifiedName.of("com.example", "DataType_Builder");
@@ -1233,19 +1241,17 @@ public class AnalyserTest {
         .addVisibleNestedTypes(valueType)
         .build();
 
-    assertEquals(expectedMetadata, metadata);
+    assertEquals(expectedMetadata, builder.getMetadata());
   }
 
   @Test
   public void explicitPrivateScopeNoArgsConstructor() {
-    TypeElement dataType = model.newType(
-        "package com.example;",
-        "public class DataType {",
-        "  private DataType() { }",
-        "}");
-
     try {
-      analyser.analyse(dataType);
+      analyser.analyse(model.newType(
+          "package com.example;",
+          "public class DataType {",
+          "  private DataType() { }",
+          "}"));
       fail("Expected CannotGenerateCodeException");
     } catch (CannotGenerateCodeException expected) { }
 
@@ -1255,14 +1261,12 @@ public class AnalyserTest {
 
   @Test
   public void noNoArgsConstructor() {
-    TypeElement dataType = model.newType(
-        "package com.example;",
-        "public class DataType {",
-        "  private DataType(int x) { }",
-        "}");
-
     try {
-      analyser.analyse(dataType);
+      analyser.analyse(model.newType(
+          "package com.example;",
+          "public class DataType {",
+          "  private DataType(int x) { }",
+          "}"));
       fail("Expected CannotGenerateCodeException");
     } catch (CannotGenerateCodeException expected) { }
 
@@ -1272,12 +1276,10 @@ public class AnalyserTest {
 
   @Test
   public void freeEnumBuilder() {
-    TypeElement dataType = model.newType(
-        "package com.example;",
-        "public enum DataType {}");
-
     try {
-      analyser.analyse(dataType);
+      analyser.analyse(model.newType(
+          "package com.example;",
+          "public enum DataType {}"));
       fail("Expected CannotGenerateCodeException");
     } catch (CannotGenerateCodeException expected) { }
 
@@ -1286,11 +1288,8 @@ public class AnalyserTest {
 
   @Test
   public void unnamedPackage() {
-    TypeElement dataType = model.newType(
-        "public class DataType {}");
-
     try {
-      analyser.analyse(dataType);
+      analyser.analyse(model.newType("public class DataType {}"));
       fail("Expected CannotGenerateCodeException");
     } catch (CannotGenerateCodeException expected) { }
 
@@ -1299,12 +1298,10 @@ public class AnalyserTest {
 
   @Test
   public void freeAnnotationBuilder() {
-    TypeElement dataType = model.newType(
-        "package com.example;",
-        "public @interface DataType {}");
-
     try {
-      analyser.analyse(dataType);
+      analyser.analyse(model.newType(
+          "package com.example;",
+          "public @interface DataType {}"));
       fail("Expected CannotGenerateCodeException");
     } catch (CannotGenerateCodeException expected) { }
 
@@ -1313,118 +1310,123 @@ public class AnalyserTest {
 
   @Test
   public void isFullyCheckedCast_nonGenericType() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract String getProperty();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).hasSize(1);
-    Property property = getOnlyElement(dataType.getProperties());
+
+    assertThat(builder.getMetadata().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
 
   @Test
   public void isFullyCheckedCast_erasedType() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract Iterable getProperty();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).hasSize(1);
-    Property property = getOnlyElement(dataType.getProperties());
+
+    assertThat(builder.getMetadata().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
 
   @Test
   public void isFullyCheckedCast_wildcardType() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract Iterable<?> getProperty();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).hasSize(1);
-    Property property = getOnlyElement(dataType.getProperties());
+
+    assertThat(builder.getMetadata().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
 
   @Test
   public void isFullyCheckedCast_genericType() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract Iterable<String> getProperty();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).hasSize(1);
-    Property property = getOnlyElement(dataType.getProperties());
+
+    assertThat(builder.getMetadata().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isFalse();
   }
 
   @Test
   public void isFullyCheckedCast_lowerBoundWildcard() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract Iterable<? extends Number> getProperty();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).hasSize(1);
-    Property property = getOnlyElement(dataType.getProperties());
+
+    assertThat(builder.getMetadata().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isFalse();
   }
 
   @Test
   public void isFullyCheckedCast_objectLowerBoundWildcard() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract Iterable<? extends Object> getProperty();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).hasSize(1);
-    Property property = getOnlyElement(dataType.getProperties());
+
+    assertThat(builder.getMetadata().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
 
   @Test
   public void isFullyCheckedCast_oneWildcard() throws CannotGenerateCodeException {
-    Metadata dataType = analyser.analyse(model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  public abstract java.util.Map<?, String> getProperty();",
         "  public static class Builder extends DataType_Builder {}",
         "}"));
-    assertThat(dataType.getProperties()).hasSize(1);
-    Property property = getOnlyElement(dataType.getProperties());
+
+    assertThat(builder.getMetadata().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isFalse();
   }
 
   @Test
   public void typeNotNamedBuilderIgnored() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    analyser.analyse(model.newType(
         "package com.example;",
         "public interface DataType {",
         "  class Bulider extends DataType_Builder {}",
-        "}");
-
-    analyser.analyse(dataType);
+        "}"));
 
     messager.verifyNote("DataType", addBuilderToInterfaceMessage("DataType_Builder"));
   }
 
   @Test
   public void valueTypeNestedClassesAddedToVisibleList() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType {",
         "  DataType(int i) { }",
@@ -1432,11 +1434,9 @@ public class AnalyserTest {
         "  DataType(String s) { }",
         "  public static class Builder extends DataType_Builder {}",
         "  public interface Objects {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getVisibleNestedTypes()).containsExactly(
+    assertThat(builder.getMetadata().getVisibleNestedTypes()).containsExactly(
         QualifiedName.of("com.example", "DataType", "Builder"),
         QualifiedName.of("com.example", "DataType", "Objects"),
         QualifiedName.of("com.example", "DataType_Builder", "Partial"),
@@ -1452,18 +1452,16 @@ public class AnalyserTest {
         "public class SuperType {",
         "  public interface Objects {}",
         "}");
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public class DataType extends SuperType {",
         "  DataType(int i) { }",
         "  DataType() { }",
         "  DataType(String s) { }",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    assertThat(metadata.getVisibleNestedTypes()).containsExactly(
+    assertThat(builder.getMetadata().getVisibleNestedTypes()).containsExactly(
         QualifiedName.of("com.example", "SuperType", "Objects"),
         QualifiedName.of("com.example", "DataType", "Builder"),
         QualifiedName.of("com.example", "DataType_Builder", "Partial"),
@@ -1474,29 +1472,27 @@ public class AnalyserTest {
   @Test
   public void missingGenericParametersOnBuilder() throws CannotGenerateCodeException {
     // See also https://github.com/inferred/FreeBuilder/issues/110
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "import java.util.*;",
         "public class DataType<A> {",
         "  public static class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-    assertThat(metadata.getOptionalBuilder()).isAbsent();
+    assertThat(builder.getMetadata().getOptionalBuilder()).isAbsent();
     messager.verifyError("Builder", "Builder must be generic");
   }
 
   @Test
   public void incorrectGenericParametersOnBuilder() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "import java.util.*;",
         "public class DataType<A> {",
         "  public static class Builder<Q, R> extends DataType_Builder<Q, R> {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-    assertThat(metadata.getOptionalBuilder()).isAbsent();
+    assertThat(builder.getMetadata().getOptionalBuilder()).isAbsent();
     messager.verifyError("Builder", "Builder has the wrong type parameters");
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
@@ -1276,8 +1276,8 @@ public class DefaultedPropertiesSourceTest {
   }
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features)
+        .add(new CodeGenerator(metadata));
     try {
       return new Formatter().formatSource(sourceBuilder.toString());
     } catch (FormatterException e) {

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
@@ -1277,7 +1277,7 @@ public class DefaultedPropertiesSourceTest {
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
     SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
+    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
     try {
       return new Formatter().formatSource(sourceBuilder.toString());
     } catch (FormatterException e) {

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
@@ -854,7 +854,7 @@ public class GenericTypeSourceTest {
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
     SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
+    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
     try {
       return new Formatter().formatSource(sourceBuilder.toString());
     } catch (FormatterException e) {

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
@@ -853,8 +853,8 @@ public class GenericTypeSourceTest {
   }
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features)
+        .add(new CodeGenerator(metadata));
     try {
       return new Formatter().formatSource(sourceBuilder.toString());
     } catch (FormatterException e) {

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
@@ -1297,8 +1297,8 @@ public class GuavaOptionalSourceTest {
   }
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features)
+        .add(new CodeGenerator(metadata));
     try {
       return new Formatter().formatSource(sourceBuilder.toString());
     } catch (FormatterException e) {

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
@@ -1298,7 +1298,7 @@ public class GuavaOptionalSourceTest {
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
     SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
+    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
     try {
       return new Formatter().formatSource(sourceBuilder.toString());
     } catch (FormatterException e) {

--- a/src/test/java/org/inferred/freebuilder/processor/JacksonSupportTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JacksonSupportTest.java
@@ -39,8 +39,6 @@ import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.lang.model.element.TypeElement;
-
 /** Unit tests for {@link Analyser}. */
 @RunWith(JUnit4.class)
 public class JacksonSupportTest {
@@ -61,51 +59,46 @@ public class JacksonSupportTest {
 
   @Test
   public void noAnnotationAddedIfJsonDeserializeMissing() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "public interface DataType {",
         "  int getFooBar();",
         "  class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    Property property = getOnlyElement(metadata.getProperties());
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertThat(property.getAccessorAnnotations()).named("property accessor annotations").isEmpty();
   }
 
   @Test
   public void jacksonAnnotationAddedWithExplicitName() throws CannotGenerateCodeException {
     // See also https://github.com/google/FreeBuilder/issues/68
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "import " + JsonProperty.class.getName() + ";",
         "@" + JsonDeserialize.class.getName() + "(builder = DataType.Builder.class)",
         "public interface DataType {",
         "  @JsonProperty(\"bob\") int getFooBar();",
         "  class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    Property property = getOnlyElement(metadata.getProperties());
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertPropertyHasAnnotation(property, JsonProperty.class, "@JsonProperty(\"bob\")");
   }
+
   @Test
   public void jacksonXmlAnnotationAddedWithExplicitName() throws CannotGenerateCodeException {
     // See also https://github.com/google/FreeBuilder/issues/68
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
          "import " + JacksonXmlProperty.class.getName() + ";",
         "@" + JsonDeserialize.class.getName() + "(builder = DataType.Builder.class)",
         "public interface DataType {",
         "  @JacksonXmlProperty(localName=\"b-ob\") int getFooBar();",
         "  class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    Property property = getOnlyElement(metadata.getProperties());
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertPropertyHasAnnotation(property,
             JacksonXmlProperty.class, "@JacksonXmlProperty(localName = \"b-ob\")");
   }
@@ -113,34 +106,30 @@ public class JacksonSupportTest {
   @Test
   public void jacksonAnnotationAddedWithImplicitName() throws CannotGenerateCodeException {
     // See also https://github.com/google/FreeBuilder/issues/90
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "@" + JsonDeserialize.class.getName() + "(builder = DataType.Builder.class)",
         "public interface DataType {",
         "  int getFooBar();",
         "  class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    Property property = getOnlyElement(metadata.getProperties());
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertPropertyHasAnnotation(property, JsonProperty.class, "@JsonProperty(\"fooBar\")");
   }
 
   @Test
   public void jsonAnyGetterAnnotationDisablesImplicitProperty() throws CannotGenerateCodeException {
-    TypeElement dataType = model.newType(
+    CodeGenerator builder = (CodeGenerator) analyser.analyse(model.newType(
         "package com.example;",
         "@" + JsonDeserialize.class.getName() + "(builder = DataType.Builder.class)",
         "public interface DataType {",
         "  @" + JsonAnyGetter.class.getName(),
         "  " + Map.class.getName() + "<Integer, String> getFooBar();",
         "  class Builder extends DataType_Builder {}",
-        "}");
+        "}"));
 
-    Metadata metadata = analyser.analyse(dataType);
-
-    Property property = getOnlyElement(metadata.getProperties());
+    Property property = getOnlyElement(builder.getMetadata().getProperties());
     assertThat(property.getAccessorAnnotations()).named("property accessor annotations").isEmpty();
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
@@ -994,7 +994,7 @@ public class JavaUtilOptionalSourceTest {
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
     SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
+    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
     try {
       return new Formatter().formatSource(sourceBuilder.toString());
     } catch (FormatterException e) {

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
@@ -993,8 +993,8 @@ public class JavaUtilOptionalSourceTest {
   }
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features)
+        .add(new CodeGenerator(metadata));
     try {
       return new Formatter().formatSource(sourceBuilder.toString());
     } catch (FormatterException e) {

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -1936,8 +1936,8 @@ public class ListSourceTest {
   }
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features)
+        .add(new CodeGenerator(metadata));
     return CompilationUnitBuilder.formatSource(sourceBuilder.toString());
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -1937,7 +1937,7 @@ public class ListSourceTest {
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
     SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
+    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
     return CompilationUnitBuilder.formatSource(sourceBuilder.toString());
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -1046,8 +1046,8 @@ public class MapSourceTest {
   }
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features)
+        .add(new CodeGenerator(metadata));
     return CompilationUnitBuilder.formatSource(sourceBuilder.toString());
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -1047,7 +1047,7 @@ public class MapSourceTest {
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
     SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
+    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
     return CompilationUnitBuilder.formatSource(sourceBuilder.toString());
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
@@ -949,8 +949,8 @@ public class NullableSourceTest {
   }
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features)
+        .add(new CodeGenerator(metadata));
     return CompilationUnitBuilder.formatSource(sourceBuilder.toString());
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
@@ -950,7 +950,7 @@ public class NullableSourceTest {
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
     SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
+    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
     return CompilationUnitBuilder.formatSource(sourceBuilder.toString());
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
@@ -1649,8 +1649,8 @@ public class RequiredPropertiesSourceTest {
   }
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features)
+        .add(new CodeGenerator(metadata));
     try {
       return new Formatter().formatSource(sourceBuilder.toString());
     } catch (FormatterException e) {

--- a/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
@@ -1650,7 +1650,7 @@ public class RequiredPropertiesSourceTest {
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
     SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
+    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
     try {
       return new Formatter().formatSource(sourceBuilder.toString());
     } catch (FormatterException e) {

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -1425,8 +1425,8 @@ public class SetSourceTest {
   }
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
+    SourceBuilder sourceBuilder = SourceStringBuilder.simple(features)
+        .add(new CodeGenerator(metadata));
     return CompilationUnitBuilder.formatSource(sourceBuilder.toString());
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -1426,7 +1426,7 @@ public class SetSourceTest {
 
   private static String generateSource(Metadata metadata, Feature<?>... features) {
     SourceBuilder sourceBuilder = SourceStringBuilder.simple(features);
-    new CodeGenerator().writeBuilderSource(sourceBuilder, metadata);
+    new CodeGenerator(metadata).writeBuilderSource(sourceBuilder);
     return CompilationUnitBuilder.formatSource(sourceBuilder.toString());
   }
 


### PR DESCRIPTION
Metadata needs to support two distinct code generation paths: generating the usual FreeBuilder superclass; and generating a stub for the user to extend. This means Metadata needs to mark its Builder property as nullable, obfuscating what data is available where in the code. Instead, move responsibility for choosing a code generator to Analyser, and move stub code generation into a new GeneratedStub type.