### PR TITLE
 Split Metadata into separate Datatype and properties list

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -42,7 +42,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.Metadata.StandardMethod;
 import org.inferred.freebuilder.processor.Metadata.UnderrideLevel;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;

--- a/src/main/java/org/inferred/freebuilder/processor/BuildableProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildableProperty.java
@@ -35,7 +35,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.Excerpts;

--- a/src/main/java/org/inferred/freebuilder/processor/BuildableProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildableProperty.java
@@ -172,7 +172,7 @@ class BuildableProperty extends PropertyCodeGenerator {
           config.getTypes());
 
       return Optional.of(new BuildableProperty(
-          config.getMetadata(),
+          config.getDatatype(),
           config.getProperty(),
           ParameterizedType.from(builder.get()),
           builderFactory.get(),
@@ -190,14 +190,14 @@ class BuildableProperty extends PropertyCodeGenerator {
   private final Excerpt suppressUnchecked;
 
   private BuildableProperty(
-      Metadata metadata,
+      Datatype datatype,
       Property property,
       ParameterizedType builderType,
       BuilderFactory builderFactory,
       FunctionalType mutatorType,
       MergeBuilderMethod mergeFromBuilderMethod,
       PartialToBuilderMethod partialToBuilderMethod) {
-    super(metadata, property);
+    super(datatype, property);
     this.builderType = builderType;
     this.builderFactory = builderFactory;
     this.mutatorType = mutatorType;
@@ -217,25 +217,25 @@ class BuildableProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addSetter(code, metadata);
-    addSetterTakingBuilder(code, metadata);
-    addMutate(code, metadata);
-    addGetter(code, metadata);
+    addSetter(code, datatype);
+    addSetterTakingBuilder(code, datatype);
+    addMutate(code, datatype);
+    addGetter(code, datatype);
   }
 
-  private void addSetter(SourceBuilder code, Metadata metadata) {
+  private void addSetter(SourceBuilder code, Datatype datatype) {
     Variable builder = new Variable("builder");
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws NullPointerException if {@code %s} is null", property.getName())
         .addLine(" */");
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s %s) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             setter(property),
             property.getType(),
             property.getName());
@@ -250,29 +250,29 @@ class BuildableProperty extends PropertyCodeGenerator {
         .addLine("    %s.clear();", builder)
         .addLine("    %s.mergeFrom(%s);", builder, property.getName())
         .addLine("  }")
-        .addLine("  return (%s) this;", metadata.getBuilder());
+        .addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addSetterTakingBuilder(SourceBuilder code, Metadata metadata) {
+  private void addSetterTakingBuilder(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws NullPointerException if {@code builder} is null")
         .addLine(" */")
         .addLine("public %s %s(%s builder) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             setter(property),
             builderType)
         .addLine("  return %s(builder.build());", setter(property))
         .addLine("}");
   }
 
-  private void addMutate(SourceBuilder code, Metadata metadata) {
+  private void addMutate(SourceBuilder code, Datatype datatype) {
     if (!code.feature(FUNCTION_PACKAGE).consumer().isPresent()) {
       return;
     }
@@ -280,31 +280,31 @@ class BuildableProperty extends PropertyCodeGenerator {
         .addLine("/**")
         .addLine(" * Applies {@code mutator} to the builder for the value that will be")
         .addLine(" * returned by %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
         .addLine(" * <p>This method mutates the builder in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored.")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws NullPointerException if {@code mutator} is null")
         .addLine(" */")
         .addLine("public %s %s(%s mutator) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             mutator(property),
             mutatorType.getFunctionalInterface())
         .add(methodBody(code, "mutator")
             .addLine("  mutator.%s(%s());", mutatorType.getMethodName(), getBuilderMethod(property))
-            .addLine("  return (%s) this;", metadata.getBuilder()))
+            .addLine("  return (%s) this;", datatype.getBuilder()))
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Metadata metadata) {
+  private void addGetter(SourceBuilder code, Datatype datatype) {
     Variable builder = new Variable("builder");
     Variable value = new Variable("value");
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns a builder for the value that will be returned by %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" */")
         .addLine("public %s %s() {", builderType, getBuilderMethod(property));
     Block body = methodBody(code)
@@ -380,7 +380,7 @@ class BuildableProperty extends PropertyCodeGenerator {
 
   @Override
   public void addMergeFromBuilder(Block code, String builder) {
-    Excerpt base = Declarations.upcastToGeneratedBuilder(code, metadata, builder);
+    Excerpt base = Declarations.upcastToGeneratedBuilder(code, datatype, builder);
     Variable fieldValue = new Variable(property.getName() + "Value");
     code.addLine("if (%s == null) {", property.getField().on(base))
         .addLine("  // Nothing to merge")

--- a/src/main/java/org/inferred/freebuilder/processor/BuildableProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildableProperty.java
@@ -217,13 +217,13 @@ class BuildableProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addSetter(code, datatype);
-    addSetterTakingBuilder(code, datatype);
-    addMutate(code, datatype);
-    addGetter(code, datatype);
+    addSetter(code);
+    addSetterTakingBuilder(code);
+    addMutate(code);
+    addGetter(code);
   }
 
-  private void addSetter(SourceBuilder code, Datatype datatype) {
+  private void addSetter(SourceBuilder code) {
     Variable builder = new Variable("builder");
     code.addLine("")
         .addLine("/**")
@@ -255,7 +255,7 @@ class BuildableProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addSetterTakingBuilder(SourceBuilder code, Datatype datatype) {
+  private void addSetterTakingBuilder(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
@@ -272,7 +272,7 @@ class BuildableProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMutate(SourceBuilder code, Datatype datatype) {
+  private void addMutate(SourceBuilder code) {
     if (!code.feature(FUNCTION_PACKAGE).consumer().isPresent()) {
       return;
     }
@@ -298,7 +298,7 @@ class BuildableProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     Variable builder = new Variable("builder");
     Variable value = new Variable("value");
     code.addLine("")

--- a/src/main/java/org/inferred/freebuilder/processor/BuilderMethods.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuilderMethods.java
@@ -1,7 +1,5 @@
 package org.inferred.freebuilder.processor;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
-
 /** Utility methods for method names used in builders. */
 public class BuilderMethods {
 

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -17,7 +17,6 @@ package org.inferred.freebuilder.processor;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -121,9 +120,6 @@ public abstract class Datatype {
   /** Returns the Property enum that may be generated. */
   public abstract ParameterizedType getPropertyEnum();
 
-  /** Returns datatype about the properties of the type. */
-  public abstract ImmutableList<Property> getProperties();
-
   public UnderrideLevel standardMethodUnderride(StandardMethod standardMethod) {
     UnderrideLevel underrideLevel = getStandardMethodUnderrides().get(standardMethod);
     return (underrideLevel == null) ? UnderrideLevel.ABSENT : underrideLevel;
@@ -147,19 +143,11 @@ public abstract class Datatype {
   public abstract Visibility getValueTypeVisibility();
 
   /** Returns a list of nested classes that should be added to the generated builder class. */
-  public abstract ImmutableList<Function<Datatype, Excerpt>> getNestedClasses();
+  public abstract ImmutableList<Excerpt> getNestedClasses();
 
   public Builder toBuilder() {
     return new Builder().mergeFrom(this);
   }
-
-  public static final Function<Property, PropertyCodeGenerator> GET_CODE_GENERATOR =
-      new Function<Property, PropertyCodeGenerator>() {
-        @Override
-        public PropertyCodeGenerator apply(Property input) {
-          return input.getCodeGenerator();
-        }
-      };
 
   /** Builder for {@link Datatype}. */
   public static class Builder extends Datatype_Builder {

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -29,9 +29,9 @@ import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 
 /**
- * Metadata about a &#64;{@link org.inferred.freebuilder.FreeBuilder FreeBuilder} type.
+ * Metadata about a user's datatype.
  */
-public abstract class Metadata {
+public abstract class Datatype {
 
   /** Standard Java methods that may be underridden. */
   public enum StandardMethod {
@@ -121,7 +121,7 @@ public abstract class Metadata {
   /** Returns the Property enum that may be generated. */
   public abstract ParameterizedType getPropertyEnum();
 
-  /** Returns metadata about the properties of the type. */
+  /** Returns datatype about the properties of the type. */
   public abstract ImmutableList<Property> getProperties();
 
   public UnderrideLevel standardMethodUnderride(StandardMethod standardMethod) {
@@ -147,7 +147,7 @@ public abstract class Metadata {
   public abstract Visibility getValueTypeVisibility();
 
   /** Returns a list of nested classes that should be added to the generated builder class. */
-  public abstract ImmutableList<Function<Metadata, Excerpt>> getNestedClasses();
+  public abstract ImmutableList<Function<Datatype, Excerpt>> getNestedClasses();
 
   public Builder toBuilder() {
     return new Builder().mergeFrom(this);
@@ -161,8 +161,8 @@ public abstract class Metadata {
         }
       };
 
-  /** Builder for {@link Metadata}. */
-  public static class Builder extends Metadata_Builder {
+  /** Builder for {@link Datatype}. */
+  public static class Builder extends Datatype_Builder {
 
     public Builder() {
       super.setValueTypeVisibility(Visibility.PRIVATE);
@@ -170,7 +170,7 @@ public abstract class Metadata {
     }
 
     /**
-     * Sets the value to be returned by {@link Metadata#getValueTypeVisibility()} to the most
+     * Sets the value to be returned by {@link Datatype#getValueTypeVisibility()} to the most
      * visible of the current value and {@code visibility}. Will not decrease visibility.
      *
      * @return this {@code Builder} object
@@ -183,22 +183,22 @@ public abstract class Metadata {
     }
 
     /**
-     * Returns a newly-built {@link Metadata} based on the content of the {@code Builder}.
+     * Returns a newly-built {@link Datatype} based on the content of the {@code Builder}.
      */
     @Override
-    public Metadata build() {
-      Metadata metadata = super.build();
-      QualifiedName generatedBuilder = metadata.getGeneratedBuilder().getQualifiedName();
-      checkState(metadata.getValueType().getQualifiedName().getEnclosingType()
+    public Datatype build() {
+      Datatype datatype = super.build();
+      QualifiedName generatedBuilder = datatype.getGeneratedBuilder().getQualifiedName();
+      checkState(datatype.getValueType().getQualifiedName().getEnclosingType()
               .equals(generatedBuilder),
-          "%s not a nested class of %s", metadata.getValueType(), generatedBuilder);
-      checkState(metadata.getPartialType().getQualifiedName().getEnclosingType()
+          "%s not a nested class of %s", datatype.getValueType(), generatedBuilder);
+      checkState(datatype.getPartialType().getQualifiedName().getEnclosingType()
               .equals(generatedBuilder),
-          "%s not a nested class of %s", metadata.getPartialType(), generatedBuilder);
-      checkState(metadata.getPropertyEnum().getQualifiedName().getEnclosingType()
+          "%s not a nested class of %s", datatype.getPartialType(), generatedBuilder);
+      checkState(datatype.getPropertyEnum().getQualifiedName().getEnclosingType()
               .equals(generatedBuilder),
-          "%s not a nested class of %s", metadata.getPropertyEnum(), generatedBuilder);
-      return metadata;
+          "%s not a nested class of %s", datatype.getPropertyEnum(), generatedBuilder);
+      return datatype;
     }
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
@@ -2,7 +2,6 @@
 package org.inferred.freebuilder.processor;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -74,7 +73,6 @@ abstract class Datatype_Builder {
   private ParameterizedType partialType;
   private Set<QualifiedName> visibleNestedTypes = ImmutableSet.of();
   private ParameterizedType propertyEnum;
-  private List<org.inferred.freebuilder.processor.Property> properties = ImmutableList.of();
   private final LinkedHashMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
       standardMethodUnderrides =
           new LinkedHashMap<Datatype.StandardMethod, Datatype.UnderrideLevel>();
@@ -83,7 +81,7 @@ abstract class Datatype_Builder {
   private List<Excerpt> generatedBuilderAnnotations = ImmutableList.of();
   private List<Excerpt> valueTypeAnnotations = ImmutableList.of();
   private Datatype.Visibility valueTypeVisibility;
-  private List<Function<Datatype, Excerpt>> nestedClasses = ImmutableList.of();
+  private List<Excerpt> nestedClasses = ImmutableList.of();
   private final EnumSet<Datatype_Builder.Property> _unsetProperties =
       EnumSet.allOf(Datatype_Builder.Property.class);
 
@@ -409,80 +407,6 @@ abstract class Datatype_Builder {
   }
 
   /**
-   * Adds {@code element} to the list to be returned from {@link Datatype#getProperties()}.
-   *
-   * @return this {@code Builder} object
-   * @throws NullPointerException if {@code element} is null
-   */
-  public Datatype.Builder addProperties(org.inferred.freebuilder.processor.Property element) {
-    if (properties instanceof ImmutableList) {
-      properties = new ArrayList<org.inferred.freebuilder.processor.Property>(properties);
-    }
-    properties.add(Preconditions.checkNotNull(element));
-    return (Datatype.Builder) this;
-  }
-
-  /**
-   * Adds each element of {@code elements} to the list to be returned from {@link
-   * Datatype#getProperties()}.
-   *
-   * @return this {@code Builder} object
-   * @throws NullPointerException if {@code elements} is null or contains a null element
-   */
-  public Datatype.Builder addProperties(org.inferred.freebuilder.processor.Property... elements) {
-    return addAllProperties(Arrays.asList(elements));
-  }
-
-  /**
-   * Adds each element of {@code elements} to the list to be returned from {@link
-   * Datatype#getProperties()}.
-   *
-   * @return this {@code Builder} object
-   * @throws NullPointerException if {@code elements} is null or contains a null element
-   */
-  public Datatype.Builder addAllProperties(
-      Iterable<? extends org.inferred.freebuilder.processor.Property> elements) {
-    if (elements instanceof Collection) {
-      int elementsSize = ((Collection<?>) elements).size();
-      if (elementsSize != 0) {
-        if (properties instanceof ImmutableList) {
-          properties = new ArrayList<org.inferred.freebuilder.processor.Property>(properties);
-        }
-        ((ArrayList<?>) properties).ensureCapacity(properties.size() + elementsSize);
-      }
-    }
-    for (org.inferred.freebuilder.processor.Property element : elements) {
-      addProperties(element);
-    }
-    return (Datatype.Builder) this;
-  }
-
-  /**
-   * Clears the list to be returned from {@link Datatype#getProperties()}.
-   *
-   * @return this {@code Builder} object
-   */
-  public Datatype.Builder clearProperties() {
-    if (properties instanceof ImmutableList) {
-      properties = ImmutableList.of();
-    } else {
-      properties.clear();
-    }
-    return (Datatype.Builder) this;
-  }
-
-  /**
-   * Returns an unmodifiable view of the list that will be returned by {@link
-   * Datatype#getProperties()}. Changes to this builder will be reflected in the view.
-   */
-  public List<org.inferred.freebuilder.processor.Property> getProperties() {
-    if (properties instanceof ImmutableList) {
-      properties = new ArrayList<org.inferred.freebuilder.processor.Property>(properties);
-    }
-    return Collections.unmodifiableList(properties);
-  }
-
-  /**
    * Associates {@code key} with {@code value} in the map to be returned from {@link
    * Datatype#getStandardMethodUnderrides()}. If the map previously contained a mapping for the key,
    * the old value is replaced by the specified value.
@@ -773,9 +697,9 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code element} is null
    */
-  public Datatype.Builder addNestedClasses(Function<Datatype, Excerpt> element) {
+  public Datatype.Builder addNestedClasses(Excerpt element) {
     if (nestedClasses instanceof ImmutableList) {
-      nestedClasses = new ArrayList<Function<Datatype, Excerpt>>(nestedClasses);
+      nestedClasses = new ArrayList<Excerpt>(nestedClasses);
     }
     nestedClasses.add(Preconditions.checkNotNull(element));
     return (Datatype.Builder) this;
@@ -788,7 +712,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Datatype.Builder addNestedClasses(Function<Datatype, Excerpt>... elements) {
+  public Datatype.Builder addNestedClasses(Excerpt... elements) {
     return addAllNestedClasses(Arrays.asList(elements));
   }
 
@@ -799,18 +723,17 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Datatype.Builder addAllNestedClasses(
-      Iterable<? extends Function<Datatype, Excerpt>> elements) {
+  public Datatype.Builder addAllNestedClasses(Iterable<? extends Excerpt> elements) {
     if (elements instanceof Collection) {
       int elementsSize = ((Collection<?>) elements).size();
       if (elementsSize != 0) {
         if (nestedClasses instanceof ImmutableList) {
-          nestedClasses = new ArrayList<Function<Datatype, Excerpt>>(nestedClasses);
+          nestedClasses = new ArrayList<Excerpt>(nestedClasses);
         }
         ((ArrayList<?>) nestedClasses).ensureCapacity(nestedClasses.size() + elementsSize);
       }
     }
-    for (Function<Datatype, Excerpt> element : elements) {
+    for (Excerpt element : elements) {
       addNestedClasses(element);
     }
     return (Datatype.Builder) this;
@@ -834,9 +757,9 @@ abstract class Datatype_Builder {
    * Returns an unmodifiable view of the list that will be returned by {@link
    * Datatype#getNestedClasses()}. Changes to this builder will be reflected in the view.
    */
-  public List<Function<Datatype, Excerpt>> getNestedClasses() {
+  public List<Excerpt> getNestedClasses() {
     if (nestedClasses instanceof ImmutableList) {
-      nestedClasses = new ArrayList<Function<Datatype, Excerpt>>(nestedClasses);
+      nestedClasses = new ArrayList<Excerpt>(nestedClasses);
     }
     return Collections.unmodifiableList(nestedClasses);
   }
@@ -885,12 +808,6 @@ abstract class Datatype_Builder {
         || !value.getPropertyEnum().equals(_defaults.getPropertyEnum())) {
       setPropertyEnum(value.getPropertyEnum());
     }
-    if (value instanceof Datatype_Builder.Value
-        && properties == ImmutableList.<org.inferred.freebuilder.processor.Property>of()) {
-      properties = ImmutableList.copyOf(value.getProperties());
-    } else {
-      addAllProperties(value.getProperties());
-    }
     putAllStandardMethodUnderrides(value.getStandardMethodUnderrides());
     if (_defaults._unsetProperties.contains(Datatype_Builder.Property.BUILDER_SERIALIZABLE)
         || value.isBuilderSerializable() != _defaults.isBuilderSerializable()) {
@@ -916,8 +833,7 @@ abstract class Datatype_Builder {
         || !value.getValueTypeVisibility().equals(_defaults.getValueTypeVisibility())) {
       setValueTypeVisibility(value.getValueTypeVisibility());
     }
-    if (value instanceof Datatype_Builder.Value
-        && nestedClasses == ImmutableList.<Function<Datatype, Excerpt>>of()) {
+    if (value instanceof Datatype_Builder.Value && nestedClasses == ImmutableList.<Excerpt>of()) {
       nestedClasses = ImmutableList.copyOf(value.getNestedClasses());
     } else {
       addAllNestedClasses(value.getNestedClasses());
@@ -977,7 +893,6 @@ abstract class Datatype_Builder {
             || !template.getPropertyEnum().equals(_defaults.getPropertyEnum()))) {
       setPropertyEnum(template.getPropertyEnum());
     }
-    addAllProperties(base.properties);
     putAllStandardMethodUnderrides(base.standardMethodUnderrides);
     if (!base._unsetProperties.contains(Datatype_Builder.Property.BUILDER_SERIALIZABLE)
         && (_defaults._unsetProperties.contains(Datatype_Builder.Property.BUILDER_SERIALIZABLE)
@@ -1013,7 +928,6 @@ abstract class Datatype_Builder {
     partialType = _defaults.partialType;
     clearVisibleNestedTypes();
     propertyEnum = _defaults.propertyEnum;
-    clearProperties();
     standardMethodUnderrides.clear();
     builderSerializable = _defaults.builderSerializable;
     hasToBuilderMethod = _defaults.hasToBuilderMethod;
@@ -1064,7 +978,6 @@ abstract class Datatype_Builder {
     private final ParameterizedType partialType;
     private final ImmutableSet<QualifiedName> visibleNestedTypes;
     private final ParameterizedType propertyEnum;
-    private final ImmutableList<org.inferred.freebuilder.processor.Property> properties;
     private final ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         standardMethodUnderrides;
     private final boolean builderSerializable;
@@ -1072,7 +985,7 @@ abstract class Datatype_Builder {
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
     private final Datatype.Visibility valueTypeVisibility;
-    private final ImmutableList<Function<Datatype, Excerpt>> nestedClasses;
+    private final ImmutableList<Excerpt> nestedClasses;
 
     private Value(Datatype_Builder builder) {
       this.type = builder.type;
@@ -1085,7 +998,6 @@ abstract class Datatype_Builder {
       this.partialType = builder.partialType;
       this.visibleNestedTypes = ImmutableSet.copyOf(builder.visibleNestedTypes);
       this.propertyEnum = builder.propertyEnum;
-      this.properties = ImmutableList.copyOf(builder.properties);
       this.standardMethodUnderrides = ImmutableMap.copyOf(builder.standardMethodUnderrides);
       this.builderSerializable = builder.builderSerializable;
       this.hasToBuilderMethod = builder.hasToBuilderMethod;
@@ -1146,11 +1058,6 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ImmutableList<org.inferred.freebuilder.processor.Property> getProperties() {
-      return properties;
-    }
-
-    @Override
     public ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         getStandardMethodUnderrides() {
       return standardMethodUnderrides;
@@ -1182,7 +1089,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ImmutableList<Function<Datatype, Excerpt>> getNestedClasses() {
+    public ImmutableList<Excerpt> getNestedClasses() {
       return nestedClasses;
     }
 
@@ -1223,9 +1130,6 @@ abstract class Datatype_Builder {
       if (!propertyEnum.equals(other.propertyEnum)) {
         return false;
       }
-      if (!properties.equals(other.properties)) {
-        return false;
-      }
       if (!standardMethodUnderrides.equals(other.standardMethodUnderrides)) {
         return false;
       }
@@ -1264,7 +1168,6 @@ abstract class Datatype_Builder {
             partialType,
             visibleNestedTypes,
             propertyEnum,
-            properties,
             standardMethodUnderrides,
             builderSerializable,
             hasToBuilderMethod,
@@ -1300,8 +1203,6 @@ abstract class Datatype_Builder {
           .append(visibleNestedTypes)
           .append(", propertyEnum=")
           .append(propertyEnum)
-          .append(", properties=")
-          .append(properties)
           .append(", standardMethodUnderrides=")
           .append(standardMethodUnderrides)
           .append(", builderSerializable=")
@@ -1335,7 +1236,6 @@ abstract class Datatype_Builder {
     private final ParameterizedType partialType;
     private final ImmutableSet<QualifiedName> visibleNestedTypes;
     private final ParameterizedType propertyEnum;
-    private final ImmutableList<org.inferred.freebuilder.processor.Property> properties;
     private final ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         standardMethodUnderrides;
     private final boolean builderSerializable;
@@ -1343,7 +1243,7 @@ abstract class Datatype_Builder {
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
     private final Datatype.Visibility valueTypeVisibility;
-    private final ImmutableList<Function<Datatype, Excerpt>> nestedClasses;
+    private final ImmutableList<Excerpt> nestedClasses;
     private final EnumSet<Datatype_Builder.Property> _unsetProperties;
 
     Partial(Datatype_Builder builder) {
@@ -1357,7 +1257,6 @@ abstract class Datatype_Builder {
       this.partialType = builder.partialType;
       this.visibleNestedTypes = ImmutableSet.copyOf(builder.visibleNestedTypes);
       this.propertyEnum = builder.propertyEnum;
-      this.properties = ImmutableList.copyOf(builder.properties);
       this.standardMethodUnderrides = ImmutableMap.copyOf(builder.standardMethodUnderrides);
       this.builderSerializable = builder.builderSerializable;
       this.hasToBuilderMethod = builder.hasToBuilderMethod;
@@ -1443,11 +1342,6 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ImmutableList<org.inferred.freebuilder.processor.Property> getProperties() {
-      return properties;
-    }
-
-    @Override
     public ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         getStandardMethodUnderrides() {
       return standardMethodUnderrides;
@@ -1488,7 +1382,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ImmutableList<Function<Datatype, Excerpt>> getNestedClasses() {
+    public ImmutableList<Excerpt> getNestedClasses() {
       return nestedClasses;
     }
 
@@ -1533,9 +1427,6 @@ abstract class Datatype_Builder {
           && (propertyEnum == null || !propertyEnum.equals(other.propertyEnum))) {
         return false;
       }
-      if (!properties.equals(other.properties)) {
-        return false;
-      }
       if (!standardMethodUnderrides.equals(other.standardMethodUnderrides)) {
         return false;
       }
@@ -1576,7 +1467,6 @@ abstract class Datatype_Builder {
             partialType,
             visibleNestedTypes,
             propertyEnum,
-            properties,
             standardMethodUnderrides,
             builderSerializable,
             hasToBuilderMethod,
@@ -1619,11 +1509,7 @@ abstract class Datatype_Builder {
       if (!_unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM)) {
         result.append(", propertyEnum=").append(propertyEnum);
       }
-      result
-          .append(", properties=")
-          .append(properties)
-          .append(", standardMethodUnderrides=")
-          .append(standardMethodUnderrides);
+      result.append(", standardMethodUnderrides=").append(standardMethodUnderrides);
       if (!_unsetProperties.contains(Datatype_Builder.Property.BUILDER_SERIALIZABLE)) {
         result.append(", builderSerializable=").append(builderSerializable);
       }

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
@@ -25,14 +25,14 @@ import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 
 /**
- * Auto-generated superclass of {@link Metadata.Builder}, derived from the API of {@link Metadata}.
+ * Auto-generated superclass of {@link Datatype.Builder}, derived from the API of {@link Datatype}.
  */
 @Generated("org.inferred.freebuilder.processor.Processor")
-abstract class Metadata_Builder {
+abstract class Datatype_Builder {
 
   /** Creates a new builder using {@code value} as a template. */
-  public static Metadata.Builder from(Metadata value) {
-    return new Metadata.Builder().mergeFrom(value);
+  public static Datatype.Builder from(Datatype value) {
+    return new Datatype.Builder().mergeFrom(value);
   }
 
   private enum Property {
@@ -75,126 +75,126 @@ abstract class Metadata_Builder {
   private Set<QualifiedName> visibleNestedTypes = ImmutableSet.of();
   private ParameterizedType propertyEnum;
   private List<org.inferred.freebuilder.processor.Property> properties = ImmutableList.of();
-  private final LinkedHashMap<Metadata.StandardMethod, Metadata.UnderrideLevel>
+  private final LinkedHashMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
       standardMethodUnderrides =
-          new LinkedHashMap<Metadata.StandardMethod, Metadata.UnderrideLevel>();
+          new LinkedHashMap<Datatype.StandardMethod, Datatype.UnderrideLevel>();
   private boolean builderSerializable;
   private boolean hasToBuilderMethod;
   private List<Excerpt> generatedBuilderAnnotations = ImmutableList.of();
   private List<Excerpt> valueTypeAnnotations = ImmutableList.of();
-  private Metadata.Visibility valueTypeVisibility;
-  private List<Function<Metadata, Excerpt>> nestedClasses = ImmutableList.of();
-  private final EnumSet<Metadata_Builder.Property> _unsetProperties =
-      EnumSet.allOf(Metadata_Builder.Property.class);
+  private Datatype.Visibility valueTypeVisibility;
+  private List<Function<Datatype, Excerpt>> nestedClasses = ImmutableList.of();
+  private final EnumSet<Datatype_Builder.Property> _unsetProperties =
+      EnumSet.allOf(Datatype_Builder.Property.class);
 
   /**
-   * Sets the value to be returned by {@link Metadata#getType()}.
+   * Sets the value to be returned by {@link Datatype#getType()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code type} is null
    */
-  public Metadata.Builder setType(ParameterizedType type) {
+  public Datatype.Builder setType(ParameterizedType type) {
     this.type = Preconditions.checkNotNull(type);
-    _unsetProperties.remove(Metadata_Builder.Property.TYPE);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.TYPE);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#getType()}.
+   * Returns the value that will be returned by {@link Datatype#getType()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public ParameterizedType getType() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.TYPE), "type not set");
+        !_unsetProperties.contains(Datatype_Builder.Property.TYPE), "type not set");
     return type;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#isInterfaceType()}.
+   * Sets the value to be returned by {@link Datatype#isInterfaceType()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder setInterfaceType(boolean interfaceType) {
+  public Datatype.Builder setInterfaceType(boolean interfaceType) {
     this.interfaceType = interfaceType;
-    _unsetProperties.remove(Metadata_Builder.Property.INTERFACE_TYPE);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.INTERFACE_TYPE);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#isInterfaceType()}.
+   * Returns the value that will be returned by {@link Datatype#isInterfaceType()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public boolean isInterfaceType() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.INTERFACE_TYPE),
+        !_unsetProperties.contains(Datatype_Builder.Property.INTERFACE_TYPE),
         "interfaceType not set");
     return interfaceType;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getBuilder()}.
+   * Sets the value to be returned by {@link Datatype#getBuilder()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code builder} is null
    */
-  public Metadata.Builder setBuilder(ParameterizedType builder) {
+  public Datatype.Builder setBuilder(ParameterizedType builder) {
     this.builder = Preconditions.checkNotNull(builder);
-    _unsetProperties.remove(Metadata_Builder.Property.BUILDER);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.BUILDER);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#getBuilder()}.
+   * Returns the value that will be returned by {@link Datatype#getBuilder()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public ParameterizedType getBuilder() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.BUILDER), "builder not set");
+        !_unsetProperties.contains(Datatype_Builder.Property.BUILDER), "builder not set");
     return builder;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#isExtensible()}.
+   * Sets the value to be returned by {@link Datatype#isExtensible()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder setExtensible(boolean extensible) {
+  public Datatype.Builder setExtensible(boolean extensible) {
     this.extensible = extensible;
-    _unsetProperties.remove(Metadata_Builder.Property.EXTENSIBLE);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.EXTENSIBLE);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#isExtensible()}.
+   * Returns the value that will be returned by {@link Datatype#isExtensible()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public boolean isExtensible() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.EXTENSIBLE), "extensible not set");
+        !_unsetProperties.contains(Datatype_Builder.Property.EXTENSIBLE), "extensible not set");
     return extensible;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getBuilderFactory()}.
+   * Sets the value to be returned by {@link Datatype#getBuilderFactory()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code builderFactory} is null
    */
-  public Metadata.Builder setBuilderFactory(BuilderFactory builderFactory) {
+  public Datatype.Builder setBuilderFactory(BuilderFactory builderFactory) {
     this.builderFactory = Preconditions.checkNotNull(builderFactory);
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getBuilderFactory()}.
+   * Sets the value to be returned by {@link Datatype#getBuilderFactory()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder setBuilderFactory(Optional<? extends BuilderFactory> builderFactory) {
+  public Datatype.Builder setBuilderFactory(Optional<? extends BuilderFactory> builderFactory) {
     if (builderFactory.isPresent()) {
       return setBuilderFactory(builderFactory.get());
     } else {
@@ -203,11 +203,11 @@ abstract class Metadata_Builder {
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getBuilderFactory()}.
+   * Sets the value to be returned by {@link Datatype#getBuilderFactory()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder setNullableBuilderFactory(@Nullable BuilderFactory builderFactory) {
+  public Datatype.Builder setNullableBuilderFactory(@Nullable BuilderFactory builderFactory) {
     if (builderFactory != null) {
       return setBuilderFactory(builderFactory);
     } else {
@@ -216,166 +216,166 @@ abstract class Metadata_Builder {
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getBuilderFactory()} to {@link
+   * Sets the value to be returned by {@link Datatype#getBuilderFactory()} to {@link
    * Optional#absent() Optional.absent()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder clearBuilderFactory() {
+  public Datatype.Builder clearBuilderFactory() {
     builderFactory = null;
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
-  /** Returns the value that will be returned by {@link Metadata#getBuilderFactory()}. */
+  /** Returns the value that will be returned by {@link Datatype#getBuilderFactory()}. */
   public Optional<BuilderFactory> getBuilderFactory() {
     return Optional.fromNullable(builderFactory);
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getGeneratedBuilder()}.
+   * Sets the value to be returned by {@link Datatype#getGeneratedBuilder()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code generatedBuilder} is null
    */
-  public Metadata.Builder setGeneratedBuilder(ParameterizedType generatedBuilder) {
+  public Datatype.Builder setGeneratedBuilder(ParameterizedType generatedBuilder) {
     this.generatedBuilder = Preconditions.checkNotNull(generatedBuilder);
-    _unsetProperties.remove(Metadata_Builder.Property.GENERATED_BUILDER);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.GENERATED_BUILDER);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#getGeneratedBuilder()}.
+   * Returns the value that will be returned by {@link Datatype#getGeneratedBuilder()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public ParameterizedType getGeneratedBuilder() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.GENERATED_BUILDER),
+        !_unsetProperties.contains(Datatype_Builder.Property.GENERATED_BUILDER),
         "generatedBuilder not set");
     return generatedBuilder;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getValueType()}.
+   * Sets the value to be returned by {@link Datatype#getValueType()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code valueType} is null
    */
-  public Metadata.Builder setValueType(ParameterizedType valueType) {
+  public Datatype.Builder setValueType(ParameterizedType valueType) {
     this.valueType = Preconditions.checkNotNull(valueType);
-    _unsetProperties.remove(Metadata_Builder.Property.VALUE_TYPE);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.VALUE_TYPE);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#getValueType()}.
+   * Returns the value that will be returned by {@link Datatype#getValueType()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public ParameterizedType getValueType() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE), "valueType not set");
+        !_unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE), "valueType not set");
     return valueType;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getPartialType()}.
+   * Sets the value to be returned by {@link Datatype#getPartialType()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code partialType} is null
    */
-  public Metadata.Builder setPartialType(ParameterizedType partialType) {
+  public Datatype.Builder setPartialType(ParameterizedType partialType) {
     this.partialType = Preconditions.checkNotNull(partialType);
-    _unsetProperties.remove(Metadata_Builder.Property.PARTIAL_TYPE);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.PARTIAL_TYPE);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#getPartialType()}.
+   * Returns the value that will be returned by {@link Datatype#getPartialType()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public ParameterizedType getPartialType() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.PARTIAL_TYPE), "partialType not set");
+        !_unsetProperties.contains(Datatype_Builder.Property.PARTIAL_TYPE), "partialType not set");
     return partialType;
   }
 
   /**
-   * Adds {@code element} to the set to be returned from {@link Metadata#getVisibleNestedTypes()}.
+   * Adds {@code element} to the set to be returned from {@link Datatype#getVisibleNestedTypes()}.
    * If the set already contains {@code element}, then {@code addVisibleNestedTypes} has no effect
    * (only the previously added element is retained).
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code element} is null
    */
-  public Metadata.Builder addVisibleNestedTypes(QualifiedName element) {
+  public Datatype.Builder addVisibleNestedTypes(QualifiedName element) {
     if (visibleNestedTypes instanceof ImmutableSet) {
       visibleNestedTypes = new LinkedHashSet<QualifiedName>(visibleNestedTypes);
     }
     visibleNestedTypes.add(Preconditions.checkNotNull(element));
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Adds each element of {@code elements} to the set to be returned from {@link
-   * Metadata#getVisibleNestedTypes()}, ignoring duplicate elements (only the first duplicate
+   * Datatype#getVisibleNestedTypes()}, ignoring duplicate elements (only the first duplicate
    * element is added).
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addVisibleNestedTypes(QualifiedName... elements) {
+  public Datatype.Builder addVisibleNestedTypes(QualifiedName... elements) {
     return addAllVisibleNestedTypes(Arrays.asList(elements));
   }
 
   /**
    * Adds each element of {@code elements} to the set to be returned from {@link
-   * Metadata#getVisibleNestedTypes()}, ignoring duplicate elements (only the first duplicate
+   * Datatype#getVisibleNestedTypes()}, ignoring duplicate elements (only the first duplicate
    * element is added).
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addAllVisibleNestedTypes(Iterable<? extends QualifiedName> elements) {
+  public Datatype.Builder addAllVisibleNestedTypes(Iterable<? extends QualifiedName> elements) {
     for (QualifiedName element : elements) {
       addVisibleNestedTypes(element);
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Removes {@code element} from the set to be returned from {@link
-   * Metadata#getVisibleNestedTypes()}. Does nothing if {@code element} is not a member of the set.
+   * Datatype#getVisibleNestedTypes()}. Does nothing if {@code element} is not a member of the set.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code element} is null
    */
-  public Metadata.Builder removeVisibleNestedTypes(QualifiedName element) {
+  public Datatype.Builder removeVisibleNestedTypes(QualifiedName element) {
     if (visibleNestedTypes instanceof ImmutableSet) {
       visibleNestedTypes = new LinkedHashSet<QualifiedName>(visibleNestedTypes);
     }
     visibleNestedTypes.remove(Preconditions.checkNotNull(element));
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Clears the set to be returned from {@link Metadata#getVisibleNestedTypes()}.
+   * Clears the set to be returned from {@link Datatype#getVisibleNestedTypes()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder clearVisibleNestedTypes() {
+  public Datatype.Builder clearVisibleNestedTypes() {
     if (visibleNestedTypes instanceof ImmutableSet) {
       visibleNestedTypes = ImmutableSet.of();
     } else {
       visibleNestedTypes.clear();
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Returns an unmodifiable view of the set that will be returned by {@link
-   * Metadata#getVisibleNestedTypes()}. Changes to this builder will be reflected in the view.
+   * Datatype#getVisibleNestedTypes()}. Changes to this builder will be reflected in the view.
    */
   public Set<QualifiedName> getVisibleNestedTypes() {
     if (visibleNestedTypes instanceof ImmutableSet) {
@@ -385,62 +385,62 @@ abstract class Metadata_Builder {
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getPropertyEnum()}.
+   * Sets the value to be returned by {@link Datatype#getPropertyEnum()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code propertyEnum} is null
    */
-  public Metadata.Builder setPropertyEnum(ParameterizedType propertyEnum) {
+  public Datatype.Builder setPropertyEnum(ParameterizedType propertyEnum) {
     this.propertyEnum = Preconditions.checkNotNull(propertyEnum);
-    _unsetProperties.remove(Metadata_Builder.Property.PROPERTY_ENUM);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.PROPERTY_ENUM);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#getPropertyEnum()}.
+   * Returns the value that will be returned by {@link Datatype#getPropertyEnum()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public ParameterizedType getPropertyEnum() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.PROPERTY_ENUM),
+        !_unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM),
         "propertyEnum not set");
     return propertyEnum;
   }
 
   /**
-   * Adds {@code element} to the list to be returned from {@link Metadata#getProperties()}.
+   * Adds {@code element} to the list to be returned from {@link Datatype#getProperties()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code element} is null
    */
-  public Metadata.Builder addProperties(org.inferred.freebuilder.processor.Property element) {
+  public Datatype.Builder addProperties(org.inferred.freebuilder.processor.Property element) {
     if (properties instanceof ImmutableList) {
       properties = new ArrayList<org.inferred.freebuilder.processor.Property>(properties);
     }
     properties.add(Preconditions.checkNotNull(element));
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Adds each element of {@code elements} to the list to be returned from {@link
-   * Metadata#getProperties()}.
+   * Datatype#getProperties()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addProperties(org.inferred.freebuilder.processor.Property... elements) {
+  public Datatype.Builder addProperties(org.inferred.freebuilder.processor.Property... elements) {
     return addAllProperties(Arrays.asList(elements));
   }
 
   /**
    * Adds each element of {@code elements} to the list to be returned from {@link
-   * Metadata#getProperties()}.
+   * Datatype#getProperties()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addAllProperties(
+  public Datatype.Builder addAllProperties(
       Iterable<? extends org.inferred.freebuilder.processor.Property> elements) {
     if (elements instanceof Collection) {
       int elementsSize = ((Collection<?>) elements).size();
@@ -454,26 +454,26 @@ abstract class Metadata_Builder {
     for (org.inferred.freebuilder.processor.Property element : elements) {
       addProperties(element);
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Clears the list to be returned from {@link Metadata#getProperties()}.
+   * Clears the list to be returned from {@link Datatype#getProperties()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder clearProperties() {
+  public Datatype.Builder clearProperties() {
     if (properties instanceof ImmutableList) {
       properties = ImmutableList.of();
     } else {
       properties.clear();
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Returns an unmodifiable view of the list that will be returned by {@link
-   * Metadata#getProperties()}. Changes to this builder will be reflected in the view.
+   * Datatype#getProperties()}. Changes to this builder will be reflected in the view.
    */
   public List<org.inferred.freebuilder.processor.Property> getProperties() {
     if (properties instanceof ImmutableList) {
@@ -484,148 +484,148 @@ abstract class Metadata_Builder {
 
   /**
    * Associates {@code key} with {@code value} in the map to be returned from {@link
-   * Metadata#getStandardMethodUnderrides()}. If the map previously contained a mapping for the key,
+   * Datatype#getStandardMethodUnderrides()}. If the map previously contained a mapping for the key,
    * the old value is replaced by the specified value.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if either {@code key} or {@code value} are null
    */
-  public Metadata.Builder putStandardMethodUnderrides(
-      Metadata.StandardMethod key, Metadata.UnderrideLevel value) {
+  public Datatype.Builder putStandardMethodUnderrides(
+      Datatype.StandardMethod key, Datatype.UnderrideLevel value) {
     Preconditions.checkNotNull(key);
     Preconditions.checkNotNull(value);
     standardMethodUnderrides.put(key, value);
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Copies all of the mappings from {@code map} to the map to be returned from {@link
-   * Metadata#getStandardMethodUnderrides()}.
+   * Datatype#getStandardMethodUnderrides()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code map} is null or contains a null key or value
    */
-  public Metadata.Builder putAllStandardMethodUnderrides(
-      Map<? extends Metadata.StandardMethod, ? extends Metadata.UnderrideLevel> map) {
-    for (Map.Entry<? extends Metadata.StandardMethod, ? extends Metadata.UnderrideLevel> entry :
+  public Datatype.Builder putAllStandardMethodUnderrides(
+      Map<? extends Datatype.StandardMethod, ? extends Datatype.UnderrideLevel> map) {
+    for (Map.Entry<? extends Datatype.StandardMethod, ? extends Datatype.UnderrideLevel> entry :
         map.entrySet()) {
       putStandardMethodUnderrides(entry.getKey(), entry.getValue());
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Removes the mapping for {@code key} from the map to be returned from {@link
-   * Metadata#getStandardMethodUnderrides()}, if one is present.
+   * Datatype#getStandardMethodUnderrides()}, if one is present.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code key} is null
    */
-  public Metadata.Builder removeStandardMethodUnderrides(Metadata.StandardMethod key) {
+  public Datatype.Builder removeStandardMethodUnderrides(Datatype.StandardMethod key) {
     Preconditions.checkNotNull(key);
     standardMethodUnderrides.remove(key);
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Removes all of the mappings from the map to be returned from {@link
-   * Metadata#getStandardMethodUnderrides()}.
+   * Datatype#getStandardMethodUnderrides()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder clearStandardMethodUnderrides() {
+  public Datatype.Builder clearStandardMethodUnderrides() {
     standardMethodUnderrides.clear();
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Returns an unmodifiable view of the map that will be returned by {@link
-   * Metadata#getStandardMethodUnderrides()}. Changes to this builder will be reflected in the view.
+   * Datatype#getStandardMethodUnderrides()}. Changes to this builder will be reflected in the view.
    */
-  public Map<Metadata.StandardMethod, Metadata.UnderrideLevel> getStandardMethodUnderrides() {
+  public Map<Datatype.StandardMethod, Datatype.UnderrideLevel> getStandardMethodUnderrides() {
     return Collections.unmodifiableMap(standardMethodUnderrides);
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#isBuilderSerializable()}.
+   * Sets the value to be returned by {@link Datatype#isBuilderSerializable()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder setBuilderSerializable(boolean builderSerializable) {
+  public Datatype.Builder setBuilderSerializable(boolean builderSerializable) {
     this.builderSerializable = builderSerializable;
-    _unsetProperties.remove(Metadata_Builder.Property.BUILDER_SERIALIZABLE);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.BUILDER_SERIALIZABLE);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#isBuilderSerializable()}.
+   * Returns the value that will be returned by {@link Datatype#isBuilderSerializable()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public boolean isBuilderSerializable() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.BUILDER_SERIALIZABLE),
+        !_unsetProperties.contains(Datatype_Builder.Property.BUILDER_SERIALIZABLE),
         "builderSerializable not set");
     return builderSerializable;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getHasToBuilderMethod()}.
+   * Sets the value to be returned by {@link Datatype#getHasToBuilderMethod()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder setHasToBuilderMethod(boolean hasToBuilderMethod) {
+  public Datatype.Builder setHasToBuilderMethod(boolean hasToBuilderMethod) {
     this.hasToBuilderMethod = hasToBuilderMethod;
-    _unsetProperties.remove(Metadata_Builder.Property.HAS_TO_BUILDER_METHOD);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.HAS_TO_BUILDER_METHOD);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#getHasToBuilderMethod()}.
+   * Returns the value that will be returned by {@link Datatype#getHasToBuilderMethod()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public boolean getHasToBuilderMethod() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.HAS_TO_BUILDER_METHOD),
+        !_unsetProperties.contains(Datatype_Builder.Property.HAS_TO_BUILDER_METHOD),
         "hasToBuilderMethod not set");
     return hasToBuilderMethod;
   }
 
   /**
    * Adds {@code element} to the list to be returned from {@link
-   * Metadata#getGeneratedBuilderAnnotations()}.
+   * Datatype#getGeneratedBuilderAnnotations()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code element} is null
    */
-  public Metadata.Builder addGeneratedBuilderAnnotations(Excerpt element) {
+  public Datatype.Builder addGeneratedBuilderAnnotations(Excerpt element) {
     if (generatedBuilderAnnotations instanceof ImmutableList) {
       generatedBuilderAnnotations = new ArrayList<Excerpt>(generatedBuilderAnnotations);
     }
     generatedBuilderAnnotations.add(Preconditions.checkNotNull(element));
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Adds each element of {@code elements} to the list to be returned from {@link
-   * Metadata#getGeneratedBuilderAnnotations()}.
+   * Datatype#getGeneratedBuilderAnnotations()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addGeneratedBuilderAnnotations(Excerpt... elements) {
+  public Datatype.Builder addGeneratedBuilderAnnotations(Excerpt... elements) {
     return addAllGeneratedBuilderAnnotations(Arrays.asList(elements));
   }
 
   /**
    * Adds each element of {@code elements} to the list to be returned from {@link
-   * Metadata#getGeneratedBuilderAnnotations()}.
+   * Datatype#getGeneratedBuilderAnnotations()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addAllGeneratedBuilderAnnotations(Iterable<? extends Excerpt> elements) {
+  public Datatype.Builder addAllGeneratedBuilderAnnotations(Iterable<? extends Excerpt> elements) {
     if (elements instanceof Collection) {
       int elementsSize = ((Collection<?>) elements).size();
       if (elementsSize != 0) {
@@ -639,26 +639,26 @@ abstract class Metadata_Builder {
     for (Excerpt element : elements) {
       addGeneratedBuilderAnnotations(element);
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Clears the list to be returned from {@link Metadata#getGeneratedBuilderAnnotations()}.
+   * Clears the list to be returned from {@link Datatype#getGeneratedBuilderAnnotations()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder clearGeneratedBuilderAnnotations() {
+  public Datatype.Builder clearGeneratedBuilderAnnotations() {
     if (generatedBuilderAnnotations instanceof ImmutableList) {
       generatedBuilderAnnotations = ImmutableList.of();
     } else {
       generatedBuilderAnnotations.clear();
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Returns an unmodifiable view of the list that will be returned by {@link
-   * Metadata#getGeneratedBuilderAnnotations()}. Changes to this builder will be reflected in the
+   * Datatype#getGeneratedBuilderAnnotations()}. Changes to this builder will be reflected in the
    * view.
    */
   public List<Excerpt> getGeneratedBuilderAnnotations() {
@@ -670,38 +670,38 @@ abstract class Metadata_Builder {
 
   /**
    * Adds {@code element} to the list to be returned from {@link
-   * Metadata#getValueTypeAnnotations()}.
+   * Datatype#getValueTypeAnnotations()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code element} is null
    */
-  public Metadata.Builder addValueTypeAnnotations(Excerpt element) {
+  public Datatype.Builder addValueTypeAnnotations(Excerpt element) {
     if (valueTypeAnnotations instanceof ImmutableList) {
       valueTypeAnnotations = new ArrayList<Excerpt>(valueTypeAnnotations);
     }
     valueTypeAnnotations.add(Preconditions.checkNotNull(element));
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Adds each element of {@code elements} to the list to be returned from {@link
-   * Metadata#getValueTypeAnnotations()}.
+   * Datatype#getValueTypeAnnotations()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addValueTypeAnnotations(Excerpt... elements) {
+  public Datatype.Builder addValueTypeAnnotations(Excerpt... elements) {
     return addAllValueTypeAnnotations(Arrays.asList(elements));
   }
 
   /**
    * Adds each element of {@code elements} to the list to be returned from {@link
-   * Metadata#getValueTypeAnnotations()}.
+   * Datatype#getValueTypeAnnotations()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addAllValueTypeAnnotations(Iterable<? extends Excerpt> elements) {
+  public Datatype.Builder addAllValueTypeAnnotations(Iterable<? extends Excerpt> elements) {
     if (elements instanceof Collection) {
       int elementsSize = ((Collection<?>) elements).size();
       if (elementsSize != 0) {
@@ -715,26 +715,26 @@ abstract class Metadata_Builder {
     for (Excerpt element : elements) {
       addValueTypeAnnotations(element);
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Clears the list to be returned from {@link Metadata#getValueTypeAnnotations()}.
+   * Clears the list to be returned from {@link Datatype#getValueTypeAnnotations()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder clearValueTypeAnnotations() {
+  public Datatype.Builder clearValueTypeAnnotations() {
     if (valueTypeAnnotations instanceof ImmutableList) {
       valueTypeAnnotations = ImmutableList.of();
     } else {
       valueTypeAnnotations.clear();
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Returns an unmodifiable view of the list that will be returned by {@link
-   * Metadata#getValueTypeAnnotations()}. Changes to this builder will be reflected in the view.
+   * Datatype#getValueTypeAnnotations()}. Changes to this builder will be reflected in the view.
    */
   public List<Excerpt> getValueTypeAnnotations() {
     if (valueTypeAnnotations instanceof ImmutableList) {
@@ -744,265 +744,265 @@ abstract class Metadata_Builder {
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata#getValueTypeVisibility()}.
+   * Sets the value to be returned by {@link Datatype#getValueTypeVisibility()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code valueTypeVisibility} is null
    */
-  public Metadata.Builder setValueTypeVisibility(Metadata.Visibility valueTypeVisibility) {
+  public Datatype.Builder setValueTypeVisibility(Datatype.Visibility valueTypeVisibility) {
     this.valueTypeVisibility = Preconditions.checkNotNull(valueTypeVisibility);
-    _unsetProperties.remove(Metadata_Builder.Property.VALUE_TYPE_VISIBILITY);
-    return (Metadata.Builder) this;
+    _unsetProperties.remove(Datatype_Builder.Property.VALUE_TYPE_VISIBILITY);
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata#getValueTypeVisibility()}.
+   * Returns the value that will be returned by {@link Datatype#getValueTypeVisibility()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public Metadata.Visibility getValueTypeVisibility() {
+  public Datatype.Visibility getValueTypeVisibility() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE_VISIBILITY),
+        !_unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE_VISIBILITY),
         "valueTypeVisibility not set");
     return valueTypeVisibility;
   }
 
   /**
-   * Adds {@code element} to the list to be returned from {@link Metadata#getNestedClasses()}.
+   * Adds {@code element} to the list to be returned from {@link Datatype#getNestedClasses()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code element} is null
    */
-  public Metadata.Builder addNestedClasses(Function<Metadata, Excerpt> element) {
+  public Datatype.Builder addNestedClasses(Function<Datatype, Excerpt> element) {
     if (nestedClasses instanceof ImmutableList) {
-      nestedClasses = new ArrayList<Function<Metadata, Excerpt>>(nestedClasses);
+      nestedClasses = new ArrayList<Function<Datatype, Excerpt>>(nestedClasses);
     }
     nestedClasses.add(Preconditions.checkNotNull(element));
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Adds each element of {@code elements} to the list to be returned from {@link
-   * Metadata#getNestedClasses()}.
+   * Datatype#getNestedClasses()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addNestedClasses(Function<Metadata, Excerpt>... elements) {
+  public Datatype.Builder addNestedClasses(Function<Datatype, Excerpt>... elements) {
     return addAllNestedClasses(Arrays.asList(elements));
   }
 
   /**
    * Adds each element of {@code elements} to the list to be returned from {@link
-   * Metadata#getNestedClasses()}.
+   * Datatype#getNestedClasses()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addAllNestedClasses(
-      Iterable<? extends Function<Metadata, Excerpt>> elements) {
+  public Datatype.Builder addAllNestedClasses(
+      Iterable<? extends Function<Datatype, Excerpt>> elements) {
     if (elements instanceof Collection) {
       int elementsSize = ((Collection<?>) elements).size();
       if (elementsSize != 0) {
         if (nestedClasses instanceof ImmutableList) {
-          nestedClasses = new ArrayList<Function<Metadata, Excerpt>>(nestedClasses);
+          nestedClasses = new ArrayList<Function<Datatype, Excerpt>>(nestedClasses);
         }
         ((ArrayList<?>) nestedClasses).ensureCapacity(nestedClasses.size() + elementsSize);
       }
     }
-    for (Function<Metadata, Excerpt> element : elements) {
+    for (Function<Datatype, Excerpt> element : elements) {
       addNestedClasses(element);
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Clears the list to be returned from {@link Metadata#getNestedClasses()}.
+   * Clears the list to be returned from {@link Datatype#getNestedClasses()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Builder clearNestedClasses() {
+  public Datatype.Builder clearNestedClasses() {
     if (nestedClasses instanceof ImmutableList) {
       nestedClasses = ImmutableList.of();
     } else {
       nestedClasses.clear();
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Returns an unmodifiable view of the list that will be returned by {@link
-   * Metadata#getNestedClasses()}. Changes to this builder will be reflected in the view.
+   * Datatype#getNestedClasses()}. Changes to this builder will be reflected in the view.
    */
-  public List<Function<Metadata, Excerpt>> getNestedClasses() {
+  public List<Function<Datatype, Excerpt>> getNestedClasses() {
     if (nestedClasses instanceof ImmutableList) {
-      nestedClasses = new ArrayList<Function<Metadata, Excerpt>>(nestedClasses);
+      nestedClasses = new ArrayList<Function<Datatype, Excerpt>>(nestedClasses);
     }
     return Collections.unmodifiableList(nestedClasses);
   }
 
-  /** Sets all property values using the given {@code Metadata} as a template. */
-  public Metadata.Builder mergeFrom(Metadata value) {
-    Metadata_Builder _defaults = new Metadata.Builder();
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.TYPE)
+  /** Sets all property values using the given {@code Datatype} as a template. */
+  public Datatype.Builder mergeFrom(Datatype value) {
+    Datatype_Builder _defaults = new Datatype.Builder();
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.TYPE)
         || !value.getType().equals(_defaults.getType())) {
       setType(value.getType());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.INTERFACE_TYPE)
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.INTERFACE_TYPE)
         || value.isInterfaceType() != _defaults.isInterfaceType()) {
       setInterfaceType(value.isInterfaceType());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.BUILDER)
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.BUILDER)
         || !value.getBuilder().equals(_defaults.getBuilder())) {
       setBuilder(value.getBuilder());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.EXTENSIBLE)
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.EXTENSIBLE)
         || value.isExtensible() != _defaults.isExtensible()) {
       setExtensible(value.isExtensible());
     }
     if (value.getBuilderFactory().isPresent()) {
       setBuilderFactory(value.getBuilderFactory().get());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.GENERATED_BUILDER)
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.GENERATED_BUILDER)
         || !value.getGeneratedBuilder().equals(_defaults.getGeneratedBuilder())) {
       setGeneratedBuilder(value.getGeneratedBuilder());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE)
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE)
         || !value.getValueType().equals(_defaults.getValueType())) {
       setValueType(value.getValueType());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.PARTIAL_TYPE)
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.PARTIAL_TYPE)
         || !value.getPartialType().equals(_defaults.getPartialType())) {
       setPartialType(value.getPartialType());
     }
-    if (value instanceof Metadata_Builder.Value
+    if (value instanceof Datatype_Builder.Value
         && visibleNestedTypes == ImmutableSet.<QualifiedName>of()) {
       visibleNestedTypes = ImmutableSet.copyOf(value.getVisibleNestedTypes());
     } else {
       addAllVisibleNestedTypes(value.getVisibleNestedTypes());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.PROPERTY_ENUM)
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM)
         || !value.getPropertyEnum().equals(_defaults.getPropertyEnum())) {
       setPropertyEnum(value.getPropertyEnum());
     }
-    if (value instanceof Metadata_Builder.Value
+    if (value instanceof Datatype_Builder.Value
         && properties == ImmutableList.<org.inferred.freebuilder.processor.Property>of()) {
       properties = ImmutableList.copyOf(value.getProperties());
     } else {
       addAllProperties(value.getProperties());
     }
     putAllStandardMethodUnderrides(value.getStandardMethodUnderrides());
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.BUILDER_SERIALIZABLE)
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.BUILDER_SERIALIZABLE)
         || value.isBuilderSerializable() != _defaults.isBuilderSerializable()) {
       setBuilderSerializable(value.isBuilderSerializable());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.HAS_TO_BUILDER_METHOD)
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.HAS_TO_BUILDER_METHOD)
         || value.getHasToBuilderMethod() != _defaults.getHasToBuilderMethod()) {
       setHasToBuilderMethod(value.getHasToBuilderMethod());
     }
-    if (value instanceof Metadata_Builder.Value
+    if (value instanceof Datatype_Builder.Value
         && generatedBuilderAnnotations == ImmutableList.<Excerpt>of()) {
       generatedBuilderAnnotations = ImmutableList.copyOf(value.getGeneratedBuilderAnnotations());
     } else {
       addAllGeneratedBuilderAnnotations(value.getGeneratedBuilderAnnotations());
     }
-    if (value instanceof Metadata_Builder.Value
+    if (value instanceof Datatype_Builder.Value
         && valueTypeAnnotations == ImmutableList.<Excerpt>of()) {
       valueTypeAnnotations = ImmutableList.copyOf(value.getValueTypeAnnotations());
     } else {
       addAllValueTypeAnnotations(value.getValueTypeAnnotations());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE_VISIBILITY)
+    if (_defaults._unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE_VISIBILITY)
         || !value.getValueTypeVisibility().equals(_defaults.getValueTypeVisibility())) {
       setValueTypeVisibility(value.getValueTypeVisibility());
     }
-    if (value instanceof Metadata_Builder.Value
-        && nestedClasses == ImmutableList.<Function<Metadata, Excerpt>>of()) {
+    if (value instanceof Datatype_Builder.Value
+        && nestedClasses == ImmutableList.<Function<Datatype, Excerpt>>of()) {
       nestedClasses = ImmutableList.copyOf(value.getNestedClasses());
     } else {
       addAllNestedClasses(value.getNestedClasses());
     }
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
    * Copies values from the given {@code Builder}. Does not affect any properties not set on the
    * input.
    */
-  public Metadata.Builder mergeFrom(Metadata.Builder template) {
+  public Datatype.Builder mergeFrom(Datatype.Builder template) {
     // Upcast to access private fields; otherwise, oddly, we get an access violation.
-    Metadata_Builder base = template;
-    Metadata_Builder _defaults = new Metadata.Builder();
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.TYPE)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.TYPE)
+    Datatype_Builder base = template;
+    Datatype_Builder _defaults = new Datatype.Builder();
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.TYPE)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.TYPE)
             || !template.getType().equals(_defaults.getType()))) {
       setType(template.getType());
     }
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.INTERFACE_TYPE)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.INTERFACE_TYPE)
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.INTERFACE_TYPE)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.INTERFACE_TYPE)
             || template.isInterfaceType() != _defaults.isInterfaceType())) {
       setInterfaceType(template.isInterfaceType());
     }
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.BUILDER)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.BUILDER)
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.BUILDER)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.BUILDER)
             || !template.getBuilder().equals(_defaults.getBuilder()))) {
       setBuilder(template.getBuilder());
     }
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.EXTENSIBLE)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.EXTENSIBLE)
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.EXTENSIBLE)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.EXTENSIBLE)
             || template.isExtensible() != _defaults.isExtensible())) {
       setExtensible(template.isExtensible());
     }
     if (template.getBuilderFactory().isPresent()) {
       setBuilderFactory(template.getBuilderFactory().get());
     }
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.GENERATED_BUILDER)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.GENERATED_BUILDER)
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.GENERATED_BUILDER)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.GENERATED_BUILDER)
             || !template.getGeneratedBuilder().equals(_defaults.getGeneratedBuilder()))) {
       setGeneratedBuilder(template.getGeneratedBuilder());
     }
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE)
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE)
             || !template.getValueType().equals(_defaults.getValueType()))) {
       setValueType(template.getValueType());
     }
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.PARTIAL_TYPE)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.PARTIAL_TYPE)
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.PARTIAL_TYPE)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.PARTIAL_TYPE)
             || !template.getPartialType().equals(_defaults.getPartialType()))) {
       setPartialType(template.getPartialType());
     }
     addAllVisibleNestedTypes(base.visibleNestedTypes);
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.PROPERTY_ENUM)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.PROPERTY_ENUM)
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM)
             || !template.getPropertyEnum().equals(_defaults.getPropertyEnum()))) {
       setPropertyEnum(template.getPropertyEnum());
     }
     addAllProperties(base.properties);
     putAllStandardMethodUnderrides(base.standardMethodUnderrides);
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.BUILDER_SERIALIZABLE)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.BUILDER_SERIALIZABLE)
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.BUILDER_SERIALIZABLE)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.BUILDER_SERIALIZABLE)
             || template.isBuilderSerializable() != _defaults.isBuilderSerializable())) {
       setBuilderSerializable(template.isBuilderSerializable());
     }
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.HAS_TO_BUILDER_METHOD)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.HAS_TO_BUILDER_METHOD)
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.HAS_TO_BUILDER_METHOD)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.HAS_TO_BUILDER_METHOD)
             || template.getHasToBuilderMethod() != _defaults.getHasToBuilderMethod())) {
       setHasToBuilderMethod(template.getHasToBuilderMethod());
     }
     addAllGeneratedBuilderAnnotations(base.generatedBuilderAnnotations);
     addAllValueTypeAnnotations(base.valueTypeAnnotations);
-    if (!base._unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE_VISIBILITY)
-        && (_defaults._unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE_VISIBILITY)
+    if (!base._unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE_VISIBILITY)
+        && (_defaults._unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE_VISIBILITY)
             || !template.getValueTypeVisibility().equals(_defaults.getValueTypeVisibility()))) {
       setValueTypeVisibility(template.getValueTypeVisibility());
     }
     addAllNestedClasses(base.nestedClasses);
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /** Resets the state of this builder. */
-  public Metadata.Builder clear() {
-    Metadata_Builder _defaults = new Metadata.Builder();
+  public Datatype.Builder clear() {
+    Datatype_Builder _defaults = new Datatype.Builder();
     type = _defaults.type;
     interfaceType = _defaults.interfaceType;
     builder = _defaults.builder;
@@ -1023,21 +1023,21 @@ abstract class Metadata_Builder {
     clearNestedClasses();
     _unsetProperties.clear();
     _unsetProperties.addAll(_defaults._unsetProperties);
-    return (Metadata.Builder) this;
+    return (Datatype.Builder) this;
   }
 
   /**
-   * Returns a newly-created {@link Metadata} based on the contents of the {@code Builder}.
+   * Returns a newly-created {@link Datatype} based on the contents of the {@code Builder}.
    *
    * @throws IllegalStateException if any field has not been set
    */
-  public Metadata build() {
+  public Datatype build() {
     Preconditions.checkState(_unsetProperties.isEmpty(), "Not set: %s", _unsetProperties);
-    return new Metadata_Builder.Value(this);
+    return new Datatype_Builder.Value(this);
   }
 
   /**
-   * Returns a newly-created partial {@link Metadata} for use in unit tests. State checking will not
+   * Returns a newly-created partial {@link Datatype} for use in unit tests. State checking will not
    * be performed. Unset properties will throw an {@link UnsupportedOperationException} when
    * accessed via the partial object.
    *
@@ -1046,11 +1046,11 @@ abstract class Metadata_Builder {
    * future. If you require partially complete values in production code, consider using a Builder.
    */
   @VisibleForTesting()
-  public Metadata buildPartial() {
-    return new Metadata_Builder.Partial(this);
+  public Datatype buildPartial() {
+    return new Datatype_Builder.Partial(this);
   }
 
-  private static final class Value extends Metadata {
+  private static final class Value extends Datatype {
     private final ParameterizedType type;
     private final boolean interfaceType;
     private final ParameterizedType builder;
@@ -1065,16 +1065,16 @@ abstract class Metadata_Builder {
     private final ImmutableSet<QualifiedName> visibleNestedTypes;
     private final ParameterizedType propertyEnum;
     private final ImmutableList<org.inferred.freebuilder.processor.Property> properties;
-    private final ImmutableMap<Metadata.StandardMethod, Metadata.UnderrideLevel>
+    private final ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         standardMethodUnderrides;
     private final boolean builderSerializable;
     private final boolean hasToBuilderMethod;
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
-    private final Metadata.Visibility valueTypeVisibility;
-    private final ImmutableList<Function<Metadata, Excerpt>> nestedClasses;
+    private final Datatype.Visibility valueTypeVisibility;
+    private final ImmutableList<Function<Datatype, Excerpt>> nestedClasses;
 
-    private Value(Metadata_Builder builder) {
+    private Value(Datatype_Builder builder) {
       this.type = builder.type;
       this.interfaceType = builder.interfaceType;
       this.builder = builder.builder;
@@ -1151,7 +1151,7 @@ abstract class Metadata_Builder {
     }
 
     @Override
-    public ImmutableMap<Metadata.StandardMethod, Metadata.UnderrideLevel>
+    public ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         getStandardMethodUnderrides() {
       return standardMethodUnderrides;
     }
@@ -1177,21 +1177,21 @@ abstract class Metadata_Builder {
     }
 
     @Override
-    public Metadata.Visibility getValueTypeVisibility() {
+    public Datatype.Visibility getValueTypeVisibility() {
       return valueTypeVisibility;
     }
 
     @Override
-    public ImmutableList<Function<Metadata, Excerpt>> getNestedClasses() {
+    public ImmutableList<Function<Datatype, Excerpt>> getNestedClasses() {
       return nestedClasses;
     }
 
     @Override
     public boolean equals(Object obj) {
-      if (!(obj instanceof Metadata_Builder.Value)) {
+      if (!(obj instanceof Datatype_Builder.Value)) {
         return false;
       }
-      Metadata_Builder.Value other = (Metadata_Builder.Value) obj;
+      Datatype_Builder.Value other = (Datatype_Builder.Value) obj;
       if (!type.equals(other.type)) {
         return false;
       }
@@ -1278,7 +1278,7 @@ abstract class Metadata_Builder {
     @Override
     public String toString() {
       StringBuilder result =
-          new StringBuilder("Metadata{type=")
+          new StringBuilder("Datatype{type=")
               .append(type)
               .append(", interfaceType=")
               .append(interfaceType)
@@ -1321,7 +1321,7 @@ abstract class Metadata_Builder {
     }
   }
 
-  private static final class Partial extends Metadata {
+  private static final class Partial extends Datatype {
     private final ParameterizedType type;
     private final boolean interfaceType;
     private final ParameterizedType builder;
@@ -1336,17 +1336,17 @@ abstract class Metadata_Builder {
     private final ImmutableSet<QualifiedName> visibleNestedTypes;
     private final ParameterizedType propertyEnum;
     private final ImmutableList<org.inferred.freebuilder.processor.Property> properties;
-    private final ImmutableMap<Metadata.StandardMethod, Metadata.UnderrideLevel>
+    private final ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         standardMethodUnderrides;
     private final boolean builderSerializable;
     private final boolean hasToBuilderMethod;
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
-    private final Metadata.Visibility valueTypeVisibility;
-    private final ImmutableList<Function<Metadata, Excerpt>> nestedClasses;
-    private final EnumSet<Metadata_Builder.Property> _unsetProperties;
+    private final Datatype.Visibility valueTypeVisibility;
+    private final ImmutableList<Function<Datatype, Excerpt>> nestedClasses;
+    private final EnumSet<Datatype_Builder.Property> _unsetProperties;
 
-    Partial(Metadata_Builder builder) {
+    Partial(Datatype_Builder builder) {
       this.type = builder.type;
       this.interfaceType = builder.interfaceType;
       this.builder = builder.builder;
@@ -1370,7 +1370,7 @@ abstract class Metadata_Builder {
 
     @Override
     public ParameterizedType getType() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.TYPE)) {
+      if (_unsetProperties.contains(Datatype_Builder.Property.TYPE)) {
         throw new UnsupportedOperationException("type not set");
       }
       return type;
@@ -1378,7 +1378,7 @@ abstract class Metadata_Builder {
 
     @Override
     public boolean isInterfaceType() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.INTERFACE_TYPE)) {
+      if (_unsetProperties.contains(Datatype_Builder.Property.INTERFACE_TYPE)) {
         throw new UnsupportedOperationException("interfaceType not set");
       }
       return interfaceType;
@@ -1386,7 +1386,7 @@ abstract class Metadata_Builder {
 
     @Override
     public ParameterizedType getBuilder() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.BUILDER)) {
+      if (_unsetProperties.contains(Datatype_Builder.Property.BUILDER)) {
         throw new UnsupportedOperationException("builder not set");
       }
       return builder;
@@ -1394,7 +1394,7 @@ abstract class Metadata_Builder {
 
     @Override
     public boolean isExtensible() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.EXTENSIBLE)) {
+      if (_unsetProperties.contains(Datatype_Builder.Property.EXTENSIBLE)) {
         throw new UnsupportedOperationException("extensible not set");
       }
       return extensible;
@@ -1407,7 +1407,7 @@ abstract class Metadata_Builder {
 
     @Override
     public ParameterizedType getGeneratedBuilder() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.GENERATED_BUILDER)) {
+      if (_unsetProperties.contains(Datatype_Builder.Property.GENERATED_BUILDER)) {
         throw new UnsupportedOperationException("generatedBuilder not set");
       }
       return generatedBuilder;
@@ -1415,7 +1415,7 @@ abstract class Metadata_Builder {
 
     @Override
     public ParameterizedType getValueType() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE)) {
+      if (_unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE)) {
         throw new UnsupportedOperationException("valueType not set");
       }
       return valueType;
@@ -1423,7 +1423,7 @@ abstract class Metadata_Builder {
 
     @Override
     public ParameterizedType getPartialType() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.PARTIAL_TYPE)) {
+      if (_unsetProperties.contains(Datatype_Builder.Property.PARTIAL_TYPE)) {
         throw new UnsupportedOperationException("partialType not set");
       }
       return partialType;
@@ -1436,7 +1436,7 @@ abstract class Metadata_Builder {
 
     @Override
     public ParameterizedType getPropertyEnum() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.PROPERTY_ENUM)) {
+      if (_unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM)) {
         throw new UnsupportedOperationException("propertyEnum not set");
       }
       return propertyEnum;
@@ -1448,14 +1448,14 @@ abstract class Metadata_Builder {
     }
 
     @Override
-    public ImmutableMap<Metadata.StandardMethod, Metadata.UnderrideLevel>
+    public ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         getStandardMethodUnderrides() {
       return standardMethodUnderrides;
     }
 
     @Override
     public boolean isBuilderSerializable() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.BUILDER_SERIALIZABLE)) {
+      if (_unsetProperties.contains(Datatype_Builder.Property.BUILDER_SERIALIZABLE)) {
         throw new UnsupportedOperationException("builderSerializable not set");
       }
       return builderSerializable;
@@ -1463,7 +1463,7 @@ abstract class Metadata_Builder {
 
     @Override
     public boolean getHasToBuilderMethod() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.HAS_TO_BUILDER_METHOD)) {
+      if (_unsetProperties.contains(Datatype_Builder.Property.HAS_TO_BUILDER_METHOD)) {
         throw new UnsupportedOperationException("hasToBuilderMethod not set");
       }
       return hasToBuilderMethod;
@@ -1480,24 +1480,24 @@ abstract class Metadata_Builder {
     }
 
     @Override
-    public Metadata.Visibility getValueTypeVisibility() {
-      if (_unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE_VISIBILITY)) {
+    public Datatype.Visibility getValueTypeVisibility() {
+      if (_unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE_VISIBILITY)) {
         throw new UnsupportedOperationException("valueTypeVisibility not set");
       }
       return valueTypeVisibility;
     }
 
     @Override
-    public ImmutableList<Function<Metadata, Excerpt>> getNestedClasses() {
+    public ImmutableList<Function<Datatype, Excerpt>> getNestedClasses() {
       return nestedClasses;
     }
 
     @Override
     public boolean equals(Object obj) {
-      if (!(obj instanceof Metadata_Builder.Partial)) {
+      if (!(obj instanceof Datatype_Builder.Partial)) {
         return false;
       }
-      Metadata_Builder.Partial other = (Metadata_Builder.Partial) obj;
+      Datatype_Builder.Partial other = (Datatype_Builder.Partial) obj;
       if (type != other.type && (type == null || !type.equals(other.type))) {
         return false;
       }
@@ -1590,33 +1590,33 @@ abstract class Metadata_Builder {
 
     @Override
     public String toString() {
-      StringBuilder result = new StringBuilder("partial Metadata{");
-      if (!_unsetProperties.contains(Metadata_Builder.Property.TYPE)) {
+      StringBuilder result = new StringBuilder("partial Datatype{");
+      if (!_unsetProperties.contains(Datatype_Builder.Property.TYPE)) {
         result.append("type=").append(type).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Builder.Property.INTERFACE_TYPE)) {
+      if (!_unsetProperties.contains(Datatype_Builder.Property.INTERFACE_TYPE)) {
         result.append("interfaceType=").append(interfaceType).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Builder.Property.BUILDER)) {
+      if (!_unsetProperties.contains(Datatype_Builder.Property.BUILDER)) {
         result.append("builder=").append(builder).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Builder.Property.EXTENSIBLE)) {
+      if (!_unsetProperties.contains(Datatype_Builder.Property.EXTENSIBLE)) {
         result.append("extensible=").append(extensible).append(", ");
       }
       if (builderFactory != null) {
         result.append("builderFactory=").append(builderFactory).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Builder.Property.GENERATED_BUILDER)) {
+      if (!_unsetProperties.contains(Datatype_Builder.Property.GENERATED_BUILDER)) {
         result.append("generatedBuilder=").append(generatedBuilder).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE)) {
+      if (!_unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE)) {
         result.append("valueType=").append(valueType).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Builder.Property.PARTIAL_TYPE)) {
+      if (!_unsetProperties.contains(Datatype_Builder.Property.PARTIAL_TYPE)) {
         result.append("partialType=").append(partialType).append(", ");
       }
       result.append("visibleNestedTypes=").append(visibleNestedTypes);
-      if (!_unsetProperties.contains(Metadata_Builder.Property.PROPERTY_ENUM)) {
+      if (!_unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM)) {
         result.append(", propertyEnum=").append(propertyEnum);
       }
       result
@@ -1624,10 +1624,10 @@ abstract class Metadata_Builder {
           .append(properties)
           .append(", standardMethodUnderrides=")
           .append(standardMethodUnderrides);
-      if (!_unsetProperties.contains(Metadata_Builder.Property.BUILDER_SERIALIZABLE)) {
+      if (!_unsetProperties.contains(Datatype_Builder.Property.BUILDER_SERIALIZABLE)) {
         result.append(", builderSerializable=").append(builderSerializable);
       }
-      if (!_unsetProperties.contains(Metadata_Builder.Property.HAS_TO_BUILDER_METHOD)) {
+      if (!_unsetProperties.contains(Datatype_Builder.Property.HAS_TO_BUILDER_METHOD)) {
         result.append(", hasToBuilderMethod=").append(hasToBuilderMethod);
       }
       result
@@ -1635,7 +1635,7 @@ abstract class Metadata_Builder {
           .append(generatedBuilderAnnotations)
           .append(", valueTypeAnnotations=")
           .append(valueTypeAnnotations);
-      if (!_unsetProperties.contains(Metadata_Builder.Property.VALUE_TYPE_VISIBILITY)) {
+      if (!_unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE_VISIBILITY)) {
         result.append(", valueTypeVisibility=").append(valueTypeVisibility);
       }
       return result.append(", nestedClasses=").append(nestedClasses).append("}").toString();

--- a/src/main/java/org/inferred/freebuilder/processor/Declarations.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Declarations.java
@@ -13,15 +13,15 @@ class Declarations {
    * Upcasts a Builder instance to the generated superclass, to allow access to private fields.
    *
    * @param block the {@link Block} to add the declaration to
-   * @param metadata metadata about the builder being generated
+   * @param datatype metadata about the user type the builder is being generated for
    * @param builder the Builder instance to upcast
    * @returns an Excerpt referencing the upcasted instance
    */
-  public static Excerpt upcastToGeneratedBuilder(Block block, Metadata metadata, String builder) {
+  public static Excerpt upcastToGeneratedBuilder(Block block, Datatype datatype, String builder) {
     return block.declare(
         Excerpts.add(
             "// Upcast to access private fields; otherwise, oddly, we get an access violation.%n%s",
-            metadata.getGeneratedBuilder()),
+            datatype.getGeneratedBuilder()),
         "base",
         Excerpts.add(builder));
   }
@@ -32,15 +32,15 @@ class Declarations {
    * @returns an Excerpt referencing a fresh Builder, if a no-args factory method is available to
    *     create one with
    */
-  public static Optional<Excerpt> freshBuilder(Block block, Metadata metadata) {
-    if (!metadata.getBuilderFactory().isPresent()) {
+  public static Optional<Excerpt> freshBuilder(Block block, Datatype datatype) {
+    if (!datatype.getBuilderFactory().isPresent()) {
       return Optional.absent();
     }
     Excerpt defaults = block.declare(
-        metadata.getGeneratedBuilder(),
+        datatype.getGeneratedBuilder(),
         "_defaults",
-        metadata.getBuilderFactory().get()
-            .newBuilder(metadata.getBuilder(), TypeInference.INFERRED_TYPES));
+        datatype.getBuilderFactory().get()
+            .newBuilder(datatype.getBuilder(), TypeInference.INFERRED_TYPES));
     return Optional.of(defaults);
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/DefaultProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/DefaultProperty.java
@@ -90,12 +90,12 @@ class DefaultProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addSetter(code, datatype);
-    addMapper(code, datatype);
-    addGetter(code, datatype);
+    addSetter(code);
+    addMapper(code);
+    addGetter(code);
   }
 
-  private void addSetter(SourceBuilder code, final Datatype datatype) {
+  private void addSetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
@@ -129,7 +129,7 @@ class DefaultProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMapper(SourceBuilder code, final Datatype datatype) {
+  private void addMapper(SourceBuilder code) {
     if (!code.feature(FUNCTION_PACKAGE).unaryOperator().isPresent()) {
       return;
     }
@@ -160,7 +160,7 @@ class DefaultProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, final Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns the value that will be returned by %s.",

--- a/src/main/java/org/inferred/freebuilder/processor/DefaultProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/DefaultProperty.java
@@ -59,7 +59,7 @@ class DefaultProperty extends PropertyCodeGenerator {
           config.getElements(),
           config.getTypes());
       return Optional.of(new DefaultProperty(
-          config.getMetadata(), property, hasDefault, mapperType));
+          config.getDatatype(), property, hasDefault, mapperType));
     }
   }
 
@@ -68,11 +68,11 @@ class DefaultProperty extends PropertyCodeGenerator {
   private final TypeKind kind;
 
   DefaultProperty(
-      Metadata metadata,
+      Datatype datatype,
       Property property,
       boolean hasDefault,
       FunctionalType mapperType) {
-    super(metadata, property);
+    super(datatype, property);
     this.hasDefault = hasDefault;
     this.mapperType = mapperType;
     this.kind = property.getType().getKind();
@@ -90,25 +90,25 @@ class DefaultProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addSetter(code, metadata);
-    addMapper(code, metadata);
-    addGetter(code, metadata);
+    addSetter(code, datatype);
+    addMapper(code, datatype);
+    addGetter(code, datatype);
   }
 
-  private void addSetter(SourceBuilder code, final Metadata metadata) {
+  private void addSetter(SourceBuilder code, final Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!kind.isPrimitive()) {
       code.addLine(" * @throws NullPointerException if {@code %s} is null", property.getName());
     }
     code.addLine(" */");
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s %s) {",
-        metadata.getBuilder(), setter(property), property.getType(), property.getName());
+        datatype.getBuilder(), setter(property), property.getType(), property.getName());
     Block body = methodBody(code, property.getName());
     if (kind.isPrimitive()) {
       body.addLine("  %s = %s;", property.getField(), property.getName());
@@ -118,28 +118,28 @@ class DefaultProperty extends PropertyCodeGenerator {
     }
     if (!hasDefault) {
       body.addLine("  %s.remove(%s.%s);",
-          UNSET_PROPERTIES, metadata.getPropertyEnum(), property.getAllCapsName());
+          UNSET_PROPERTIES, datatype.getPropertyEnum(), property.getAllCapsName());
     }
-    if ((metadata.getBuilder() == metadata.getGeneratedBuilder())) {
+    if ((datatype.getBuilder() == datatype.getGeneratedBuilder())) {
       body.addLine("  return this;");
     } else {
-      body.addLine("  return (%s) this;", metadata.getBuilder());
+      body.addLine("  return (%s) this;", datatype.getBuilder());
     }
     code.add(body)
         .addLine("}");
   }
 
-  private void addMapper(SourceBuilder code, final Metadata metadata) {
+  private void addMapper(SourceBuilder code, final Datatype datatype) {
     if (!code.feature(FUNCTION_PACKAGE).unaryOperator().isPresent()) {
       return;
     }
     code.addLine("")
         .addLine("/**")
         .addLine(" * Replaces the value to be returned by %s",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * by applying {@code mapper} to it and using the result.")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws NullPointerException if {@code mapper} is null");
     if (mapperType.canReturnNull()) {
       code.addLine(" * or returns null");
@@ -149,7 +149,7 @@ class DefaultProperty extends PropertyCodeGenerator {
     }
     code.addLine(" */")
         .add("public %s %s(%s mapper) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             mapper(property),
             mapperType.getFunctionalInterface());
     if (!hasDefault) {
@@ -160,11 +160,11 @@ class DefaultProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, final Metadata metadata) {
+  private void addGetter(SourceBuilder code, final Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns the value that will be returned by %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()));
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()));
     if (!hasDefault) {
       code.addLine(" *")
           .addLine(" * @throws IllegalStateException if the field has not been set");
@@ -173,7 +173,7 @@ class DefaultProperty extends PropertyCodeGenerator {
         .addLine("public %s %s() {", property.getType(), getter(property));
     if (!hasDefault) {
       Excerpt propertyIsSet = Excerpts.add("!%s.contains(%s.%s)",
-              UNSET_PROPERTIES, metadata.getPropertyEnum(), property.getAllCapsName());
+              UNSET_PROPERTIES, datatype.getPropertyEnum(), property.getAllCapsName());
       code.add(PreconditionExcerpts.checkState(propertyIsSet, property.getName() + " not set"));
     }
     code.addLine("  return %s;", property.getField())
@@ -192,12 +192,12 @@ class DefaultProperty extends PropertyCodeGenerator {
 
   @Override
   public void addMergeFromValue(Block code, String value) {
-    Excerpt defaults = Declarations.freshBuilder(code, metadata).orNull();
+    Excerpt defaults = Declarations.freshBuilder(code, datatype).orNull();
     if (defaults != null) {
       code.add("if (");
       if (!hasDefault) {
         code.add("%s.contains(%s.%s) || ",
-            UNSET_PROPERTIES.on(defaults), metadata.getPropertyEnum(), property.getAllCapsName());
+            UNSET_PROPERTIES.on(defaults), datatype.getPropertyEnum(), property.getAllCapsName());
       }
       code.add(ObjectsExcerpts.notEquals(
           Excerpts.add("%s.%s()", value, property.getGetterName()),
@@ -215,16 +215,16 @@ class DefaultProperty extends PropertyCodeGenerator {
   @Override
   public void addMergeFromBuilder(Block code, String builder) {
     Excerpt base =
-        hasDefault ? null : Declarations.upcastToGeneratedBuilder(code, metadata, builder);
-    Excerpt defaults = Declarations.freshBuilder(code, metadata).orNull();
+        hasDefault ? null : Declarations.upcastToGeneratedBuilder(code, datatype, builder);
+    Excerpt defaults = Declarations.freshBuilder(code, datatype).orNull();
     if (defaults != null) {
       code.add("if (");
       if (!hasDefault) {
         code.add("!%s.contains(%s.%s) && ",
-                UNSET_PROPERTIES.on(base), metadata.getPropertyEnum(), property.getAllCapsName())
+                UNSET_PROPERTIES.on(base), datatype.getPropertyEnum(), property.getAllCapsName())
             .add("(%s.contains(%s.%s) ||",
                 UNSET_PROPERTIES.on(defaults),
-                metadata.getPropertyEnum(),
+                datatype.getPropertyEnum(),
                 property.getAllCapsName());
       }
       code.add(ObjectsExcerpts.notEquals(
@@ -238,7 +238,7 @@ class DefaultProperty extends PropertyCodeGenerator {
       code.add(") {%n");
     } else if (!hasDefault) {
       code.addLine("if (!%s.contains(%s.%s)) {",
-          UNSET_PROPERTIES.on(base), metadata.getPropertyEnum(), property.getAllCapsName());
+          UNSET_PROPERTIES.on(base), datatype.getPropertyEnum(), property.getAllCapsName());
     }
     code.addLine("  %s(%s.%s());", setter(property), builder, getter(property));
     if (defaults != null || !hasDefault) {
@@ -250,7 +250,7 @@ class DefaultProperty extends PropertyCodeGenerator {
   public void addSetBuilderFromPartial(Block code, Variable builder) {
     if (!hasDefault) {
       code.add("if (!%s.contains(%s.%s)) {",
-          UNSET_PROPERTIES, metadata.getPropertyEnum(), property.getAllCapsName());
+          UNSET_PROPERTIES, datatype.getPropertyEnum(), property.getAllCapsName());
     }
     code.addLine("  %s.%s(%s);", builder, setter(property), property.getField());
     if (!hasDefault) {
@@ -265,7 +265,7 @@ class DefaultProperty extends PropertyCodeGenerator {
 
   @Override
   public void addClearField(Block code) {
-    Optional<Excerpt> defaults = Declarations.freshBuilder(code, metadata);
+    Optional<Excerpt> defaults = Declarations.freshBuilder(code, datatype);
     // Cannot clear property without defaults
     if (defaults.isPresent()) {
       code.addLine("%s = %s;", property.getField(), property.getField().on(defaults.get()));

--- a/src/main/java/org/inferred/freebuilder/processor/DefaultProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/DefaultProperty.java
@@ -30,7 +30,6 @@ import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FU
 
 import com.google.common.base.Optional;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.Excerpts;

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
@@ -36,7 +36,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.inferred.freebuilder.FreeBuilder;
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.Metadata.StandardMethod;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
 import org.inferred.freebuilder.processor.util.Block;

--- a/src/main/java/org/inferred/freebuilder/processor/GwtSupport.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GwtSupport.java
@@ -7,7 +7,6 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.Metadata.Visibility;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;

--- a/src/main/java/org/inferred/freebuilder/processor/JacksonSupport.java
+++ b/src/main/java/org/inferred/freebuilder/processor/JacksonSupport.java
@@ -5,7 +5,6 @@ import static org.inferred.freebuilder.processor.util.ModelUtils.findAnnotationM
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 

--- a/src/main/java/org/inferred/freebuilder/processor/ListMultimapProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListMultimapProperty.java
@@ -41,7 +41,6 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.excerpt.CheckedListMultimap;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;

--- a/src/main/java/org/inferred/freebuilder/processor/ListMultimapProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListMultimapProperty.java
@@ -156,17 +156,17 @@ class ListMultimapProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addPut(code, datatype);
-    addSingleKeyPutAll(code, datatype);
-    addMultimapPutAll(code, datatype);
-    addRemove(code, datatype);
-    addRemoveAll(code, datatype);
-    addMutate(code, datatype);
-    addClear(code, datatype);
-    addGetter(code, datatype);
+    addPut(code);
+    addSingleKeyPutAll(code);
+    addMultimapPutAll(code);
+    addRemove(code);
+    addRemoveAll(code);
+    addMutate(code);
+    addClear(code);
+    addGetter(code);
   }
 
-  private void addPut(SourceBuilder code, Datatype datatype) {
+  private void addPut(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds a {@code key}-{@code value} mapping to the multimap to be returned")
@@ -204,7 +204,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addSingleKeyPutAll(SourceBuilder code, Datatype datatype) {
+  private void addSingleKeyPutAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds a collection of {@code values} with the same {@code key} to the")
@@ -233,7 +233,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMultimapPutAll(SourceBuilder code, Datatype datatype) {
+  private void addMultimapPutAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each entry of {@code multimap} to the multimap to be returned from")
@@ -259,7 +259,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addRemove(SourceBuilder code, Datatype datatype) {
+  private void addRemove(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes a single key-value pair with the key {@code key} and the value"
@@ -300,7 +300,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addRemoveAll(SourceBuilder code, Datatype datatype) {
+  private void addRemoveAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes all values associated with the key {@code key} from the multimap to")
@@ -326,7 +326,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMutate(SourceBuilder code, Datatype datatype) {
+  private void addMutate(SourceBuilder code) {
     if (!code.feature(FUNCTION_PACKAGE).consumer().isPresent()) {
       return;
     }
@@ -362,7 +362,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Datatype datatype) {
+  private void addClear(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes all of the mappings from the multimap to be returned from")
@@ -376,7 +376,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the multimap that will be returned by")

--- a/src/main/java/org/inferred/freebuilder/processor/ListMultimapProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListMultimapProperty.java
@@ -93,7 +93,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
           config.getTypes());
 
       return Optional.of(new ListMultimapProperty(
-          config.getMetadata(),
+          config.getDatatype(),
           property,
           overridesPutMethod,
           keyType,
@@ -131,7 +131,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
   private final FunctionalType mutatorType;
 
   ListMultimapProperty(
-      Metadata metadata,
+      Datatype datatype,
       Property property,
       boolean overridesPutMethod,
       TypeMirror keyType,
@@ -139,7 +139,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
       TypeMirror valueType,
       Optional<TypeMirror> unboxedValueType,
       FunctionalType mutatorType) {
-    super(metadata, property);
+    super(datatype, property);
     this.overridesPutMethod = overridesPutMethod;
     this.keyType = keyType;
     this.unboxedKeyType = unboxedKeyType;
@@ -156,24 +156,24 @@ class ListMultimapProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addPut(code, metadata);
-    addSingleKeyPutAll(code, metadata);
-    addMultimapPutAll(code, metadata);
-    addRemove(code, metadata);
-    addRemoveAll(code, metadata);
-    addMutate(code, metadata);
-    addClear(code, metadata);
-    addGetter(code, metadata);
+    addPut(code, datatype);
+    addSingleKeyPutAll(code, datatype);
+    addMultimapPutAll(code, datatype);
+    addRemove(code, datatype);
+    addRemoveAll(code, datatype);
+    addMutate(code, datatype);
+    addClear(code, datatype);
+    addGetter(code, datatype);
   }
 
-  private void addPut(SourceBuilder code, Metadata metadata) {
+  private void addPut(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds a {@code key}-{@code value} mapping to the multimap to be returned")
         .addLine(" * from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedKeyType.isPresent() || !unboxedValueType.isPresent()) {
       code.add(" * @throws NullPointerException if ");
       if (unboxedKeyType.isPresent()) {
@@ -187,7 +187,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
     }
     code.addLine(" */")
         .addLine("public %s %s(%s key, %s value) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             putMethod(property),
             unboxedKeyType.or(keyType),
             unboxedValueType.or(valueType));
@@ -199,19 +199,19 @@ class ListMultimapProperty extends PropertyCodeGenerator {
       body.addLine("  %s.checkNotNull(value);", Preconditions.class);
     }
     body.addLine("  %s.put(key, value);", property.getField())
-        .addLine("  return (%s) this;", metadata.getBuilder());
+        .addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addSingleKeyPutAll(SourceBuilder code, Metadata metadata) {
+  private void addSingleKeyPutAll(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds a collection of {@code values} with the same {@code key} to the")
         .addLine(" * multimap to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (unboxedKeyType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code values} is null or contains a"
           + " null element");
@@ -221,7 +221,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
     }
     code.addLine(" */")
         .addLine("public %s %s(%s key, %s<? extends %s> values) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             putAllMethod(property),
             unboxedKeyType.or(keyType),
             Iterable.class,
@@ -229,23 +229,23 @@ class ListMultimapProperty extends PropertyCodeGenerator {
         .addLine("  for (%s value : values) {", unboxedValueType.or(valueType))
         .addLine("    %s(key, value);", putMethod(property))
         .addLine("  }")
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addMultimapPutAll(SourceBuilder code, Metadata metadata) {
+  private void addMultimapPutAll(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each entry of {@code multimap} to the multimap to be returned from")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws NullPointerException if {@code multimap} is null or contains a")
         .addLine(" *     null key or value")
         .addLine(" */");
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s, ? extends %s> multimap) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             putAllMethod(property),
             Multimap.class,
             keyType,
@@ -255,21 +255,21 @@ class ListMultimapProperty extends PropertyCodeGenerator {
         .addLine("      : multimap.asMap().entrySet()) {")
         .addLine("    %s(entry.getKey(), entry.getValue());", putAllMethod(property))
         .addLine("  }")
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addRemove(SourceBuilder code, Metadata metadata) {
+  private void addRemove(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes a single key-value pair with the key {@code key} and the value"
             + " {@code value}")
         .addLine(" * from the multimap to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * If multiple key-value pairs in the multimap fit this description, which one")
         .addLine(" * is removed is unspecified.")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedKeyType.isPresent() || !unboxedValueType.isPresent()) {
       code.add(" * @throws NullPointerException if ");
       if (unboxedKeyType.isPresent()) {
@@ -283,7 +283,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
     }
     code.addLine(" */")
         .addLine("public %s %s(%s key, %s value) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             removeMethod(property),
             unboxedKeyType.or(keyType),
             unboxedValueType.or(valueType));
@@ -295,25 +295,25 @@ class ListMultimapProperty extends PropertyCodeGenerator {
       body.addLine("  %s.checkNotNull(value);", Preconditions.class);
     }
     body.addLine("  %s.remove(key, value);", property.getField())
-        .addLine("  return (%s) this;", metadata.getBuilder());
+        .addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addRemoveAll(SourceBuilder code, Metadata metadata) {
+  private void addRemoveAll(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes all values associated with the key {@code key} from the multimap to")
         .addLine(" * be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedKeyType.isPresent()) {
       code.add(" * @throws NullPointerException if {@code key} is null\n");
     }
     code.addLine(" */")
         .addLine("public %s %s(%s key) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             removeAllMethod(property),
             unboxedKeyType.or(keyType));
     Block body = methodBody(code, "key");
@@ -321,19 +321,19 @@ class ListMultimapProperty extends PropertyCodeGenerator {
       body.addLine("  %s.checkNotNull(key);", Preconditions.class);
     }
     body.addLine("  %s.removeAll(key);", property.getField())
-        .addLine("  return (%s) this;", metadata.getBuilder());
+        .addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addMutate(SourceBuilder code, Metadata metadata) {
+  private void addMutate(SourceBuilder code, Datatype datatype) {
     if (!code.feature(FUNCTION_PACKAGE).consumer().isPresent()) {
       return;
     }
     code.addLine("")
         .addLine("/**")
         .addLine(" * Applies {@code mutator} to the multimap to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
         .addLine(" * <p>This method mutates the multimap in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored.")
@@ -342,7 +342,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
         .addLine(" * @throws NullPointerException if {@code mutator} is null")
         .addLine(" */")
         .addLine("public %s %s(%s mutator) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             mutator(property),
             mutatorType.getFunctionalInterface());
     Block body = methodBody(code, "mutator");
@@ -357,30 +357,30 @@ class ListMultimapProperty extends PropertyCodeGenerator {
               putMethod(property))
           .addLine("  mutator.%s(%s);", mutatorType.getMethodName(), property.getField());
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Metadata metadata) {
+  private void addClear(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes all of the mappings from the multimap to be returned from")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */")
-        .addLine("public %s %s() {", metadata.getBuilder(), clearMethod(property))
+        .addLine("public %s %s() {", datatype.getBuilder(), clearMethod(property))
         .addLine("  %s.clear();", property.getField())
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Metadata metadata) {
+  private void addGetter(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the multimap that will be returned by")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * Changes to this builder will be reflected in the view.")
         .addLine(" */")
         .addLine("public %s<%s, %s> %s() {",
@@ -406,7 +406,7 @@ class ListMultimapProperty extends PropertyCodeGenerator {
 
   @Override
   public void addMergeFromBuilder(Block code, String builder) {
-    Excerpt base = Declarations.upcastToGeneratedBuilder(code, metadata, builder);
+    Excerpt base = Declarations.upcastToGeneratedBuilder(code, datatype, builder);
     code.addLine("%s(%s);", putAllMethod(property), property.getField().on(base));
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/ListProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListProperty.java
@@ -40,7 +40,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.excerpt.CheckedList;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;

--- a/src/main/java/org/inferred/freebuilder/processor/ListProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListProperty.java
@@ -177,15 +177,15 @@ class ListProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addAdd(code, datatype);
-    addVarargsAdd(code, datatype);
-    addAddAllMethods(code, datatype);
-    addMutate(code, datatype);
-    addClear(code, datatype);
-    addGetter(code, datatype);
+    addAdd(code);
+    addVarargsAdd(code);
+    addAddAllMethods(code);
+    addMutate(code);
+    addClear(code);
+    addGetter(code);
   }
 
-  private void addAdd(SourceBuilder code, Datatype datatype) {
+  private void addAdd(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds {@code element} to the list to be returned from %s.",
@@ -218,7 +218,7 @@ class ListProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addVarargsAdd(SourceBuilder code, Datatype datatype) {
+  private void addVarargsAdd(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the list to be returned from")
@@ -263,18 +263,18 @@ class ListProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addAddAllMethods(SourceBuilder code, Datatype datatype) {
+  private void addAddAllMethods(SourceBuilder code) {
     if (code.feature(SOURCE_LEVEL).stream().isPresent()) {
-      addSpliteratorAddAll(code, datatype);
-      addStreamAddAll(code, datatype);
-      addIterableAddAll(code, datatype);
+      addSpliteratorAddAll(code);
+      addStreamAddAll(code);
+      addIterableAddAll(code);
     } else {
-      addPreStreamsAddAll(code, datatype);
+      addPreStreamsAddAll(code);
     }
   }
 
-  private void addPreStreamsAddAll(SourceBuilder code, Datatype datatype) {
-    addJavadocForAddAll(code, datatype);
+  private void addPreStreamsAddAll(SourceBuilder code) {
+    addJavadocForAddAll(code);
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
         datatype.getBuilder(),
@@ -305,9 +305,9 @@ class ListProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addSpliteratorAddAll(SourceBuilder code, Datatype datatype) {
+  private void addSpliteratorAddAll(SourceBuilder code) {
     QualifiedName spliterator = code.feature(SOURCE_LEVEL).spliterator().get();
-    addJavadocForAddAll(code, datatype);
+    addJavadocForAddAll(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
             datatype.getBuilder(),
             addAllMethod(property),
@@ -335,8 +335,8 @@ class ListProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addIterableAddAll(SourceBuilder code, Datatype datatype) {
-    addJavadocForAddAll(code, datatype);
+  private void addIterableAddAll(SourceBuilder code) {
+    addJavadocForAddAll(code);
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
             datatype.getBuilder(),
@@ -347,9 +347,9 @@ class ListProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addStreamAddAll(SourceBuilder code, Datatype datatype) {
+  private void addStreamAddAll(SourceBuilder code) {
     QualifiedName baseStream = code.feature(SOURCE_LEVEL).baseStream().get();
-    addJavadocForAddAll(code, datatype);
+    addJavadocForAddAll(code);
     code.addLine("public %s %s(%s<? extends %s, ?> elements) {",
             datatype.getBuilder(),
             addAllMethod(property),
@@ -359,7 +359,7 @@ class ListProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addJavadocForAddAll(SourceBuilder code, Datatype datatype) {
+  private void addJavadocForAddAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the list to be returned from")
@@ -371,7 +371,7 @@ class ListProperty extends PropertyCodeGenerator {
         .addLine(" */");
   }
 
-  private void addMutate(SourceBuilder code, Datatype datatype) {
+  private void addMutate(SourceBuilder code) {
     if (!code.feature(FUNCTION_PACKAGE).consumer().isPresent()) {
       return;
     }
@@ -414,7 +414,7 @@ class ListProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Datatype datatype) {
+  private void addClear(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Clears the list to be returned from %s.",
@@ -436,7 +436,7 @@ class ListProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the list that will be returned by")

--- a/src/main/java/org/inferred/freebuilder/processor/MapProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MapProperty.java
@@ -87,7 +87,7 @@ class MapProperty extends PropertyCodeGenerator {
           config.getTypes());
 
       return Optional.of(new MapProperty(
-          config.getMetadata(),
+          config.getDatatype(),
           property,
           overridesPutMethod,
           keyType,
@@ -128,7 +128,7 @@ class MapProperty extends PropertyCodeGenerator {
   private final FunctionalType mutatorType;
 
   MapProperty(
-      Metadata metadata,
+      Datatype datatype,
       Property property,
       boolean overridesPutMethod,
       TypeMirror keyType,
@@ -136,7 +136,7 @@ class MapProperty extends PropertyCodeGenerator {
       TypeMirror valueType,
       Optional<TypeMirror> unboxedValueType,
       FunctionalType mutatorType) {
-    super(metadata, property);
+    super(datatype, property);
     this.overridesPutMethod = overridesPutMethod;
     this.keyType = keyType;
     this.unboxedKeyType = unboxedKeyType;
@@ -157,23 +157,23 @@ class MapProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addPut(code, metadata);
-    addPutAll(code, metadata);
-    addRemove(code, metadata);
-    addMutate(code, metadata);
-    addClear(code, metadata);
-    addGetter(code, metadata);
+    addPut(code, datatype);
+    addPutAll(code, datatype);
+    addRemove(code, datatype);
+    addMutate(code, datatype);
+    addClear(code, datatype);
+    addGetter(code, datatype);
   }
 
-  private void addPut(SourceBuilder code, Metadata metadata) {
+  private void addPut(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Associates {@code key} with {@code value} in the map to be returned from")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * If the map previously contained a mapping for the key,")
         .addLine(" * the old value is replaced by the specified value.")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedKeyType.isPresent() || !unboxedValueType.isPresent()) {
       code.add(" * @throws NullPointerException if ");
       if (unboxedKeyType.isPresent()) {
@@ -187,7 +187,7 @@ class MapProperty extends PropertyCodeGenerator {
     }
     code.addLine(" */")
         .addLine("public %s %s(%s key, %s value) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             putMethod(property),
             unboxedKeyType.or(keyType),
             unboxedValueType.or(valueType));
@@ -199,24 +199,24 @@ class MapProperty extends PropertyCodeGenerator {
       body.add(PreconditionExcerpts.checkNotNull("value"));
     }
     body.addLine("  %s.put(key, value);", property.getField())
-        .addLine("  return (%s) this;", metadata.getBuilder());
+        .addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addPutAll(SourceBuilder code, Metadata metadata) {
+  private void addPutAll(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Copies all of the mappings from {@code map} to the map to be returned from")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws NullPointerException if {@code map} is null or contains a")
         .addLine(" *     null key or value")
         .addLine(" */");
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s, ? extends %s> map) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             putAllMethod(property),
             Map.class,
             keyType,
@@ -225,24 +225,24 @@ class MapProperty extends PropertyCodeGenerator {
             Map.Entry.class, keyType, valueType)
         .addLine("    %s(entry.getKey(), entry.getValue());", putMethod(property))
         .addLine("  }")
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addRemove(SourceBuilder code, Metadata metadata) {
+  private void addRemove(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes the mapping for {@code key} from the map to be returned from")
         .addLine(" * %s, if one is present.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedKeyType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code key} is null");
     }
     code.addLine(" */")
         .addLine("public %s %s(%s key) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             removeMethod(property),
             unboxedKeyType.or(keyType));
     Block body = methodBody(code, "key");
@@ -250,19 +250,19 @@ class MapProperty extends PropertyCodeGenerator {
       body.add(PreconditionExcerpts.checkNotNull("key"));
     }
     body.addLine("  %s.remove(key);", property.getField())
-        .addLine("  return (%s) this;", metadata.getBuilder());
+        .addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addMutate(SourceBuilder code, Metadata metadata) {
+  private void addMutate(SourceBuilder code, Datatype datatype) {
     if (!code.feature(FUNCTION_PACKAGE).consumer().isPresent()) {
       return;
     }
     code.addLine("")
         .addLine("/**")
         .addLine(" * Invokes {@code mutator} with the map to be returned from")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
         .addLine(" * <p>This method mutates the map in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
@@ -273,7 +273,7 @@ class MapProperty extends PropertyCodeGenerator {
         .addLine(" * @throws NullPointerException if {@code mutator} is null")
         .addLine(" */")
         .addLine("public %s %s(%s mutator) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             mutator(property),
             mutatorType.getFunctionalInterface());
     Block body = methodBody(code, "mutator");
@@ -285,30 +285,30 @@ class MapProperty extends PropertyCodeGenerator {
               putMethod(property))
           .addLine("  mutator.%s(%s);", mutatorType.getMethodName(), property.getField());
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Metadata metadata) {
+  private void addClear(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes all of the mappings from the map to be returned from ")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */")
-        .addLine("public %s %s() {", metadata.getBuilder(), clearMethod(property))
+        .addLine("public %s %s() {", datatype.getBuilder(), clearMethod(property))
         .addLine("  %s.clear();", property.getField())
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Metadata metadata) {
+  private void addGetter(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the map that will be returned by")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * Changes to this builder will be reflected in the view.")
         .addLine(" */")
         .addLine("public %s<%s, %s> %s() {", Map.class, keyType, valueType, getter(property))
@@ -334,7 +334,7 @@ class MapProperty extends PropertyCodeGenerator {
 
   @Override
   public void addMergeFromBuilder(Block code, String builder) {
-    Excerpt base = Declarations.upcastToGeneratedBuilder(code, metadata, builder);
+    Excerpt base = Declarations.upcastToGeneratedBuilder(code, datatype, builder);
     code.addLine("%s(%s);", putAllMethod(property), property.getField().on(base));
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/MapProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MapProperty.java
@@ -36,7 +36,6 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.diamon
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.excerpt.CheckedMap;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;

--- a/src/main/java/org/inferred/freebuilder/processor/MapProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MapProperty.java
@@ -157,15 +157,15 @@ class MapProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addPut(code, datatype);
-    addPutAll(code, datatype);
-    addRemove(code, datatype);
-    addMutate(code, datatype);
-    addClear(code, datatype);
-    addGetter(code, datatype);
+    addPut(code);
+    addPutAll(code);
+    addRemove(code);
+    addMutate(code);
+    addClear(code);
+    addGetter(code);
   }
 
-  private void addPut(SourceBuilder code, Datatype datatype) {
+  private void addPut(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Associates {@code key} with {@code value} in the map to be returned from")
@@ -204,7 +204,7 @@ class MapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addPutAll(SourceBuilder code, Datatype datatype) {
+  private void addPutAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Copies all of the mappings from {@code map} to the map to be returned from")
@@ -229,7 +229,7 @@ class MapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addRemove(SourceBuilder code, Datatype datatype) {
+  private void addRemove(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes the mapping for {@code key} from the map to be returned from")
@@ -255,7 +255,7 @@ class MapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMutate(SourceBuilder code, Datatype datatype) {
+  private void addMutate(SourceBuilder code) {
     if (!code.feature(FUNCTION_PACKAGE).consumer().isPresent()) {
       return;
     }
@@ -290,7 +290,7 @@ class MapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Datatype datatype) {
+  private void addClear(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes all of the mappings from the map to be returned from ")
@@ -304,7 +304,7 @@ class MapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the map that will be returned by")

--- a/src/main/java/org/inferred/freebuilder/processor/Metadata.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Metadata.java
@@ -24,13 +24,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.util.Excerpt;
-import org.inferred.freebuilder.processor.util.FieldAccess;
 import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
-
-import javax.annotation.Nullable;
-import javax.lang.model.type.TypeMirror;
 
 /**
  * Metadata about a &#64;{@link org.inferred.freebuilder.FreeBuilder FreeBuilder} type.
@@ -155,64 +151,6 @@ public abstract class Metadata {
 
   public Builder toBuilder() {
     return new Builder().mergeFrom(this);
-  }
-
-  /** Metadata about a property of a {@link Metadata}. */
-  public abstract static class Property {
-
-    /** Returns the type of the property. */
-    public abstract TypeMirror getType();
-
-    /** Returns the boxed form of {@link #getType()}, or null if type is not primitive. */
-    @Nullable public abstract TypeMirror getBoxedType();
-
-    /** Returns the name of the property, e.g. myProperty. */
-    public abstract String getName();
-
-    /** Returns the field name that stores the property, e.g. myProperty. */
-    public FieldAccess getField() {
-      return new FieldAccess(getName());
-    }
-
-    /** Returns the capitalized name of the property, e.g. MyProperty. */
-    public abstract String getCapitalizedName();
-
-    /** Returns the name of the property in all-caps with underscores, e.g. MY_PROPERTY. */
-    public abstract String getAllCapsName();
-
-    /** Returns true if getters start with "get"; setters should follow suit with "set". */
-    public abstract boolean isUsingBeanConvention();
-
-    /** Returns the name of the getter for the property, e.g. getMyProperty, or isSomethingTrue. */
-    public abstract String getGetterName();
-
-    /**
-     * Returns the code generator to use for this property, or null if no generator has been picked
-     * (i.e. when passed to {@link PropertyCodeGenerator.Factory#create}.
-     */
-    @Nullable public abstract PropertyCodeGenerator getCodeGenerator();
-
-    /**
-     * Returns true if a cast to this property type is guaranteed to be fully checked at runtime.
-     * This is true for any type that is non-generic, raw, or parameterized with unbounded
-     * wildcards, such as {@code Integer}, {@code List} or {@code Map<?, ?>}.
-     */
-    public abstract boolean isFullyCheckedCast();
-
-    /**
-     * Returns a list of annotations that should be applied to the accessor methods of this
-     * property; that is, the getter method, and a single setter method that will accept the result
-     * of the getter method as its argument. For a list, for example, that would be getX() and
-     * addAllX().
-     */
-    public abstract ImmutableList<Excerpt> getAccessorAnnotations();
-
-    public Builder toBuilder() {
-      return new Builder().mergeFrom(this);
-    }
-
-    /** Builder for {@link Property}. */
-    public static class Builder extends Metadata_Property_Builder {}
   }
 
   public static final Function<Property, PropertyCodeGenerator> GET_CODE_GENERATOR =

--- a/src/main/java/org/inferred/freebuilder/processor/Metadata_Builder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Metadata_Builder.java
@@ -74,7 +74,7 @@ abstract class Metadata_Builder {
   private ParameterizedType partialType;
   private Set<QualifiedName> visibleNestedTypes = ImmutableSet.of();
   private ParameterizedType propertyEnum;
-  private List<Metadata.Property> properties = ImmutableList.of();
+  private List<org.inferred.freebuilder.processor.Property> properties = ImmutableList.of();
   private final LinkedHashMap<Metadata.StandardMethod, Metadata.UnderrideLevel>
       standardMethodUnderrides =
           new LinkedHashMap<Metadata.StandardMethod, Metadata.UnderrideLevel>();
@@ -414,9 +414,9 @@ abstract class Metadata_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code element} is null
    */
-  public Metadata.Builder addProperties(Metadata.Property element) {
+  public Metadata.Builder addProperties(org.inferred.freebuilder.processor.Property element) {
     if (properties instanceof ImmutableList) {
-      properties = new ArrayList<Metadata.Property>(properties);
+      properties = new ArrayList<org.inferred.freebuilder.processor.Property>(properties);
     }
     properties.add(Preconditions.checkNotNull(element));
     return (Metadata.Builder) this;
@@ -429,7 +429,7 @@ abstract class Metadata_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addProperties(Metadata.Property... elements) {
+  public Metadata.Builder addProperties(org.inferred.freebuilder.processor.Property... elements) {
     return addAllProperties(Arrays.asList(elements));
   }
 
@@ -440,17 +440,18 @@ abstract class Metadata_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Builder addAllProperties(Iterable<? extends Metadata.Property> elements) {
+  public Metadata.Builder addAllProperties(
+      Iterable<? extends org.inferred.freebuilder.processor.Property> elements) {
     if (elements instanceof Collection) {
       int elementsSize = ((Collection<?>) elements).size();
       if (elementsSize != 0) {
         if (properties instanceof ImmutableList) {
-          properties = new ArrayList<Metadata.Property>(properties);
+          properties = new ArrayList<org.inferred.freebuilder.processor.Property>(properties);
         }
         ((ArrayList<?>) properties).ensureCapacity(properties.size() + elementsSize);
       }
     }
-    for (Metadata.Property element : elements) {
+    for (org.inferred.freebuilder.processor.Property element : elements) {
       addProperties(element);
     }
     return (Metadata.Builder) this;
@@ -474,9 +475,9 @@ abstract class Metadata_Builder {
    * Returns an unmodifiable view of the list that will be returned by {@link
    * Metadata#getProperties()}. Changes to this builder will be reflected in the view.
    */
-  public List<Metadata.Property> getProperties() {
+  public List<org.inferred.freebuilder.processor.Property> getProperties() {
     if (properties instanceof ImmutableList) {
-      properties = new ArrayList<Metadata.Property>(properties);
+      properties = new ArrayList<org.inferred.freebuilder.processor.Property>(properties);
     }
     return Collections.unmodifiableList(properties);
   }
@@ -885,7 +886,7 @@ abstract class Metadata_Builder {
       setPropertyEnum(value.getPropertyEnum());
     }
     if (value instanceof Metadata_Builder.Value
-        && properties == ImmutableList.<Metadata.Property>of()) {
+        && properties == ImmutableList.<org.inferred.freebuilder.processor.Property>of()) {
       properties = ImmutableList.copyOf(value.getProperties());
     } else {
       addAllProperties(value.getProperties());
@@ -1063,7 +1064,7 @@ abstract class Metadata_Builder {
     private final ParameterizedType partialType;
     private final ImmutableSet<QualifiedName> visibleNestedTypes;
     private final ParameterizedType propertyEnum;
-    private final ImmutableList<Metadata.Property> properties;
+    private final ImmutableList<org.inferred.freebuilder.processor.Property> properties;
     private final ImmutableMap<Metadata.StandardMethod, Metadata.UnderrideLevel>
         standardMethodUnderrides;
     private final boolean builderSerializable;
@@ -1145,7 +1146,7 @@ abstract class Metadata_Builder {
     }
 
     @Override
-    public ImmutableList<Metadata.Property> getProperties() {
+    public ImmutableList<org.inferred.freebuilder.processor.Property> getProperties() {
       return properties;
     }
 
@@ -1334,7 +1335,7 @@ abstract class Metadata_Builder {
     private final ParameterizedType partialType;
     private final ImmutableSet<QualifiedName> visibleNestedTypes;
     private final ParameterizedType propertyEnum;
-    private final ImmutableList<Metadata.Property> properties;
+    private final ImmutableList<org.inferred.freebuilder.processor.Property> properties;
     private final ImmutableMap<Metadata.StandardMethod, Metadata.UnderrideLevel>
         standardMethodUnderrides;
     private final boolean builderSerializable;
@@ -1442,7 +1443,7 @@ abstract class Metadata_Builder {
     }
 
     @Override
-    public ImmutableList<Metadata.Property> getProperties() {
+    public ImmutableList<org.inferred.freebuilder.processor.Property> getProperties() {
       return properties;
     }
 

--- a/src/main/java/org/inferred/freebuilder/processor/MultisetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MultisetProperty.java
@@ -41,7 +41,6 @@ import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multisets;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.excerpt.CheckedMultiset;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;

--- a/src/main/java/org/inferred/freebuilder/processor/MultisetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MultisetProperty.java
@@ -88,7 +88,7 @@ class MultisetProperty extends PropertyCodeGenerator {
           config.getTypes());
 
       return Optional.of(new MultisetProperty(
-          config.getMetadata(),
+          config.getDatatype(),
           config.getProperty(),
           needsSafeVarargs,
           overridesSetCountMethod,
@@ -135,7 +135,7 @@ class MultisetProperty extends PropertyCodeGenerator {
   private final FunctionalType mutatorType;
 
   MultisetProperty(
-      Metadata metadata,
+      Datatype datatype,
       Property property,
       boolean needsSafeVarargs,
       boolean overridesSetCountMethod,
@@ -143,7 +143,7 @@ class MultisetProperty extends PropertyCodeGenerator {
       TypeMirror elementType,
       Optional<TypeMirror> unboxedType,
       FunctionalType mutatorType) {
-    super(metadata, property);
+    super(datatype, property);
     this.needsSafeVarargs = needsSafeVarargs;
     this.overridesSetCountMethod = overridesSetCountMethod;
     this.overridesVarargsAddMethod = overridesVarargsAddMethod;
@@ -160,43 +160,43 @@ class MultisetProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addAdd(code, metadata);
-    addVarargsAdd(code, metadata);
-    addAddAllMethods(code, metadata);
-    addAddCopiesTo(code, metadata);
-    addMutate(code, metadata);
-    addClear(code, metadata);
-    addSetCountOf(code, metadata);
-    addGetter(code, metadata);
+    addAdd(code, datatype);
+    addVarargsAdd(code, datatype);
+    addAddAllMethods(code, datatype);
+    addAddCopiesTo(code, datatype);
+    addMutate(code, datatype);
+    addClear(code, datatype);
+    addSetCountOf(code, datatype);
+    addGetter(code, datatype);
   }
 
-  private void addAdd(SourceBuilder code, Metadata metadata) {
+  private void addAdd(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds {@code element} to the multiset to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code element} is null");
     }
     code.addLine(" */")
         .addLine("public %s %s(%s element) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addMethod(property),
             unboxedType.or(elementType))
         .addLine("  %s(element, 1);", addCopiesMethod(property))
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addVarargsAdd(SourceBuilder code, Metadata metadata) {
+  private void addVarargsAdd(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the multiset to be returned from")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
           .addLine(" *     null element");
@@ -216,46 +216,46 @@ class MultisetProperty extends PropertyCodeGenerator {
       code.add("final ");
     }
     code.add("%s %s(%s... elements) {\n",
-           metadata.getBuilder(),
+           datatype.getBuilder(),
             addMethod(property),
             unboxedType.or(elementType))
         .addLine("  for (%s element : elements) {", unboxedType.or(elementType))
         .addLine("    %s(element, 1);", addCopiesMethod(property))
         .addLine("  }")
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addAddAllMethods(SourceBuilder code, Metadata metadata) {
+  private void addAddAllMethods(SourceBuilder code, Datatype datatype) {
     if (code.feature(SOURCE_LEVEL).stream().isPresent()) {
-      addSpliteratorAddAll(code, metadata);
-      addStreamAddAll(code, metadata);
-      addIterableAddAll(code, metadata);
+      addSpliteratorAddAll(code, datatype);
+      addStreamAddAll(code, datatype);
+      addIterableAddAll(code, datatype);
     } else {
-      addPreStreamsAddAll(code, metadata);
+      addPreStreamsAddAll(code, datatype);
     }
   }
 
-  private void addSpliteratorAddAll(SourceBuilder code, Metadata metadata) {
+  private void addSpliteratorAddAll(SourceBuilder code, Datatype datatype) {
     QualifiedName spliterator = code.feature(SOURCE_LEVEL).spliterator().get();
-    addJavadocForAddAll(code, metadata);
+    addJavadocForAddAll(code, datatype);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addAllMethod(property),
             spliterator,
             elementType)
         .addLine("  elements.forEachRemaining(element -> {")
         .addLine("    %s(element, 1);", addCopiesMethod(property))
         .addLine("  });")
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addStreamAddAll(SourceBuilder code, Metadata metadata) {
+  private void addStreamAddAll(SourceBuilder code, Datatype datatype) {
     QualifiedName baseStream = code.feature(SOURCE_LEVEL).baseStream().get();
-    addJavadocForAddAll(code, metadata);
+    addJavadocForAddAll(code, datatype);
     code.addLine("public %s %s(%s<? extends %s, ?> elements) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addAllMethod(property),
             baseStream,
             elementType)
@@ -263,11 +263,11 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addIterableAddAll(SourceBuilder code, Metadata metadata) {
-    addJavadocForAddAll(code, metadata);
+  private void addIterableAddAll(SourceBuilder code, Datatype datatype) {
+    addJavadocForAddAll(code, datatype);
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addAllMethod(property),
             Iterable.class,
             elementType)
@@ -275,58 +275,58 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addPreStreamsAddAll(SourceBuilder code, Metadata metadata) {
-    addJavadocForAddAll(code, metadata);
+  private void addPreStreamsAddAll(SourceBuilder code, Datatype datatype) {
+    addJavadocForAddAll(code, datatype);
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addAllMethod(property),
             Iterable.class,
             elementType)
         .addLine("  for (%s element : elements) {", unboxedType.or(elementType))
         .addLine("    %s(element, 1);", addCopiesMethod(property))
         .addLine("  }")
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addJavadocForAddAll(SourceBuilder code, Metadata metadata) {
+  private void addJavadocForAddAll(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the multiset to be returned from")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
         .addLine(" *     null element")
         .addLine(" */");
   }
 
-  private void addAddCopiesTo(SourceBuilder code, Metadata metadata) {
+  private void addAddCopiesTo(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds a number of occurrences of {@code element} to the multiset to be")
         .addLine(" * returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code element} is null");
     }
     code.addLine(" * @throws IllegalArgumentException if {@code occurrences} is negative")
         .addLine(" */")
         .addLine("public %s %s(%s element, int occurrences) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addCopiesMethod(property),
             unboxedType.or(elementType))
         .add(methodBody(code, "element", "occurrences")
             .addLine("  %s(element, %s.count(element) + occurrences);",
                 setCountMethod(property), property.getField())
-            .addLine("  return (%s) this;", metadata.getBuilder()))
+            .addLine("  return (%s) this;", datatype.getBuilder()))
         .addLine("}");
   }
 
-  private void addMutate(SourceBuilder code, Metadata metadata) {
+  private void addMutate(SourceBuilder code, Datatype datatype) {
     ParameterizedType consumer = code.feature(FUNCTION_PACKAGE).consumer().orNull();
     if (consumer == null) {
       return;
@@ -334,7 +334,7 @@ class MultisetProperty extends PropertyCodeGenerator {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Applies {@code mutator} to the multiset to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
         .addLine(" * <p>This method mutates the multiset in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
@@ -345,7 +345,7 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine(" * @throws NullPointerException if {@code mutator} is null")
         .addLine(" */")
         .addLine("public %s %s(%s mutator) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             mutator(property),
             mutatorType.getFunctionalInterface());
     Block body = methodBody(code, "mutator");
@@ -360,41 +360,41 @@ class MultisetProperty extends PropertyCodeGenerator {
               setCountMethod(property))
           .addLine("  mutator.%s(%s);", mutatorType.getMethodName(), property.getField());
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Metadata metadata) {
+  private void addClear(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Clears the multiset to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */")
-        .addLine("public %s %s() {", metadata.getBuilder(), clearMethod(property))
+        .addLine("public %s %s() {", datatype.getBuilder(), clearMethod(property))
         .addLine("  %s.clear();", property.getField())
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addSetCountOf(SourceBuilder code, Metadata metadata) {
+  private void addSetCountOf(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds or removes the necessary occurrences of {@code element} to/from the")
         .addLine(" * multiset to be returned from %s, such that it attains the",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * desired count.")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code element} is null");
     }
     code.addLine(" * @throws IllegalArgumentException if {@code occurrences} is negative")
         .addLine(" */")
         .addLine("public %s %s(%s element, int occurrences) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             setCountMethod(property),
             unboxedType.or(elementType));
     Block body = methodBody(code, "element", "occurrences");
@@ -402,16 +402,16 @@ class MultisetProperty extends PropertyCodeGenerator {
       code.addLine("  %s.checkNotNull(element);", Preconditions.class);
     }
     code.addLine("  %s.setCount(element, occurrences);", property.getField())
-        .addLine("  return (%s) this;", metadata.getBuilder());
+        .addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Metadata metadata) {
+  private void addGetter(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the multiset that will be returned by")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * Changes to this builder will be reflected in the view.")
         .addLine(" */")
         .addLine("public %s<%s> %s() {", Multiset.class, elementType, getter(property))
@@ -432,7 +432,7 @@ class MultisetProperty extends PropertyCodeGenerator {
 
   @Override
   public void addMergeFromBuilder(Block code, String builder) {
-    Excerpt base = Declarations.upcastToGeneratedBuilder(code, metadata, builder);
+    Excerpt base = Declarations.upcastToGeneratedBuilder(code, datatype, builder);
     code.addLine("%s(%s);", addAllMethod(property), property.getField().on(base));
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/MultisetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MultisetProperty.java
@@ -160,17 +160,17 @@ class MultisetProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addAdd(code, datatype);
-    addVarargsAdd(code, datatype);
-    addAddAllMethods(code, datatype);
-    addAddCopiesTo(code, datatype);
-    addMutate(code, datatype);
-    addClear(code, datatype);
-    addSetCountOf(code, datatype);
-    addGetter(code, datatype);
+    addAdd(code);
+    addVarargsAdd(code);
+    addAddAllMethods(code);
+    addAddCopiesTo(code);
+    addMutate(code);
+    addClear(code);
+    addSetCountOf(code);
+    addGetter(code);
   }
 
-  private void addAdd(SourceBuilder code, Datatype datatype) {
+  private void addAdd(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds {@code element} to the multiset to be returned from %s.",
@@ -190,7 +190,7 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addVarargsAdd(SourceBuilder code, Datatype datatype) {
+  private void addVarargsAdd(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the multiset to be returned from")
@@ -226,19 +226,19 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addAddAllMethods(SourceBuilder code, Datatype datatype) {
+  private void addAddAllMethods(SourceBuilder code) {
     if (code.feature(SOURCE_LEVEL).stream().isPresent()) {
-      addSpliteratorAddAll(code, datatype);
-      addStreamAddAll(code, datatype);
-      addIterableAddAll(code, datatype);
+      addSpliteratorAddAll(code);
+      addStreamAddAll(code);
+      addIterableAddAll(code);
     } else {
-      addPreStreamsAddAll(code, datatype);
+      addPreStreamsAddAll(code);
     }
   }
 
-  private void addSpliteratorAddAll(SourceBuilder code, Datatype datatype) {
+  private void addSpliteratorAddAll(SourceBuilder code) {
     QualifiedName spliterator = code.feature(SOURCE_LEVEL).spliterator().get();
-    addJavadocForAddAll(code, datatype);
+    addJavadocForAddAll(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
             datatype.getBuilder(),
             addAllMethod(property),
@@ -251,9 +251,9 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addStreamAddAll(SourceBuilder code, Datatype datatype) {
+  private void addStreamAddAll(SourceBuilder code) {
     QualifiedName baseStream = code.feature(SOURCE_LEVEL).baseStream().get();
-    addJavadocForAddAll(code, datatype);
+    addJavadocForAddAll(code);
     code.addLine("public %s %s(%s<? extends %s, ?> elements) {",
             datatype.getBuilder(),
             addAllMethod(property),
@@ -263,8 +263,8 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addIterableAddAll(SourceBuilder code, Datatype datatype) {
-    addJavadocForAddAll(code, datatype);
+  private void addIterableAddAll(SourceBuilder code) {
+    addJavadocForAddAll(code);
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
             datatype.getBuilder(),
@@ -275,8 +275,8 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addPreStreamsAddAll(SourceBuilder code, Datatype datatype) {
-    addJavadocForAddAll(code, datatype);
+  private void addPreStreamsAddAll(SourceBuilder code) {
+    addJavadocForAddAll(code);
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
             datatype.getBuilder(),
@@ -290,7 +290,7 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addJavadocForAddAll(SourceBuilder code, Datatype datatype) {
+  private void addJavadocForAddAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the multiset to be returned from")
@@ -302,7 +302,7 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine(" */");
   }
 
-  private void addAddCopiesTo(SourceBuilder code, Datatype datatype) {
+  private void addAddCopiesTo(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds a number of occurrences of {@code element} to the multiset to be")
@@ -326,7 +326,7 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMutate(SourceBuilder code, Datatype datatype) {
+  private void addMutate(SourceBuilder code) {
     ParameterizedType consumer = code.feature(FUNCTION_PACKAGE).consumer().orNull();
     if (consumer == null) {
       return;
@@ -365,7 +365,7 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Datatype datatype) {
+  private void addClear(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Clears the multiset to be returned from %s.",
@@ -379,7 +379,7 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addSetCountOf(SourceBuilder code, Datatype datatype) {
+  private void addSetCountOf(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds or removes the necessary occurrences of {@code element} to/from the")
@@ -407,7 +407,7 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the multiset that will be returned by")

--- a/src/main/java/org/inferred/freebuilder/processor/NullableProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/NullableProperty.java
@@ -107,12 +107,12 @@ class NullableProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addSetter(code, datatype);
-    addMapper(code, datatype);
-    addGetter(code, datatype);
+    addSetter(code);
+    addMapper(code);
+    addGetter(code);
   }
 
-  private void addSetter(SourceBuilder code, final Datatype datatype) {
+  private void addSetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
@@ -130,7 +130,7 @@ class NullableProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMapper(SourceBuilder code, final Datatype datatype) {
+  private void addMapper(SourceBuilder code) {
     if (!code.feature(FUNCTION_PACKAGE).unaryOperator().isPresent()) {
       return;
     }
@@ -158,7 +158,7 @@ class NullableProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, final Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns the value that will be returned by %s.",

--- a/src/main/java/org/inferred/freebuilder/processor/NullableProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/NullableProperty.java
@@ -29,7 +29,6 @@ import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FU
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.Excerpts;

--- a/src/main/java/org/inferred/freebuilder/processor/OptionalProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/OptionalProperty.java
@@ -224,15 +224,15 @@ class OptionalProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addSetter(code, datatype);
-    addOptionalSetter(code, datatype);
-    addNullableSetter(code, datatype);
-    addMapper(code, datatype);
-    addClear(code, datatype);
-    addGetter(code, datatype);
+    addSetter(code);
+    addOptionalSetter(code);
+    addNullableSetter(code);
+    addMapper(code);
+    addClear(code);
+    addGetter(code);
   }
 
-  private void addSetter(SourceBuilder code, Datatype datatype) {
+  private void addSetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
@@ -261,7 +261,7 @@ class OptionalProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addOptionalSetter(SourceBuilder code, Datatype datatype) {
+  private void addOptionalSetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
@@ -285,7 +285,7 @@ class OptionalProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addNullableSetter(SourceBuilder code, Datatype datatype) {
+  private void addNullableSetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
@@ -308,7 +308,7 @@ class OptionalProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMapper(SourceBuilder code, Datatype datatype) {
+  private void addMapper(SourceBuilder code) {
     ParameterizedType unaryOperator = code.feature(FUNCTION_PACKAGE).unaryOperator().orNull();
     if (unaryOperator == null) {
       return;
@@ -334,7 +334,7 @@ class OptionalProperty extends PropertyCodeGenerator {
     code.addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Datatype datatype) {
+  private void addClear(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s",
@@ -349,7 +349,7 @@ class OptionalProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns the value that will be returned by %s.",

--- a/src/main/java/org/inferred/freebuilder/processor/OptionalProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/OptionalProperty.java
@@ -32,7 +32,6 @@ import static org.inferred.freebuilder.processor.util.feature.FunctionPackage.FU
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.FieldAccess;

--- a/src/main/java/org/inferred/freebuilder/processor/OptionalProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/OptionalProperty.java
@@ -59,7 +59,7 @@ class OptionalProperty extends PropertyCodeGenerator {
       @Override
       protected void applyMapper(
           SourceBuilder code,
-          Metadata metadata,
+          Datatype datatype,
           FunctionalType mapperType,
           Property property) {
         // Guava's transform method throws a NullPointerException if mapper returns null,
@@ -76,7 +76,7 @@ class OptionalProperty extends PropertyCodeGenerator {
                   mapperType.getMethodName(),
                   property.getCapitalizedName())
               .addLine("  }")
-              .addLine("  return (%s) this;", metadata.getBuilder());
+              .addLine("  return (%s) this;", datatype.getBuilder());
         } else {
           code.addLine("  return %s(%s().transform(mapper::%s));",
               setter(property), getter(property), mapperType.getMethodName());
@@ -94,7 +94,7 @@ class OptionalProperty extends PropertyCodeGenerator {
       @Override
       protected void applyMapper(
           SourceBuilder code,
-          Metadata metadata,
+          Datatype datatype,
           FunctionalType mapperType,
           Property property) {
         code.add("  return %s(%s().map(mapper", setter(property), getter(property));
@@ -123,7 +123,7 @@ class OptionalProperty extends PropertyCodeGenerator {
 
     protected abstract void applyMapper(
         SourceBuilder code,
-        Metadata metadata,
+        Datatype datatype,
         FunctionalType mapperType,
         Property property);
     protected abstract void invokeIfPresent(SourceBuilder code, String value, String method);
@@ -160,7 +160,7 @@ class OptionalProperty extends PropertyCodeGenerator {
           config.getTypes());
 
       return Optional.of(new OptionalProperty(
-          config.getMetadata(),
+          config.getDatatype(),
           property,
           optionalType,
           elementType,
@@ -186,14 +186,14 @@ class OptionalProperty extends PropertyCodeGenerator {
   private final boolean requiresExplicitTypeParameters;
 
   @VisibleForTesting OptionalProperty(
-      Metadata metadata,
+      Datatype datatype,
       Property property,
       OptionalType optional,
       TypeMirror elementType,
       Optional<TypeMirror> unboxedType,
       FunctionalType mapperType,
       boolean requiresExplicitTypeParametersInJava7) {
-    super(metadata, property);
+    super(datatype, property);
     this.optional = optional;
     this.elementType = elementType;
     this.unboxedType = unboxedType;
@@ -224,27 +224,27 @@ class OptionalProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addSetter(code, metadata);
-    addOptionalSetter(code, metadata);
-    addNullableSetter(code, metadata);
-    addMapper(code, metadata);
-    addClear(code, metadata);
-    addGetter(code, metadata);
+    addSetter(code, datatype);
+    addOptionalSetter(code, datatype);
+    addNullableSetter(code, datatype);
+    addMapper(code, datatype);
+    addClear(code, datatype);
+    addGetter(code, datatype);
   }
 
-  private void addSetter(SourceBuilder code, Metadata metadata) {
+  private void addSetter(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code %s} is null", property.getName());
     }
     code.addLine(" */")
         .addLine("public %s %s(%s %s) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             setter(property),
             unboxedType.or(elementType),
             property.getName());
@@ -256,22 +256,22 @@ class OptionalProperty extends PropertyCodeGenerator {
           .addLine("  %s = %s;",
               property.getField(), PreconditionExcerpts.checkNotNullInline(property.getName()));
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addOptionalSetter(SourceBuilder code, Metadata metadata) {
+  private void addOptionalSetter(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */");
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> %s) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             setter(property),
             optional.cls,
             elementType,
@@ -285,16 +285,16 @@ class OptionalProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addNullableSetter(SourceBuilder code, Metadata metadata) {
+  private void addNullableSetter(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */")
         .addLine("public %s %s(@%s %s %s) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             nullableSetter(property),
             javax.annotation.Nullable.class,
             elementType,
@@ -308,7 +308,7 @@ class OptionalProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMapper(SourceBuilder code, Metadata metadata) {
+  private void addMapper(SourceBuilder code, Datatype datatype) {
     ParameterizedType unaryOperator = code.feature(FUNCTION_PACKAGE).unaryOperator().orNull();
     if (unaryOperator == null) {
       return;
@@ -316,44 +316,44 @@ class OptionalProperty extends PropertyCodeGenerator {
     code.addLine("")
         .addLine("/**")
         .addLine(" * If the value to be returned by %s is present,",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * replaces it by applying {@code mapper} to it and using the result.");
     if (mapperType.canReturnNull()) {
       code.addLine(" *")
           .addLine(" * <p>If the result is null, clears the value.");
     }
     code.addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws NullPointerException if {@code mapper} is null")
         .addLine(" */")
         .addLine("public %s %s(%s mapper) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             mapper(property),
             mapperType.getFunctionalInterface());
-    optional.applyMapper(code, metadata, mapperType, property);
+    optional.applyMapper(code, datatype, mapperType, property);
     code.addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Metadata metadata) {
+  private void addClear(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the value to be returned by %s",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * to {@link %1$s#%2$s() Optional.%2$s()}.", optional.cls, optional.empty)
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */")
-        .addLine("public %s %s() {", metadata.getBuilder(), clearMethod(property))
+        .addLine("public %s %s() {", datatype.getBuilder(), clearMethod(property))
         .addLine("  %s = null;", property.getField())
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Metadata metadata) {
+  private void addGetter(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns the value that will be returned by %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" */")
         .addLine("public %s %s() {", property.getType(), getter(property));
     code.add("  return %s.", optional.cls);
@@ -402,7 +402,7 @@ class OptionalProperty extends PropertyCodeGenerator {
 
   @Override
   public void addClearField(Block code) {
-    Optional<Excerpt> defaults = Declarations.freshBuilder(code, metadata);
+    Optional<Excerpt> defaults = Declarations.freshBuilder(code, datatype);
     if (defaults.isPresent()) {
       code.addLine("%s = %s;", property.getField(), property.getField().on(defaults.get()));
     } else {

--- a/src/main/java/org/inferred/freebuilder/processor/Property.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Property.java
@@ -1,0 +1,67 @@
+package org.inferred.freebuilder.processor;
+
+import com.google.common.collect.ImmutableList;
+
+import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.FieldAccess;
+
+import javax.annotation.Nullable;
+import javax.lang.model.type.TypeMirror;
+
+/** Metadata about a property of a {@link Metadata}. */
+public abstract class Property {
+
+  /** Returns the type of the property. */
+  public abstract TypeMirror getType();
+
+  /** Returns the boxed form of {@link #getType()}, or null if type is not primitive. */
+  @Nullable public abstract TypeMirror getBoxedType();
+
+  /** Returns the name of the property, e.g. myProperty. */
+  public abstract String getName();
+
+  /** Returns the field name that stores the property, e.g. myProperty. */
+  public FieldAccess getField() {
+    return new FieldAccess(getName());
+  }
+
+  /** Returns the capitalized name of the property, e.g. MyProperty. */
+  public abstract String getCapitalizedName();
+
+  /** Returns the name of the property in all-caps with underscores, e.g. MY_PROPERTY. */
+  public abstract String getAllCapsName();
+
+  /** Returns true if getters start with "get"; setters should follow suit with "set". */
+  public abstract boolean isUsingBeanConvention();
+
+  /** Returns the name of the getter for the property, e.g. getMyProperty, or isSomethingTrue. */
+  public abstract String getGetterName();
+
+  /**
+   * Returns the code generator to use for this property, or null if no generator has been picked
+   * (i.e. when passed to {@link PropertyCodeGenerator.Factory#create}.
+   */
+  @Nullable public abstract PropertyCodeGenerator getCodeGenerator();
+
+  /**
+   * Returns true if a cast to this property type is guaranteed to be fully checked at runtime.
+   * This is true for any type that is non-generic, raw, or parameterized with unbounded
+   * wildcards, such as {@code Integer}, {@code List} or {@code Map<?, ?>}.
+   */
+  public abstract boolean isFullyCheckedCast();
+
+  /**
+   * Returns a list of annotations that should be applied to the accessor methods of this
+   * property; that is, the getter method, and a single setter method that will accept the result
+   * of the getter method as its argument. For a list, for example, that would be getX() and
+   * addAllX().
+   */
+  public abstract ImmutableList<Excerpt> getAccessorAnnotations();
+
+  public Property.Builder toBuilder() {
+    return new Builder().mergeFrom(this);
+  }
+
+  /** Builder for {@link Property}. */
+  public static class Builder extends Property_Builder {}
+}

--- a/src/main/java/org/inferred/freebuilder/processor/Property.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Property.java
@@ -8,7 +8,7 @@ import org.inferred.freebuilder.processor.util.FieldAccess;
 import javax.annotation.Nullable;
 import javax.lang.model.type.TypeMirror;
 
-/** Metadata about a property of a {@link Metadata}. */
+/** Datatype about a property of a {@link Datatype}. */
 public abstract class Property {
 
   /** Returns the type of the property. */

--- a/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
@@ -42,10 +42,10 @@ public abstract class PropertyCodeGenerator {
 
   /** Data available to {@link Factory} instances when creating a {@link PropertyCodeGenerator}. */
   interface Config {
-    /** Returns metadata about the builder being generated. */
-    Metadata getMetadata();
+    /** Returns datatype about the builder being generated. */
+    Datatype getDatatype();
 
-    /** Returns metadata about the property requiring code generation. */
+    /** Returns datatype about the property requiring code generation. */
     Property getProperty();
 
     /** Returns annotations on the property requiring code generation. */
@@ -82,11 +82,11 @@ public abstract class PropertyCodeGenerator {
     Optional<? extends PropertyCodeGenerator> create(Config config);
   }
 
-  protected final Metadata metadata;
+  protected final Datatype datatype;
   protected final Property property;
 
-  public PropertyCodeGenerator(Metadata metadata, Property property) {
-    this.metadata = metadata;
+  public PropertyCodeGenerator(Datatype datatype, Property property) {
+    this.datatype = datatype;
     this.property = property;
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
@@ -21,7 +21,6 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.FieldAccess;
@@ -47,7 +46,7 @@ public abstract class PropertyCodeGenerator {
     Metadata getMetadata();
 
     /** Returns metadata about the property requiring code generation. */
-    Metadata.Property getProperty();
+    Property getProperty();
 
     /** Returns annotations on the property requiring code generation. */
     List<? extends AnnotationMirror> getAnnotations();

--- a/src/main/java/org/inferred/freebuilder/processor/Property_Builder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Property_Builder.java
@@ -16,15 +16,16 @@ import javax.lang.model.type.TypeMirror;
 import org.inferred.freebuilder.processor.util.Excerpt;
 
 /**
- * Auto-generated superclass of {@link Metadata.Property.Builder}, derived from the API of {@link
- * Metadata.Property}.
+ * Auto-generated superclass of {@link org.inferred.freebuilder.processor.Property.Builder}, derived
+ * from the API of {@link org.inferred.freebuilder.processor.Property}.
  */
 @Generated("org.inferred.freebuilder.processor.Processor")
-abstract class Metadata_Property_Builder {
+abstract class Property_Builder {
 
   /** Creates a new builder using {@code value} as a template. */
-  public static Metadata.Property.Builder from(Metadata.Property value) {
-    return new Metadata.Property.Builder().mergeFrom(value);
+  public static org.inferred.freebuilder.processor.Property.Builder from(
+      org.inferred.freebuilder.processor.Property value) {
+    return new org.inferred.freebuilder.processor.Property.Builder().mergeFrom(value);
   }
 
   private enum Property {
@@ -59,239 +60,265 @@ abstract class Metadata_Property_Builder {
   @Nullable private PropertyCodeGenerator codeGenerator = null;
   private boolean fullyCheckedCast;
   private List<Excerpt> accessorAnnotations = ImmutableList.of();
-  private final EnumSet<Metadata_Property_Builder.Property> _unsetProperties =
-      EnumSet.allOf(Metadata_Property_Builder.Property.class);
+  private final EnumSet<Property_Builder.Property> _unsetProperties =
+      EnumSet.allOf(Property_Builder.Property.class);
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getType()}.
+   * Sets the value to be returned by {@link org.inferred.freebuilder.processor.Property#getType()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code type} is null
    */
-  public Metadata.Property.Builder setType(TypeMirror type) {
+  public org.inferred.freebuilder.processor.Property.Builder setType(TypeMirror type) {
     this.type = Preconditions.checkNotNull(type);
-    _unsetProperties.remove(Metadata_Property_Builder.Property.TYPE);
-    return (Metadata.Property.Builder) this;
+    _unsetProperties.remove(Property_Builder.Property.TYPE);
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#getType()}.
+   * Returns the value that will be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getType()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public TypeMirror getType() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.TYPE), "type not set");
+        !_unsetProperties.contains(Property_Builder.Property.TYPE), "type not set");
     return type;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getBoxedType()}.
+   * Sets the value to be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getBoxedType()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Property.Builder setBoxedType(@Nullable TypeMirror boxedType) {
+  public org.inferred.freebuilder.processor.Property.Builder setBoxedType(
+      @Nullable TypeMirror boxedType) {
     this.boxedType = boxedType;
-    return (Metadata.Property.Builder) this;
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
-  /** Returns the value that will be returned by {@link Metadata.Property#getBoxedType()}. */
+  /**
+   * Returns the value that will be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getBoxedType()}.
+   */
   @Nullable
   public TypeMirror getBoxedType() {
     return boxedType;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getName()}.
+   * Sets the value to be returned by {@link org.inferred.freebuilder.processor.Property#getName()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code name} is null
    */
-  public Metadata.Property.Builder setName(String name) {
+  public org.inferred.freebuilder.processor.Property.Builder setName(String name) {
     this.name = Preconditions.checkNotNull(name);
-    _unsetProperties.remove(Metadata_Property_Builder.Property.NAME);
-    return (Metadata.Property.Builder) this;
+    _unsetProperties.remove(Property_Builder.Property.NAME);
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#getName()}.
+   * Returns the value that will be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getName()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public String getName() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.NAME), "name not set");
+        !_unsetProperties.contains(Property_Builder.Property.NAME), "name not set");
     return name;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getCapitalizedName()}.
+   * Sets the value to be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getCapitalizedName()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code capitalizedName} is null
    */
-  public Metadata.Property.Builder setCapitalizedName(String capitalizedName) {
+  public org.inferred.freebuilder.processor.Property.Builder setCapitalizedName(
+      String capitalizedName) {
     this.capitalizedName = Preconditions.checkNotNull(capitalizedName);
-    _unsetProperties.remove(Metadata_Property_Builder.Property.CAPITALIZED_NAME);
-    return (Metadata.Property.Builder) this;
+    _unsetProperties.remove(Property_Builder.Property.CAPITALIZED_NAME);
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#getCapitalizedName()}.
+   * Returns the value that will be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getCapitalizedName()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public String getCapitalizedName() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME),
+        !_unsetProperties.contains(Property_Builder.Property.CAPITALIZED_NAME),
         "capitalizedName not set");
     return capitalizedName;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getAllCapsName()}.
+   * Sets the value to be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getAllCapsName()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code allCapsName} is null
    */
-  public Metadata.Property.Builder setAllCapsName(String allCapsName) {
+  public org.inferred.freebuilder.processor.Property.Builder setAllCapsName(String allCapsName) {
     this.allCapsName = Preconditions.checkNotNull(allCapsName);
-    _unsetProperties.remove(Metadata_Property_Builder.Property.ALL_CAPS_NAME);
-    return (Metadata.Property.Builder) this;
+    _unsetProperties.remove(Property_Builder.Property.ALL_CAPS_NAME);
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#getAllCapsName()}.
+   * Returns the value that will be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getAllCapsName()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public String getAllCapsName() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME),
-        "allCapsName not set");
+        !_unsetProperties.contains(Property_Builder.Property.ALL_CAPS_NAME), "allCapsName not set");
     return allCapsName;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#isUsingBeanConvention()}.
+   * Sets the value to be returned by {@link
+   * org.inferred.freebuilder.processor.Property#isUsingBeanConvention()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Property.Builder setUsingBeanConvention(boolean usingBeanConvention) {
+  public org.inferred.freebuilder.processor.Property.Builder setUsingBeanConvention(
+      boolean usingBeanConvention) {
     this.usingBeanConvention = usingBeanConvention;
-    _unsetProperties.remove(Metadata_Property_Builder.Property.USING_BEAN_CONVENTION);
-    return (Metadata.Property.Builder) this;
+    _unsetProperties.remove(Property_Builder.Property.USING_BEAN_CONVENTION);
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#isUsingBeanConvention()}.
+   * Returns the value that will be returned by {@link
+   * org.inferred.freebuilder.processor.Property#isUsingBeanConvention()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public boolean isUsingBeanConvention() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.USING_BEAN_CONVENTION),
+        !_unsetProperties.contains(Property_Builder.Property.USING_BEAN_CONVENTION),
         "usingBeanConvention not set");
     return usingBeanConvention;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getGetterName()}.
+   * Sets the value to be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getGetterName()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code getterName} is null
    */
-  public Metadata.Property.Builder setGetterName(String getterName) {
+  public org.inferred.freebuilder.processor.Property.Builder setGetterName(String getterName) {
     this.getterName = Preconditions.checkNotNull(getterName);
-    _unsetProperties.remove(Metadata_Property_Builder.Property.GETTER_NAME);
-    return (Metadata.Property.Builder) this;
+    _unsetProperties.remove(Property_Builder.Property.GETTER_NAME);
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#getGetterName()}.
+   * Returns the value that will be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getGetterName()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public String getGetterName() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.GETTER_NAME),
-        "getterName not set");
+        !_unsetProperties.contains(Property_Builder.Property.GETTER_NAME), "getterName not set");
     return getterName;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#getCodeGenerator()}.
+   * Sets the value to be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getCodeGenerator()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Property.Builder setCodeGenerator(@Nullable PropertyCodeGenerator codeGenerator) {
+  public org.inferred.freebuilder.processor.Property.Builder setCodeGenerator(
+      @Nullable PropertyCodeGenerator codeGenerator) {
     this.codeGenerator = codeGenerator;
-    return (Metadata.Property.Builder) this;
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
-  /** Returns the value that will be returned by {@link Metadata.Property#getCodeGenerator()}. */
+  /**
+   * Returns the value that will be returned by {@link
+   * org.inferred.freebuilder.processor.Property#getCodeGenerator()}.
+   */
   @Nullable
   public PropertyCodeGenerator getCodeGenerator() {
     return codeGenerator;
   }
 
   /**
-   * Sets the value to be returned by {@link Metadata.Property#isFullyCheckedCast()}.
+   * Sets the value to be returned by {@link
+   * org.inferred.freebuilder.processor.Property#isFullyCheckedCast()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Property.Builder setFullyCheckedCast(boolean fullyCheckedCast) {
+  public org.inferred.freebuilder.processor.Property.Builder setFullyCheckedCast(
+      boolean fullyCheckedCast) {
     this.fullyCheckedCast = fullyCheckedCast;
-    _unsetProperties.remove(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST);
-    return (Metadata.Property.Builder) this;
+    _unsetProperties.remove(Property_Builder.Property.FULLY_CHECKED_CAST);
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
-   * Returns the value that will be returned by {@link Metadata.Property#isFullyCheckedCast()}.
+   * Returns the value that will be returned by {@link
+   * org.inferred.freebuilder.processor.Property#isFullyCheckedCast()}.
    *
    * @throws IllegalStateException if the field has not been set
    */
   public boolean isFullyCheckedCast() {
     Preconditions.checkState(
-        !_unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST),
+        !_unsetProperties.contains(Property_Builder.Property.FULLY_CHECKED_CAST),
         "fullyCheckedCast not set");
     return fullyCheckedCast;
   }
 
   /**
    * Adds {@code element} to the list to be returned from {@link
-   * Metadata.Property#getAccessorAnnotations()}.
+   * org.inferred.freebuilder.processor.Property#getAccessorAnnotations()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code element} is null
    */
-  public Metadata.Property.Builder addAccessorAnnotations(Excerpt element) {
+  public org.inferred.freebuilder.processor.Property.Builder addAccessorAnnotations(
+      Excerpt element) {
     if (accessorAnnotations instanceof ImmutableList) {
       accessorAnnotations = new ArrayList<Excerpt>(accessorAnnotations);
     }
     accessorAnnotations.add(Preconditions.checkNotNull(element));
-    return (Metadata.Property.Builder) this;
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
    * Adds each element of {@code elements} to the list to be returned from {@link
-   * Metadata.Property#getAccessorAnnotations()}.
+   * org.inferred.freebuilder.processor.Property#getAccessorAnnotations()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Property.Builder addAccessorAnnotations(Excerpt... elements) {
+  public org.inferred.freebuilder.processor.Property.Builder addAccessorAnnotations(
+      Excerpt... elements) {
     return addAllAccessorAnnotations(Arrays.asList(elements));
   }
 
   /**
    * Adds each element of {@code elements} to the list to be returned from {@link
-   * Metadata.Property#getAccessorAnnotations()}.
+   * org.inferred.freebuilder.processor.Property#getAccessorAnnotations()}.
    *
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code elements} is null or contains a null element
    */
-  public Metadata.Property.Builder addAllAccessorAnnotations(Iterable<? extends Excerpt> elements) {
+  public org.inferred.freebuilder.processor.Property.Builder addAllAccessorAnnotations(
+      Iterable<? extends Excerpt> elements) {
     if (elements instanceof Collection) {
       int elementsSize = ((Collection<?>) elements).size();
       if (elementsSize != 0) {
@@ -305,27 +332,28 @@ abstract class Metadata_Property_Builder {
     for (Excerpt element : elements) {
       addAccessorAnnotations(element);
     }
-    return (Metadata.Property.Builder) this;
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
-   * Clears the list to be returned from {@link Metadata.Property#getAccessorAnnotations()}.
+   * Clears the list to be returned from {@link
+   * org.inferred.freebuilder.processor.Property#getAccessorAnnotations()}.
    *
    * @return this {@code Builder} object
    */
-  public Metadata.Property.Builder clearAccessorAnnotations() {
+  public org.inferred.freebuilder.processor.Property.Builder clearAccessorAnnotations() {
     if (accessorAnnotations instanceof ImmutableList) {
       accessorAnnotations = ImmutableList.of();
     } else {
       accessorAnnotations.clear();
     }
-    return (Metadata.Property.Builder) this;
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
    * Returns an unmodifiable view of the list that will be returned by {@link
-   * Metadata.Property#getAccessorAnnotations()}. Changes to this builder will be reflected in the
-   * view.
+   * org.inferred.freebuilder.processor.Property#getAccessorAnnotations()}. Changes to this builder
+   * will be reflected in the view.
    */
   public List<Excerpt> getAccessorAnnotations() {
     if (accessorAnnotations instanceof ImmutableList) {
@@ -334,10 +362,14 @@ abstract class Metadata_Property_Builder {
     return Collections.unmodifiableList(accessorAnnotations);
   }
 
-  /** Sets all property values using the given {@code Metadata.Property} as a template. */
-  public Metadata.Property.Builder mergeFrom(Metadata.Property value) {
-    Metadata_Property_Builder _defaults = new Metadata.Property.Builder();
-    if (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.TYPE)
+  /**
+   * Sets all property values using the given {@code org.inferred.freebuilder.processor.Property} as
+   * a template.
+   */
+  public org.inferred.freebuilder.processor.Property.Builder mergeFrom(
+      org.inferred.freebuilder.processor.Property value) {
+    Property_Builder _defaults = new org.inferred.freebuilder.processor.Property.Builder();
+    if (_defaults._unsetProperties.contains(Property_Builder.Property.TYPE)
         || !value.getType().equals(_defaults.getType())) {
       setType(value.getType());
     }
@@ -346,24 +378,23 @@ abstract class Metadata_Property_Builder {
             || !value.getBoxedType().equals(_defaults.getBoxedType()))) {
       setBoxedType(value.getBoxedType());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.NAME)
+    if (_defaults._unsetProperties.contains(Property_Builder.Property.NAME)
         || !value.getName().equals(_defaults.getName())) {
       setName(value.getName());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)
+    if (_defaults._unsetProperties.contains(Property_Builder.Property.CAPITALIZED_NAME)
         || !value.getCapitalizedName().equals(_defaults.getCapitalizedName())) {
       setCapitalizedName(value.getCapitalizedName());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)
+    if (_defaults._unsetProperties.contains(Property_Builder.Property.ALL_CAPS_NAME)
         || !value.getAllCapsName().equals(_defaults.getAllCapsName())) {
       setAllCapsName(value.getAllCapsName());
     }
-    if (_defaults._unsetProperties.contains(
-            Metadata_Property_Builder.Property.USING_BEAN_CONVENTION)
+    if (_defaults._unsetProperties.contains(Property_Builder.Property.USING_BEAN_CONVENTION)
         || value.isUsingBeanConvention() != _defaults.isUsingBeanConvention()) {
       setUsingBeanConvention(value.isUsingBeanConvention());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.GETTER_NAME)
+    if (_defaults._unsetProperties.contains(Property_Builder.Property.GETTER_NAME)
         || !value.getGetterName().equals(_defaults.getGetterName())) {
       setGetterName(value.getGetterName());
     }
@@ -372,29 +403,30 @@ abstract class Metadata_Property_Builder {
             || !value.getCodeGenerator().equals(_defaults.getCodeGenerator()))) {
       setCodeGenerator(value.getCodeGenerator());
     }
-    if (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST)
+    if (_defaults._unsetProperties.contains(Property_Builder.Property.FULLY_CHECKED_CAST)
         || value.isFullyCheckedCast() != _defaults.isFullyCheckedCast()) {
       setFullyCheckedCast(value.isFullyCheckedCast());
     }
-    if (value instanceof Metadata_Property_Builder.Value
+    if (value instanceof Property_Builder.Value
         && accessorAnnotations == ImmutableList.<Excerpt>of()) {
       accessorAnnotations = ImmutableList.copyOf(value.getAccessorAnnotations());
     } else {
       addAllAccessorAnnotations(value.getAccessorAnnotations());
     }
-    return (Metadata.Property.Builder) this;
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
    * Copies values from the given {@code Builder}. Does not affect any properties not set on the
    * input.
    */
-  public Metadata.Property.Builder mergeFrom(Metadata.Property.Builder template) {
+  public org.inferred.freebuilder.processor.Property.Builder mergeFrom(
+      org.inferred.freebuilder.processor.Property.Builder template) {
     // Upcast to access private fields; otherwise, oddly, we get an access violation.
-    Metadata_Property_Builder base = template;
-    Metadata_Property_Builder _defaults = new Metadata.Property.Builder();
-    if (!base._unsetProperties.contains(Metadata_Property_Builder.Property.TYPE)
-        && (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.TYPE)
+    Property_Builder base = template;
+    Property_Builder _defaults = new org.inferred.freebuilder.processor.Property.Builder();
+    if (!base._unsetProperties.contains(Property_Builder.Property.TYPE)
+        && (_defaults._unsetProperties.contains(Property_Builder.Property.TYPE)
             || !template.getType().equals(_defaults.getType()))) {
       setType(template.getType());
     }
@@ -403,29 +435,28 @@ abstract class Metadata_Property_Builder {
             || !template.getBoxedType().equals(_defaults.getBoxedType()))) {
       setBoxedType(template.getBoxedType());
     }
-    if (!base._unsetProperties.contains(Metadata_Property_Builder.Property.NAME)
-        && (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.NAME)
+    if (!base._unsetProperties.contains(Property_Builder.Property.NAME)
+        && (_defaults._unsetProperties.contains(Property_Builder.Property.NAME)
             || !template.getName().equals(_defaults.getName()))) {
       setName(template.getName());
     }
-    if (!base._unsetProperties.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)
-        && (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)
+    if (!base._unsetProperties.contains(Property_Builder.Property.CAPITALIZED_NAME)
+        && (_defaults._unsetProperties.contains(Property_Builder.Property.CAPITALIZED_NAME)
             || !template.getCapitalizedName().equals(_defaults.getCapitalizedName()))) {
       setCapitalizedName(template.getCapitalizedName());
     }
-    if (!base._unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)
-        && (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)
+    if (!base._unsetProperties.contains(Property_Builder.Property.ALL_CAPS_NAME)
+        && (_defaults._unsetProperties.contains(Property_Builder.Property.ALL_CAPS_NAME)
             || !template.getAllCapsName().equals(_defaults.getAllCapsName()))) {
       setAllCapsName(template.getAllCapsName());
     }
-    if (!base._unsetProperties.contains(Metadata_Property_Builder.Property.USING_BEAN_CONVENTION)
-        && (_defaults._unsetProperties.contains(
-                Metadata_Property_Builder.Property.USING_BEAN_CONVENTION)
+    if (!base._unsetProperties.contains(Property_Builder.Property.USING_BEAN_CONVENTION)
+        && (_defaults._unsetProperties.contains(Property_Builder.Property.USING_BEAN_CONVENTION)
             || template.isUsingBeanConvention() != _defaults.isUsingBeanConvention())) {
       setUsingBeanConvention(template.isUsingBeanConvention());
     }
-    if (!base._unsetProperties.contains(Metadata_Property_Builder.Property.GETTER_NAME)
-        && (_defaults._unsetProperties.contains(Metadata_Property_Builder.Property.GETTER_NAME)
+    if (!base._unsetProperties.contains(Property_Builder.Property.GETTER_NAME)
+        && (_defaults._unsetProperties.contains(Property_Builder.Property.GETTER_NAME)
             || !template.getGetterName().equals(_defaults.getGetterName()))) {
       setGetterName(template.getGetterName());
     }
@@ -434,19 +465,18 @@ abstract class Metadata_Property_Builder {
             || !template.getCodeGenerator().equals(_defaults.getCodeGenerator()))) {
       setCodeGenerator(template.getCodeGenerator());
     }
-    if (!base._unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST)
-        && (_defaults._unsetProperties.contains(
-                Metadata_Property_Builder.Property.FULLY_CHECKED_CAST)
+    if (!base._unsetProperties.contains(Property_Builder.Property.FULLY_CHECKED_CAST)
+        && (_defaults._unsetProperties.contains(Property_Builder.Property.FULLY_CHECKED_CAST)
             || template.isFullyCheckedCast() != _defaults.isFullyCheckedCast())) {
       setFullyCheckedCast(template.isFullyCheckedCast());
     }
     addAllAccessorAnnotations(base.accessorAnnotations);
-    return (Metadata.Property.Builder) this;
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /** Resets the state of this builder. */
-  public Metadata.Property.Builder clear() {
-    Metadata_Property_Builder _defaults = new Metadata.Property.Builder();
+  public org.inferred.freebuilder.processor.Property.Builder clear() {
+    Property_Builder _defaults = new org.inferred.freebuilder.processor.Property.Builder();
     type = _defaults.type;
     boxedType = _defaults.boxedType;
     name = _defaults.name;
@@ -459,34 +489,35 @@ abstract class Metadata_Property_Builder {
     clearAccessorAnnotations();
     _unsetProperties.clear();
     _unsetProperties.addAll(_defaults._unsetProperties);
-    return (Metadata.Property.Builder) this;
+    return (org.inferred.freebuilder.processor.Property.Builder) this;
   }
 
   /**
-   * Returns a newly-created {@link Metadata.Property} based on the contents of the {@code Builder}.
+   * Returns a newly-created {@link org.inferred.freebuilder.processor.Property} based on the
+   * contents of the {@code Builder}.
    *
    * @throws IllegalStateException if any field has not been set
    */
-  public Metadata.Property build() {
+  public org.inferred.freebuilder.processor.Property build() {
     Preconditions.checkState(_unsetProperties.isEmpty(), "Not set: %s", _unsetProperties);
-    return new Metadata_Property_Builder.Value(this);
+    return new Property_Builder.Value(this);
   }
 
   /**
-   * Returns a newly-created partial {@link Metadata.Property} for use in unit tests. State checking
-   * will not be performed. Unset properties will throw an {@link UnsupportedOperationException}
-   * when accessed via the partial object.
+   * Returns a newly-created partial {@link org.inferred.freebuilder.processor.Property} for use in
+   * unit tests. State checking will not be performed. Unset properties will throw an {@link
+   * UnsupportedOperationException} when accessed via the partial object.
    *
    * <p>Partials should only ever be used in tests. They permit writing robust test cases that won't
    * fail if this type gains more application-level constraints (e.g. new required fields) in
    * future. If you require partially complete values in production code, consider using a Builder.
    */
   @VisibleForTesting()
-  public Metadata.Property buildPartial() {
-    return new Metadata_Property_Builder.Partial(this);
+  public org.inferred.freebuilder.processor.Property buildPartial() {
+    return new Property_Builder.Partial(this);
   }
 
-  private static final class Value extends Metadata.Property {
+  private static final class Value extends org.inferred.freebuilder.processor.Property {
     private final TypeMirror type;
     @Nullable private final TypeMirror boxedType;
     private final String name;
@@ -498,7 +529,7 @@ abstract class Metadata_Property_Builder {
     private final boolean fullyCheckedCast;
     private final ImmutableList<Excerpt> accessorAnnotations;
 
-    private Value(Metadata_Property_Builder builder) {
+    private Value(Property_Builder builder) {
       this.type = builder.type;
       this.boxedType = builder.boxedType;
       this.name = builder.name;
@@ -565,10 +596,10 @@ abstract class Metadata_Property_Builder {
 
     @Override
     public boolean equals(Object obj) {
-      if (!(obj instanceof Metadata_Property_Builder.Value)) {
+      if (!(obj instanceof Property_Builder.Value)) {
         return false;
       }
-      Metadata_Property_Builder.Value other = (Metadata_Property_Builder.Value) obj;
+      Property_Builder.Value other = (Property_Builder.Value) obj;
       if (!type.equals(other.type)) {
         return false;
       }
@@ -651,7 +682,7 @@ abstract class Metadata_Property_Builder {
     }
   }
 
-  private static final class Partial extends Metadata.Property {
+  private static final class Partial extends org.inferred.freebuilder.processor.Property {
     private final TypeMirror type;
     @Nullable private final TypeMirror boxedType;
     private final String name;
@@ -662,9 +693,9 @@ abstract class Metadata_Property_Builder {
     @Nullable private final PropertyCodeGenerator codeGenerator;
     private final boolean fullyCheckedCast;
     private final ImmutableList<Excerpt> accessorAnnotations;
-    private final EnumSet<Metadata_Property_Builder.Property> _unsetProperties;
+    private final EnumSet<Property_Builder.Property> _unsetProperties;
 
-    Partial(Metadata_Property_Builder builder) {
+    Partial(Property_Builder builder) {
       this.type = builder.type;
       this.boxedType = builder.boxedType;
       this.name = builder.name;
@@ -680,7 +711,7 @@ abstract class Metadata_Property_Builder {
 
     @Override
     public TypeMirror getType() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.TYPE)) {
+      if (_unsetProperties.contains(Property_Builder.Property.TYPE)) {
         throw new UnsupportedOperationException("type not set");
       }
       return type;
@@ -694,7 +725,7 @@ abstract class Metadata_Property_Builder {
 
     @Override
     public String getName() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.NAME)) {
+      if (_unsetProperties.contains(Property_Builder.Property.NAME)) {
         throw new UnsupportedOperationException("name not set");
       }
       return name;
@@ -702,7 +733,7 @@ abstract class Metadata_Property_Builder {
 
     @Override
     public String getCapitalizedName() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)) {
+      if (_unsetProperties.contains(Property_Builder.Property.CAPITALIZED_NAME)) {
         throw new UnsupportedOperationException("capitalizedName not set");
       }
       return capitalizedName;
@@ -710,7 +741,7 @@ abstract class Metadata_Property_Builder {
 
     @Override
     public String getAllCapsName() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)) {
+      if (_unsetProperties.contains(Property_Builder.Property.ALL_CAPS_NAME)) {
         throw new UnsupportedOperationException("allCapsName not set");
       }
       return allCapsName;
@@ -718,7 +749,7 @@ abstract class Metadata_Property_Builder {
 
     @Override
     public boolean isUsingBeanConvention() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.USING_BEAN_CONVENTION)) {
+      if (_unsetProperties.contains(Property_Builder.Property.USING_BEAN_CONVENTION)) {
         throw new UnsupportedOperationException("usingBeanConvention not set");
       }
       return usingBeanConvention;
@@ -726,7 +757,7 @@ abstract class Metadata_Property_Builder {
 
     @Override
     public String getGetterName() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.GETTER_NAME)) {
+      if (_unsetProperties.contains(Property_Builder.Property.GETTER_NAME)) {
         throw new UnsupportedOperationException("getterName not set");
       }
       return getterName;
@@ -740,7 +771,7 @@ abstract class Metadata_Property_Builder {
 
     @Override
     public boolean isFullyCheckedCast() {
-      if (_unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST)) {
+      if (_unsetProperties.contains(Property_Builder.Property.FULLY_CHECKED_CAST)) {
         throw new UnsupportedOperationException("fullyCheckedCast not set");
       }
       return fullyCheckedCast;
@@ -753,10 +784,10 @@ abstract class Metadata_Property_Builder {
 
     @Override
     public boolean equals(Object obj) {
-      if (!(obj instanceof Metadata_Property_Builder.Partial)) {
+      if (!(obj instanceof Property_Builder.Partial)) {
         return false;
       }
-      Metadata_Property_Builder.Partial other = (Metadata_Property_Builder.Partial) obj;
+      Property_Builder.Partial other = (Property_Builder.Partial) obj;
       if (type != other.type && (type == null || !type.equals(other.type))) {
         return false;
       }
@@ -816,31 +847,31 @@ abstract class Metadata_Property_Builder {
     @Override
     public String toString() {
       StringBuilder result = new StringBuilder("partial Property{");
-      if (!_unsetProperties.contains(Metadata_Property_Builder.Property.TYPE)) {
+      if (!_unsetProperties.contains(Property_Builder.Property.TYPE)) {
         result.append("type=").append(type).append(", ");
       }
       if (boxedType != null) {
         result.append("boxedType=").append(boxedType).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Property_Builder.Property.NAME)) {
+      if (!_unsetProperties.contains(Property_Builder.Property.NAME)) {
         result.append("name=").append(name).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Property_Builder.Property.CAPITALIZED_NAME)) {
+      if (!_unsetProperties.contains(Property_Builder.Property.CAPITALIZED_NAME)) {
         result.append("capitalizedName=").append(capitalizedName).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Property_Builder.Property.ALL_CAPS_NAME)) {
+      if (!_unsetProperties.contains(Property_Builder.Property.ALL_CAPS_NAME)) {
         result.append("allCapsName=").append(allCapsName).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Property_Builder.Property.USING_BEAN_CONVENTION)) {
+      if (!_unsetProperties.contains(Property_Builder.Property.USING_BEAN_CONVENTION)) {
         result.append("usingBeanConvention=").append(usingBeanConvention).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Property_Builder.Property.GETTER_NAME)) {
+      if (!_unsetProperties.contains(Property_Builder.Property.GETTER_NAME)) {
         result.append("getterName=").append(getterName).append(", ");
       }
       if (codeGenerator != null) {
         result.append("codeGenerator=").append(codeGenerator).append(", ");
       }
-      if (!_unsetProperties.contains(Metadata_Property_Builder.Property.FULLY_CHECKED_CAST)) {
+      if (!_unsetProperties.contains(Property_Builder.Property.FULLY_CHECKED_CAST)) {
         result.append("fullyCheckedCast=").append(fullyCheckedCast).append(", ");
       }
       return result

--- a/src/main/java/org/inferred/freebuilder/processor/SetMultimapProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetMultimapProperty.java
@@ -147,17 +147,17 @@ class SetMultimapProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addPut(code, datatype);
-    addSingleKeyPutAll(code, datatype);
-    addMultimapPutAll(code, datatype);
-    addRemove(code, datatype);
-    addRemoveAll(code, datatype);
-    addMutate(code, datatype);
-    addClear(code, datatype);
-    addGetter(code, datatype);
+    addPut(code);
+    addSingleKeyPutAll(code);
+    addMultimapPutAll(code);
+    addRemove(code);
+    addRemoveAll(code);
+    addMutate(code);
+    addClear(code);
+    addGetter(code);
   }
 
-  private void addPut(SourceBuilder code, Datatype datatype) {
+  private void addPut(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds a {@code key}-{@code value} mapping to the multimap to be returned")
@@ -198,7 +198,7 @@ class SetMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addSingleKeyPutAll(SourceBuilder code, Datatype datatype) {
+  private void addSingleKeyPutAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds a collection of {@code values} with the same {@code key} to the")
@@ -228,7 +228,7 @@ class SetMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMultimapPutAll(SourceBuilder code, Datatype datatype) {
+  private void addMultimapPutAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each mapping in {@code multimap} to the multimap to be returned from")
@@ -257,7 +257,7 @@ class SetMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addRemove(SourceBuilder code, Datatype datatype) {
+  private void addRemove(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes a single key-value pair with the key {@code key} and the value"
@@ -296,7 +296,7 @@ class SetMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addRemoveAll(SourceBuilder code, Datatype datatype) {
+  private void addRemoveAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes all values associated with the key {@code key} from the multimap to")
@@ -322,7 +322,7 @@ class SetMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMutate(SourceBuilder code, Datatype datatype) {
+  private void addMutate(SourceBuilder code) {
     if (!code.feature(FUNCTION_PACKAGE).consumer().isPresent()) {
       return;
     }
@@ -358,7 +358,7 @@ class SetMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Datatype datatype) {
+  private void addClear(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes all of the mappings from the multimap to be returned from")
@@ -372,7 +372,7 @@ class SetMultimapProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the multimap that will be returned by")

--- a/src/main/java/org/inferred/freebuilder/processor/SetMultimapProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetMultimapProperty.java
@@ -40,7 +40,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.excerpt.CheckedSetMultimap;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;

--- a/src/main/java/org/inferred/freebuilder/processor/SetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetProperty.java
@@ -40,7 +40,6 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.diamon
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.excerpt.CheckedSet;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;

--- a/src/main/java/org/inferred/freebuilder/processor/SetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetProperty.java
@@ -165,16 +165,16 @@ class SetProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addAdd(code, datatype);
-    addVarargsAdd(code, datatype);
-    addAddAllMethods(code, datatype);
-    addRemove(code, datatype);
-    addMutator(code, datatype);
-    addClear(code, datatype);
-    addGetter(code, datatype);
+    addAdd(code);
+    addVarargsAdd(code);
+    addAddAllMethods(code);
+    addRemove(code);
+    addMutator(code);
+    addClear(code);
+    addGetter(code);
   }
 
-  private void addAdd(SourceBuilder code, Datatype datatype) {
+  private void addAdd(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds {@code element} to the set to be returned from %s.",
@@ -210,7 +210,7 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addVarargsAdd(SourceBuilder code, Datatype datatype) {
+  private void addVarargsAdd(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the set to be returned from")
@@ -254,17 +254,17 @@ class SetProperty extends PropertyCodeGenerator {
     code.addLine("}");
   }
 
-  private void addAddAllMethods(SourceBuilder code, Datatype datatype) {
+  private void addAddAllMethods(SourceBuilder code) {
     if (code.feature(SOURCE_LEVEL).stream().isPresent()) {
-      addSpliteratorAddAll(code, datatype);
-      addStreamAddAll(code, datatype);
+      addSpliteratorAddAll(code);
+      addStreamAddAll(code);
     }
-    addIterableAddAll(code, datatype);
+    addIterableAddAll(code);
   }
 
-  private void addSpliteratorAddAll(SourceBuilder code, Datatype datatype) {
+  private void addSpliteratorAddAll(SourceBuilder code) {
     QualifiedName spliterator = code.feature(SOURCE_LEVEL).spliterator().get();
-    addJavadocForAddAll(code, datatype);
+    addJavadocForAddAll(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
             datatype.getBuilder(),
             addAllMethod(property),
@@ -275,9 +275,9 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addStreamAddAll(SourceBuilder code, Datatype datatype) {
+  private void addStreamAddAll(SourceBuilder code) {
     QualifiedName baseStream = code.feature(SOURCE_LEVEL).baseStream().get();
-    addJavadocForAddAll(code, datatype);
+    addJavadocForAddAll(code);
     code.addLine("public %s %s(%s<? extends %s, ?> elements) {",
             datatype.getBuilder(),
             addAllMethod(property),
@@ -287,8 +287,8 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addIterableAddAll(SourceBuilder code, Datatype datatype) {
-    addJavadocForAddAll(code, datatype);
+  private void addIterableAddAll(SourceBuilder code) {
+    addJavadocForAddAll(code);
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
             datatype.getBuilder(),
@@ -300,7 +300,7 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addJavadocForAddAll(SourceBuilder code, Datatype datatype) {
+  private void addJavadocForAddAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the set to be returned from")
@@ -314,7 +314,7 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine(" */");
   }
 
-  private void addRemove(SourceBuilder code, Datatype datatype) {
+  private void addRemove(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes {@code element} from the set to be returned from %s.",
@@ -348,7 +348,7 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMutator(SourceBuilder code, Datatype datatype) {
+  private void addMutator(SourceBuilder code) {
     if (!code.feature(FUNCTION_PACKAGE).consumer().isPresent()) {
       return;
     }
@@ -391,7 +391,7 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Datatype datatype) {
+  private void addClear(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Clears the set to be returned from %s.",
@@ -413,7 +413,7 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the set that will be returned by")

--- a/src/main/java/org/inferred/freebuilder/processor/SetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetProperty.java
@@ -90,7 +90,7 @@ class SetProperty extends PropertyCodeGenerator {
           config.getTypes());
 
       return Optional.of(new SetProperty(
-          config.getMetadata(),
+          config.getDatatype(),
           config.getProperty(),
           elementType,
           unboxedType,
@@ -135,7 +135,7 @@ class SetProperty extends PropertyCodeGenerator {
   private final boolean overridesVarargsAddMethod;
 
   SetProperty(
-      Metadata metadata,
+      Datatype datatype,
       Property property,
       TypeMirror elementType,
       Optional<TypeMirror> unboxedType,
@@ -143,7 +143,7 @@ class SetProperty extends PropertyCodeGenerator {
       boolean needsSafeVarargs,
       boolean overridesAddMethod,
       boolean overridesVarargsAddMethod) {
-    super(metadata, property);
+    super(datatype, property);
     this.elementType = elementType;
     this.unboxedType = unboxedType;
     this.mutatorType = mutatorType;
@@ -165,31 +165,31 @@ class SetProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addAdd(code, metadata);
-    addVarargsAdd(code, metadata);
-    addAddAllMethods(code, metadata);
-    addRemove(code, metadata);
-    addMutator(code, metadata);
-    addClear(code, metadata);
-    addGetter(code, metadata);
+    addAdd(code, datatype);
+    addVarargsAdd(code, datatype);
+    addAddAllMethods(code, datatype);
+    addRemove(code, datatype);
+    addMutator(code, datatype);
+    addClear(code, datatype);
+    addGetter(code, datatype);
   }
 
-  private void addAdd(SourceBuilder code, Metadata metadata) {
+  private void addAdd(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds {@code element} to the set to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * If the set already contains {@code element}, then {@code %s}",
             addMethod(property))
         .addLine(" * has no effect (only the previously added element is retained).")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code element} is null");
     }
     code.addLine(" */")
         .addLine("public %s %s(%s element) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addMethod(property),
             unboxedType.or(elementType));
     Block body = methodBody(code, "element");
@@ -205,20 +205,20 @@ class SetProperty extends PropertyCodeGenerator {
       body.add(checkNotNullPreamble("element"))
           .addLine("  %s.add(%s);", property.getField(), checkNotNullInline("element"));
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addVarargsAdd(SourceBuilder code, Metadata metadata) {
+  private void addVarargsAdd(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the set to be returned from")
         .addLine(" * %s, ignoring duplicate elements",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * (only the first duplicate element is added).")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
           .addLine(" *     null element");
@@ -238,7 +238,7 @@ class SetProperty extends PropertyCodeGenerator {
       code.add("final ");
     }
     code.add("%s %s(%s... elements) {\n",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addMethod(property),
             unboxedType.or(elementType));
     Optional<Class<?>> arrayUtils = code.feature(GUAVA).arrayUtils(unboxedType.or(elementType));
@@ -249,37 +249,37 @@ class SetProperty extends PropertyCodeGenerator {
       code.addLine("  for (%s element : elements) {", elementType)
           .addLine("    %s(element);", addMethod(property))
           .addLine("  }")
-          .addLine("  return (%s) this;", metadata.getBuilder());
+          .addLine("  return (%s) this;", datatype.getBuilder());
     }
     code.addLine("}");
   }
 
-  private void addAddAllMethods(SourceBuilder code, Metadata metadata) {
+  private void addAddAllMethods(SourceBuilder code, Datatype datatype) {
     if (code.feature(SOURCE_LEVEL).stream().isPresent()) {
-      addSpliteratorAddAll(code, metadata);
-      addStreamAddAll(code, metadata);
+      addSpliteratorAddAll(code, datatype);
+      addStreamAddAll(code, datatype);
     }
-    addIterableAddAll(code, metadata);
+    addIterableAddAll(code, datatype);
   }
 
-  private void addSpliteratorAddAll(SourceBuilder code, Metadata metadata) {
+  private void addSpliteratorAddAll(SourceBuilder code, Datatype datatype) {
     QualifiedName spliterator = code.feature(SOURCE_LEVEL).spliterator().get();
-    addJavadocForAddAll(code, metadata);
+    addJavadocForAddAll(code, datatype);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addAllMethod(property),
             spliterator,
             elementType)
         .addLine("  elements.forEachRemaining(this::%s);", addMethod(property))
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addStreamAddAll(SourceBuilder code, Metadata metadata) {
+  private void addStreamAddAll(SourceBuilder code, Datatype datatype) {
     QualifiedName baseStream = code.feature(SOURCE_LEVEL).baseStream().get();
-    addJavadocForAddAll(code, metadata);
+    addJavadocForAddAll(code, datatype);
     code.addLine("public %s %s(%s<? extends %s, ?> elements) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addAllMethod(property),
             baseStream,
             elementType)
@@ -287,47 +287,47 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addIterableAddAll(SourceBuilder code, Metadata metadata) {
-    addJavadocForAddAll(code, metadata);
+  private void addIterableAddAll(SourceBuilder code, Datatype datatype) {
+    addJavadocForAddAll(code, datatype);
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addAllMethod(property),
             Iterable.class,
             elementType)
         .add(Excerpts.forEach(unboxedType.or(elementType), "elements", addMethod(property)))
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addJavadocForAddAll(SourceBuilder code, Metadata metadata) {
+  private void addJavadocForAddAll(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the set to be returned from")
         .addLine(" * %s, ignoring duplicate elements",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * (only the first duplicate element is added).")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
         .addLine(" *     null element")
         .addLine(" */");
   }
 
-  private void addRemove(SourceBuilder code, Metadata metadata) {
+  private void addRemove(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes {@code element} from the set to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * Does nothing if {@code element} is not a member of the set.")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code element} is null");
     }
     code.addLine(" */")
         .addLine("public %s %s(%s element) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             removeMethod(property),
             unboxedType.or(elementType));
     Block body = methodBody(code, "element");
@@ -343,19 +343,19 @@ class SetProperty extends PropertyCodeGenerator {
       body.add(checkNotNullPreamble("element"))
           .addLine("  %s.remove(%s);", property.getField(), checkNotNullInline("element"));
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addMutator(SourceBuilder code, Metadata metadata) {
+  private void addMutator(SourceBuilder code, Datatype datatype) {
     if (!code.feature(FUNCTION_PACKAGE).consumer().isPresent()) {
       return;
     }
     code.addLine("")
         .addLine("/**")
         .addLine(" * Applies {@code mutator} to the set to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
         .addLine(" * <p>This method mutates the set in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
@@ -366,7 +366,7 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine(" * @throws NullPointerException if {@code mutator} is null")
         .addLine(" */")
         .addLine("public %s %s(%s mutator) {",
-            metadata.getBuilder(), mutator(property), mutatorType.getFunctionalInterface());
+            datatype.getBuilder(), mutator(property), mutatorType.getFunctionalInterface());
     Block body = methodBody(code, "mutator");
     if (body.feature(GUAVA).isAvailable()) {
       body.addLine("  if (%s instanceof %s) {", property.getField(), ImmutableSet.class)
@@ -386,20 +386,20 @@ class SetProperty extends PropertyCodeGenerator {
               addMethod(property))
           .addLine("  mutator.%s(%s);", mutatorType.getMethodName(), property.getField());
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Metadata metadata) {
+  private void addClear(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Clears the set to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */")
-        .addLine("public %s %s() {", metadata.getBuilder(), clearMethod(property));
+        .addLine("public %s %s() {", datatype.getBuilder(), clearMethod(property));
     if (code.feature(GUAVA).isAvailable()) {
       code.addLine("if (%s instanceof %s) {", property.getField(), ImmutableSet.class)
           .addLine("  %s = %s.of();", property.getField(), ImmutableSet.class)
@@ -409,15 +409,15 @@ class SetProperty extends PropertyCodeGenerator {
     if (code.feature(GUAVA).isAvailable()) {
       code.addLine("}");
     }
-    code.addLine("  return (%s) this;", metadata.getBuilder())
+    code.addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Metadata metadata) {
+  private void addGetter(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the set that will be returned by")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * Changes to this builder will be reflected in the view.")
         .addLine(" */")
         .addLine("public %s<%s> %s() {", Set.class, elementType, getter(property));
@@ -447,7 +447,7 @@ class SetProperty extends PropertyCodeGenerator {
     if (code.feature(GUAVA).isAvailable()) {
       code.addLine("if (%s instanceof %s && %s == %s.<%s>of()) {",
               value,
-              metadata.getValueType().getQualifiedName(),
+              datatype.getValueType().getQualifiedName(),
               property.getField(),
               ImmutableSet.class,
               elementType)
@@ -463,7 +463,7 @@ class SetProperty extends PropertyCodeGenerator {
 
   @Override
   public void addMergeFromBuilder(Block code, String builder) {
-    Excerpt base = Declarations.upcastToGeneratedBuilder(code, metadata, builder);
+    Excerpt base = Declarations.upcastToGeneratedBuilder(code, datatype, builder);
     code.addLine("%s(%s);", addAllMethod(property), property.getField().on(base));
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
@@ -42,7 +42,6 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.nested
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSortedSet;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.excerpt.CheckedNavigableSet;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;

--- a/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
@@ -163,17 +163,17 @@ class SortedSetProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addSetComparator(code, datatype);
-    addAdd(code, datatype);
-    addVarargsAdd(code, datatype);
-    addAddAllMethods(code, datatype);
-    addRemove(code, datatype);
-    addMutator(code, datatype);
-    addClear(code, datatype);
-    addGetter(code, datatype);
+    addSetComparator(code);
+    addAdd(code);
+    addVarargsAdd(code);
+    addAddAllMethods(code);
+    addRemove(code);
+    addMutator(code);
+    addClear(code);
+    addGetter(code);
   }
 
-  private void addSetComparator(SourceBuilder code, Datatype datatype) {
+  private void addSetComparator(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the comparator of the set to be returned from %s.",
@@ -218,7 +218,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addAdd(SourceBuilder code, Datatype datatype) {
+  private void addAdd(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds {@code element} to the set to be returned from %s.",
@@ -263,7 +263,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
     code.addLine("  }");
   }
 
-  private void addVarargsAdd(SourceBuilder code, Datatype datatype) {
+  private void addVarargsAdd(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the set to be returned from")
@@ -307,17 +307,17 @@ class SortedSetProperty extends PropertyCodeGenerator {
     code.addLine("}");
   }
 
-  private void addAddAllMethods(SourceBuilder code, Datatype datatype) {
+  private void addAddAllMethods(SourceBuilder code) {
     if (code.feature(SOURCE_LEVEL).stream().isPresent()) {
-      addSpliteratorAddAll(code, datatype);
-      addStreamAddAll(code, datatype);
+      addSpliteratorAddAll(code);
+      addStreamAddAll(code);
     }
-    addIterableAddAll(code, datatype);
+    addIterableAddAll(code);
   }
 
-  private void addSpliteratorAddAll(SourceBuilder code, Datatype datatype) {
+  private void addSpliteratorAddAll(SourceBuilder code) {
     QualifiedName spliterator = code.feature(SOURCE_LEVEL).spliterator().get();
-    addJavadocForAddAll(code, datatype);
+    addJavadocForAddAll(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
             datatype.getBuilder(),
             addAllMethod(property),
@@ -328,9 +328,9 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addStreamAddAll(SourceBuilder code, Datatype datatype) {
+  private void addStreamAddAll(SourceBuilder code) {
     QualifiedName baseStream = code.feature(SOURCE_LEVEL).baseStream().get();
-    addJavadocForAddAll(code, datatype);
+    addJavadocForAddAll(code);
     code.addLine("public %s %s(%s<? extends %s, ?> elements) {",
             datatype.getBuilder(),
             addAllMethod(property),
@@ -340,8 +340,8 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addIterableAddAll(SourceBuilder code, Datatype datatype) {
-    addJavadocForAddAll(code, datatype);
+  private void addIterableAddAll(SourceBuilder code) {
+    addJavadocForAddAll(code);
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
             datatype.getBuilder(),
@@ -353,7 +353,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addJavadocForAddAll(SourceBuilder code, Datatype datatype) {
+  private void addJavadocForAddAll(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the set to be returned from")
@@ -367,7 +367,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine(" */");
   }
 
-  private void addRemove(SourceBuilder code, Datatype datatype) {
+  private void addRemove(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes {@code element} from the set to be returned from %s.",
@@ -396,7 +396,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addMutator(SourceBuilder code, Datatype datatype) {
+  private void addMutator(SourceBuilder code) {
     ParameterizedType consumer = code.feature(FUNCTION_PACKAGE).consumer().orNull();
     if (consumer == null) {
       return;
@@ -437,7 +437,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Datatype datatype) {
+  private void addClear(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Clears the set to be returned from %s.",
@@ -465,7 +465,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Datatype datatype) {
+  private void addGetter(SourceBuilder code) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the set that will be returned by")

--- a/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
@@ -94,7 +94,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
           config.getTypes());
 
       return Optional.of(new SortedSetProperty(
-          config.getMetadata(),
+          config.getDatatype(),
           config.getProperty(),
           elementType,
           unboxedType,
@@ -139,7 +139,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
   private final boolean overridesVarargsAddMethod;
 
   SortedSetProperty(
-      Metadata metadata,
+      Datatype datatype,
       Property property,
       TypeMirror elementType,
       Optional<TypeMirror> unboxedType,
@@ -147,7 +147,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
       boolean needsSafeVarargs,
       boolean overridesAddMethod,
       boolean overridesVarargsAddMethod) {
-    super(metadata, property);
+    super(datatype, property);
     this.elementType = elementType;
     this.unboxedType = unboxedType;
     this.mutatorType = mutatorType;
@@ -163,21 +163,21 @@ class SortedSetProperty extends PropertyCodeGenerator {
 
   @Override
   public void addBuilderFieldAccessors(SourceBuilder code) {
-    addSetComparator(code, metadata);
-    addAdd(code, metadata);
-    addVarargsAdd(code, metadata);
-    addAddAllMethods(code, metadata);
-    addRemove(code, metadata);
-    addMutator(code, metadata);
-    addClear(code, metadata);
-    addGetter(code, metadata);
+    addSetComparator(code, datatype);
+    addAdd(code, datatype);
+    addVarargsAdd(code, datatype);
+    addAddAllMethods(code, datatype);
+    addRemove(code, datatype);
+    addMutator(code, datatype);
+    addClear(code, datatype);
+    addGetter(code, datatype);
   }
 
-  private void addSetComparator(SourceBuilder code, Metadata metadata) {
+  private void addSetComparator(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Sets the comparator of the set to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
         .addLine(" * Pass in {@code null} to use the {@linkplain Comparable natural ordering}")
         .addLine(" * of the elements.")
@@ -187,13 +187,13 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine(" * (Note that this immutability is an implementation detail that may change in")
         .addLine(" * future; it should not be relied on for correctness.)")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws IllegalStateException if the set has been accessed at all,")
         .addLine(" *     whether by adding an element, setting the comparator, or calling")
         .addLine(" *     {@link #%s()}.", getter(property));
     code.addLine(" */")
         .addLine("protected %s %s(%s<? super %s> comparator) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             setComparatorMethod(property),
             Comparator.class,
             elementType);
@@ -213,27 +213,27 @@ class SortedSetProperty extends PropertyCodeGenerator {
       body.addLine("  %s = new %s%s(comparator);",
           property.getField(), TreeSet.class, diamondOperator(elementType));
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addAdd(SourceBuilder code, Metadata metadata) {
+  private void addAdd(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds {@code element} to the set to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * If the set already contains {@code element}, then {@code %s}",
             addMethod(property))
         .addLine(" * has no effect (only the previously added element is retained).")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code element} is null");
     }
     code.addLine(" */")
         .addLine("public %s %s(%s element) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addMethod(property),
             unboxedType.or(elementType));
     Block body = methodBody(code, "element");
@@ -244,7 +244,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
       body.add(checkNotNullPreamble("element"))
           .addLine("  %s.add(%s);", property.getField(), checkNotNullInline("element"));
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
@@ -263,15 +263,15 @@ class SortedSetProperty extends PropertyCodeGenerator {
     code.addLine("  }");
   }
 
-  private void addVarargsAdd(SourceBuilder code, Metadata metadata) {
+  private void addVarargsAdd(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the set to be returned from")
         .addLine(" * %s, ignoring duplicate elements",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * (only the first duplicate element is added).")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
           .addLine(" *     null element");
@@ -291,7 +291,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
       code.add("final ");
     }
     code.add("%s %s(%s... elements) {\n",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addMethod(property),
             unboxedType.or(elementType));
     Optional<Class<?>> arrayUtils = code.feature(GUAVA).arrayUtils(unboxedType.or(elementType));
@@ -302,37 +302,37 @@ class SortedSetProperty extends PropertyCodeGenerator {
       code.addLine("  for (%s element : elements) {", elementType)
           .addLine("    %s(element);", addMethod(property))
           .addLine("  }")
-          .addLine("  return (%s) this;", metadata.getBuilder());
+          .addLine("  return (%s) this;", datatype.getBuilder());
     }
     code.addLine("}");
   }
 
-  private void addAddAllMethods(SourceBuilder code, Metadata metadata) {
+  private void addAddAllMethods(SourceBuilder code, Datatype datatype) {
     if (code.feature(SOURCE_LEVEL).stream().isPresent()) {
-      addSpliteratorAddAll(code, metadata);
-      addStreamAddAll(code, metadata);
+      addSpliteratorAddAll(code, datatype);
+      addStreamAddAll(code, datatype);
     }
-    addIterableAddAll(code, metadata);
+    addIterableAddAll(code, datatype);
   }
 
-  private void addSpliteratorAddAll(SourceBuilder code, Metadata metadata) {
+  private void addSpliteratorAddAll(SourceBuilder code, Datatype datatype) {
     QualifiedName spliterator = code.feature(SOURCE_LEVEL).spliterator().get();
-    addJavadocForAddAll(code, metadata);
+    addJavadocForAddAll(code, datatype);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addAllMethod(property),
             spliterator,
             elementType)
         .addLine("  elements.forEachRemaining(this::%s);", addMethod(property))
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addStreamAddAll(SourceBuilder code, Metadata metadata) {
+  private void addStreamAddAll(SourceBuilder code, Datatype datatype) {
     QualifiedName baseStream = code.feature(SOURCE_LEVEL).baseStream().get();
-    addJavadocForAddAll(code, metadata);
+    addJavadocForAddAll(code, datatype);
     code.addLine("public %s %s(%s<? extends %s, ?> elements) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addAllMethod(property),
             baseStream,
             elementType)
@@ -340,47 +340,47 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine("}");
   }
 
-  private void addIterableAddAll(SourceBuilder code, Metadata metadata) {
-    addJavadocForAddAll(code, metadata);
+  private void addIterableAddAll(SourceBuilder code, Datatype datatype) {
+    addJavadocForAddAll(code, datatype);
     addAccessorAnnotations(code);
     code.addLine("public %s %s(%s<? extends %s> elements) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             addAllMethod(property),
             Iterable.class,
             elementType)
         .add(Excerpts.forEach(unboxedType.or(elementType), "elements", addMethod(property)))
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addJavadocForAddAll(SourceBuilder code, Metadata metadata) {
+  private void addJavadocForAddAll(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Adds each element of {@code elements} to the set to be returned from")
         .addLine(" * %s, ignoring duplicate elements",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * (only the first duplicate element is added).")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" * @throws NullPointerException if {@code elements} is null or contains a")
         .addLine(" *     null element")
         .addLine(" */");
   }
 
-  private void addRemove(SourceBuilder code, Metadata metadata) {
+  private void addRemove(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Removes {@code element} from the set to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * Does nothing if {@code element} is not a member of the set.")
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName());
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName());
     if (!unboxedType.isPresent()) {
       code.addLine(" * @throws NullPointerException if {@code element} is null");
     }
     code.addLine(" */")
         .addLine("public %s %s(%s element) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             removeMethod(property),
             unboxedType.or(elementType));
     Block body = methodBody(code, "mutator");
@@ -391,12 +391,12 @@ class SortedSetProperty extends PropertyCodeGenerator {
       body.add(checkNotNullPreamble("element"))
           .addLine("  %s.remove(%s);", property.getField(), checkNotNullInline("element"));
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addMutator(SourceBuilder code, Metadata metadata) {
+  private void addMutator(SourceBuilder code, Datatype datatype) {
     ParameterizedType consumer = code.feature(FUNCTION_PACKAGE).consumer().orNull();
     if (consumer == null) {
       return;
@@ -404,7 +404,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Applies {@code mutator} to the set to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
         .addLine(" * <p>This method mutates the set in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
@@ -415,7 +415,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine(" * @throws NullPointerException if {@code mutator} is null")
         .addLine(" */")
         .addLine("public %s %s(%s mutator) {",
-            metadata.getBuilder(),
+            datatype.getBuilder(),
             mutator(property),
             mutatorType.getFunctionalInterface());
     Block body = methodBody(code, "mutator");
@@ -432,20 +432,20 @@ class SortedSetProperty extends PropertyCodeGenerator {
               addMethod(property))
           .addLine("  mutator.%s(%s);", mutatorType.getMethodName(), property.getField());
     }
-    body.addLine("  return (%s) this;", metadata.getBuilder());
+    body.addLine("  return (%s) this;", datatype.getBuilder());
     code.add(body)
         .addLine("}");
   }
 
-  private void addClear(SourceBuilder code, Metadata metadata) {
+  private void addClear(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Clears the set to be returned from %s.",
-            metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+            datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" *")
-        .addLine(" * @return this {@code %s} object", metadata.getBuilder().getSimpleName())
+        .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */")
-        .addLine("public %s %s() {", metadata.getBuilder(), clearMethod(property));
+        .addLine("public %s %s() {", datatype.getBuilder(), clearMethod(property));
     if (code.feature(GUAVA).isAvailable()) {
       code.addLine("  if (%s instanceof %s) {", property.getField(), ImmutableSortedSet.class)
           .addLine("    if (%s.isEmpty()) {", property.getField())
@@ -461,15 +461,15 @@ class SortedSetProperty extends PropertyCodeGenerator {
     code.addLine("  if (%s != null) {", property.getField())
         .addLine("    %s.clear();", property.getField())
         .addLine("  }")
-        .addLine("  return (%s) this;", metadata.getBuilder())
+        .addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
   }
 
-  private void addGetter(SourceBuilder code, Metadata metadata) {
+  private void addGetter(SourceBuilder code, Datatype datatype) {
     code.addLine("")
         .addLine("/**")
         .addLine(" * Returns an unmodifiable view of the set that will be returned by")
-        .addLine(" * %s.", metadata.getType().javadocNoArgMethodLink(property.getGetterName()))
+        .addLine(" * %s.", datatype.getType().javadocNoArgMethodLink(property.getGetterName()))
         .addLine(" * Changes to this builder will be reflected in the view.")
         .addLine(" */")
         .addLine("public %s<%s> %s() {", SortedSet.class, elementType, getter(property));
@@ -511,7 +511,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
   @Override
   public void addMergeFromValue(Block code, String value) {
     if (code.feature(GUAVA).isAvailable()) {
-      code.addLine("if (%s instanceof %s", value, metadata.getValueType().getQualifiedName())
+      code.addLine("if (%s instanceof %s", value, datatype.getValueType().getQualifiedName())
           .addLine("      && (%s == null", property.getField())
           .addLine("          || (%s instanceof %s ",
               property.getField(), ImmutableSortedSet.class)
@@ -537,7 +537,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
 
   @Override
   public void addMergeFromBuilder(Block code, String builder) {
-    Excerpt base = Declarations.upcastToGeneratedBuilder(code, metadata, builder);
+    Excerpt base = Declarations.upcastToGeneratedBuilder(code, datatype, builder);
     code.addLine("if (%s != null) {", property.getField().on(base))
         .addLine("  %s(%s);", addAllMethod(property), property.getField().on(base))
         .addLine("}");

--- a/src/main/java/org/inferred/freebuilder/processor/ToStringGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ToStringGenerator.java
@@ -11,7 +11,6 @@ import static org.inferred.freebuilder.processor.util.Block.methodBody;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.SourceBuilder;

--- a/src/main/java/org/inferred/freebuilder/processor/naming/BeanConvention.java
+++ b/src/main/java/org/inferred/freebuilder/processor/naming/BeanConvention.java
@@ -19,7 +19,7 @@ import static javax.tools.Diagnostic.Kind.ERROR;
 
 import com.google.common.base.Optional;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
+import org.inferred.freebuilder.processor.Property;
 import org.inferred.freebuilder.processor.util.IsInvalidTypeVisitor;
 import org.inferred.freebuilder.processor.util.ModelUtils;
 

--- a/src/main/java/org/inferred/freebuilder/processor/naming/NamingConvention.java
+++ b/src/main/java/org/inferred/freebuilder/processor/naming/NamingConvention.java
@@ -17,7 +17,7 @@ package org.inferred.freebuilder.processor.naming;
 
 import com.google.common.base.Optional;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
+import org.inferred.freebuilder.processor.Property;
 
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;

--- a/src/main/java/org/inferred/freebuilder/processor/naming/PrefixlessConvention.java
+++ b/src/main/java/org/inferred/freebuilder/processor/naming/PrefixlessConvention.java
@@ -20,7 +20,7 @@ import static org.inferred.freebuilder.processor.util.ModelUtils.getReturnType;
 
 import com.google.common.base.Optional;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
+import org.inferred.freebuilder.processor.Property;
 
 import java.util.Set;
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/FunctionalType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/FunctionalType.java
@@ -31,7 +31,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 /**
- * Metadata about a functional interface.
+ * Datatype about a functional interface.
  */
 public class FunctionalType extends ValueType {
 

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.fail;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.inferred.freebuilder.processor.Analyser.CannotGenerateCodeException;
@@ -164,7 +165,8 @@ public class AnalyserTest {
                 generatedType.nestedType("Partial"),
                 generatedType.nestedType("Property"),
                 generatedType.nestedType("Value"))
-            .build()));
+            .build(),
+        ImmutableList.of()));
   }
 
   @Test
@@ -202,7 +204,8 @@ public class AnalyserTest {
                 generatedType.nestedType("Partial"),
                 generatedType.nestedType("Property"),
                 generatedType.nestedType("Value"))
-            .build()));
+            .build(),
+        ImmutableList.of()));
   }
 
   @Test
@@ -309,7 +312,7 @@ public class AnalyserTest {
         "}"));
 
     assertTrue(builder.getDatatype().getHasToBuilderMethod());
-    assertThat(builder.getDatatype().getProperties()).isEmpty();
+    assertThat(builder.getProperties()).isEmpty();
   }
 
   @Test
@@ -322,7 +325,7 @@ public class AnalyserTest {
         "}"));
 
     assertTrue(builder.getDatatype().getHasToBuilderMethod());
-    assertThat(builder.getDatatype().getProperties()).isEmpty();
+    assertThat(builder.getProperties()).isEmpty();
   }
 
   @Test
@@ -366,7 +369,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
 
     Property age = properties.get("age");
@@ -396,7 +399,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
 
     Property age = properties.get("age");
@@ -426,7 +429,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("customURLTemplate", "top50Sites");
     assertEquals("CUSTOM_URL_TEMPLATE", properties.get("customURLTemplate").getAllCapsName());
     assertEquals("TOP50_SITES", properties.get("top50Sites").getAllCapsName());
@@ -442,7 +445,7 @@ public class AnalyserTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals(model.typeMirror(int.class), properties.get("age").getType());
     assertEquals("Age", properties.get("age").getCapitalizedName());
@@ -461,7 +464,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("available");
     assertEquals(model.typeMirror(boolean.class), properties.get("available").getType());
     assertEquals("Available", properties.get("available").getCapitalizedName());
@@ -480,7 +483,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).isEmpty();
+    assertThat(builder.getProperties()).isEmpty();
   }
 
   @Test
@@ -492,7 +495,7 @@ public class AnalyserTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertEquals(DefaultProperty.class, properties.get("name").getCodeGenerator().getClass());
   }
 
@@ -507,7 +510,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).isEmpty();
+    assertThat(builder.getProperties()).isEmpty();
   }
 
   @Test
@@ -521,7 +524,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).isEmpty();
+    assertThat(builder.getProperties()).isEmpty();
   }
 
   @Test
@@ -533,7 +536,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).isEmpty();
+    assertThat(builder.getProperties()).isEmpty();
     messager.verifyError("getName", "Getter methods must not be void on @FreeBuilder types");
   }
 
@@ -546,7 +549,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).isEmpty();
+    assertThat(builder.getProperties()).isEmpty();
     messager.verifyError(
         "isName", "Getter methods starting with 'is' must return a boolean on @FreeBuilder types");
   }
@@ -560,7 +563,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).isEmpty();
+    assertThat(builder.getProperties()).isEmpty();
     messager.verifyError("getName", "Getter methods cannot take parameters on @FreeBuilder types");
   }
 
@@ -573,7 +576,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("get");
     assertEquals("Get", properties.get("get").getCapitalizedName());
     assertEquals("get", properties.get("get").getGetterName());
@@ -589,7 +592,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("getter");
     assertEquals("Getter", properties.get("getter").getCapitalizedName());
     assertEquals("getter", properties.get("getter").getGetterName());
@@ -605,7 +608,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("issue");
     assertEquals("ISSUE", properties.get("issue").getAllCapsName());
     assertEquals("Issue", properties.get("issue").getCapitalizedName());
@@ -622,7 +625,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("getürkt");
     assertEquals("GETÜRKT", properties.get("getürkt").getAllCapsName());
     assertEquals("Getürkt", properties.get("getürkt").getCapitalizedName());
@@ -639,7 +642,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("is");
     assertEquals("IS", properties.get("is").getAllCapsName());
     assertEquals("Is", properties.get("is").getCapitalizedName());
@@ -659,7 +662,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals("AGE", properties.get("age").getAllCapsName());
     assertEquals("Age", properties.get("age").getCapitalizedName());
@@ -687,7 +690,7 @@ public class AnalyserTest {
         "  }",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertEquals(Type.REQUIRED, properties.get("name").getCodeGenerator().getType());
     assertEquals(Type.REQUIRED, properties.get("age").getCodeGenerator().getType());
   }
@@ -706,7 +709,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
   }
 
@@ -723,7 +726,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("property");
     assertEquals("java.lang.String", properties.get("property").getType().toString());
   }
@@ -1051,7 +1054,7 @@ public class AnalyserTest {
         "  public class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name");
     assertEquals("java.lang.String", properties.get("name").getType().toString());
     assertNull(properties.get("name").getBoxedType());
@@ -1087,7 +1090,7 @@ public class AnalyserTest {
     assertEquals("com.example.DataType<A, B>", builder.getDatatype().getType().toString());
     assertEquals("com.example.DataType_Builder.Value<A, B>",
         builder.getDatatype().getValueType().toString());
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals("B", properties.get("age").getType().toString());
     assertNull(properties.get("age").getBoxedType());
@@ -1146,7 +1149,7 @@ public class AnalyserTest {
     assertEquals("com.example.DataType<A, B>", builder.getDatatype().getType().toString());
     assertEquals("com.example.DataType_Builder.Value<A, B>",
         builder.getDatatype().getValueType().toString());
-    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals("B", properties.get("age").getType().toString());
     assertNull(properties.get("age").getBoxedType());
@@ -1331,8 +1334,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    assertThat(builder.getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
@@ -1346,8 +1349,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    assertThat(builder.getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
@@ -1361,8 +1364,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    assertThat(builder.getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
@@ -1376,8 +1379,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    assertThat(builder.getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isFalse();
   }
@@ -1391,8 +1394,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    assertThat(builder.getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isFalse();
   }
@@ -1406,8 +1409,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    assertThat(builder.getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
@@ -1421,8 +1424,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getDatatype().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    assertThat(builder.getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isFalse();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -21,8 +21,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.inferred.freebuilder.processor.BuilderFactory.BUILDER_METHOD;
 import static org.inferred.freebuilder.processor.BuilderFactory.NEW_BUILDER_METHOD;
 import static org.inferred.freebuilder.processor.BuilderFactory.NO_ARGS_CONSTRUCTOR;
-import static org.inferred.freebuilder.processor.Metadata.Visibility.PACKAGE;
-import static org.inferred.freebuilder.processor.Metadata.Visibility.PRIVATE;
+import static org.inferred.freebuilder.processor.Datatype.Visibility.PACKAGE;
+import static org.inferred.freebuilder.processor.Datatype.Visibility.PRIVATE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -35,8 +35,8 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import org.inferred.freebuilder.processor.Analyser.CannotGenerateCodeException;
-import org.inferred.freebuilder.processor.Metadata.StandardMethod;
-import org.inferred.freebuilder.processor.Metadata.UnderrideLevel;
+import org.inferred.freebuilder.processor.Datatype.StandardMethod;
+import org.inferred.freebuilder.processor.Datatype.UnderrideLevel;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.QualifiedName;
@@ -147,7 +147,7 @@ public class AnalyserTest {
     QualifiedName dataType = QualifiedName.of("com.example", "DataType");
     QualifiedName generatedType = QualifiedName.of("com.example", "DataType_Builder");
     assertThat(builder).isEqualTo(new GeneratedBuilder(
-        new Metadata.Builder()
+        new Datatype.Builder()
             .setBuilder(dataType.nestedType("Builder").withParameters())
             .setBuilderFactory(NO_ARGS_CONSTRUCTOR)
             .setBuilderSerializable(false)
@@ -185,7 +185,7 @@ public class AnalyserTest {
     QualifiedName dataType = QualifiedName.of("com.example", "DataType");
     QualifiedName generatedType = QualifiedName.of("com.example", "DataType_Builder");
     assertThat(builder).isEqualTo(new GeneratedBuilder(
-        new Metadata.Builder()
+        new Datatype.Builder()
             .setBuilder(dataType.nestedType("Builder").withParameters(kVar, vVar))
             .setBuilderFactory(NO_ARGS_CONSTRUCTOR)
             .setBuilderSerializable(false)
@@ -215,10 +215,10 @@ public class AnalyserTest {
         "}"));
 
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        builder.getMetadata().getGeneratedBuilder());
+        builder.getDatatype().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        builder.getMetadata().getBuilder().getQualifiedName().toString());
-    assertTrue(builder.getMetadata().isBuilderSerializable());
+        builder.getDatatype().getBuilder().getQualifiedName().toString());
+    assertTrue(builder.getDatatype().isBuilderSerializable());
   }
 
   @Test
@@ -231,12 +231,12 @@ public class AnalyserTest {
         "}"));
 
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        builder.getMetadata().getGeneratedBuilder());
+        builder.getDatatype().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        builder.getMetadata().getBuilder().getQualifiedName().toString());
-    assertThat(builder.getMetadata().isExtensible()).isTrue();
-    assertThat(builder.getMetadata().getBuilderFactory()).hasValue(BUILDER_METHOD);
-    assertFalse(builder.getMetadata().isBuilderSerializable());
+        builder.getDatatype().getBuilder().getQualifiedName().toString());
+    assertThat(builder.getDatatype().isExtensible()).isTrue();
+    assertThat(builder.getDatatype().getBuilderFactory()).hasValue(BUILDER_METHOD);
+    assertFalse(builder.getDatatype().isBuilderSerializable());
   }
 
   @Test
@@ -252,12 +252,12 @@ public class AnalyserTest {
         "}"));
 
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        builder.getMetadata().getGeneratedBuilder());
+        builder.getDatatype().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        builder.getMetadata().getBuilder().getQualifiedName().toString());
-    assertThat(builder.getMetadata().isExtensible()).isTrue();
-    assertThat(builder.getMetadata().getBuilderFactory()).hasValue(BUILDER_METHOD);
-    assertFalse(builder.getMetadata().isBuilderSerializable());
+        builder.getDatatype().getBuilder().getQualifiedName().toString());
+    assertThat(builder.getDatatype().isExtensible()).isTrue();
+    assertThat(builder.getDatatype().getBuilderFactory()).hasValue(BUILDER_METHOD);
+    assertFalse(builder.getDatatype().isBuilderSerializable());
   }
 
   @Test
@@ -273,12 +273,12 @@ public class AnalyserTest {
         "}"));
 
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        builder.getMetadata().getGeneratedBuilder());
+        builder.getDatatype().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        builder.getMetadata().getBuilder().getQualifiedName().toString());
-    assertThat(builder.getMetadata().isExtensible()).isFalse();
-    assertThat(builder.getMetadata().getBuilderFactory()).hasValue(BUILDER_METHOD);
-    assertFalse(builder.getMetadata().isBuilderSerializable());
+        builder.getDatatype().getBuilder().getQualifiedName().toString());
+    assertThat(builder.getDatatype().isExtensible()).isFalse();
+    assertThat(builder.getDatatype().getBuilderFactory()).hasValue(BUILDER_METHOD);
+    assertFalse(builder.getDatatype().isBuilderSerializable());
   }
 
   @Test
@@ -291,12 +291,12 @@ public class AnalyserTest {
         "}"));
 
     assertEquals(QualifiedName.of("com.example", "DataType_Builder").withParameters(),
-        builder.getMetadata().getGeneratedBuilder());
+        builder.getDatatype().getGeneratedBuilder());
     assertEquals("com.example.DataType.Builder",
-        builder.getMetadata().getBuilder().getQualifiedName().toString());
-    assertThat(builder.getMetadata().isExtensible()).isTrue();
-    assertThat(builder.getMetadata().getBuilderFactory()).hasValue(NEW_BUILDER_METHOD);
-    assertFalse(builder.getMetadata().isBuilderSerializable());
+        builder.getDatatype().getBuilder().getQualifiedName().toString());
+    assertThat(builder.getDatatype().isExtensible()).isTrue();
+    assertThat(builder.getDatatype().getBuilderFactory()).hasValue(NEW_BUILDER_METHOD);
+    assertFalse(builder.getDatatype().isBuilderSerializable());
   }
 
   @Test
@@ -308,8 +308,8 @@ public class AnalyserTest {
         "  class Builder extends DataType_Builder { }",
         "}"));
 
-    assertTrue(builder.getMetadata().getHasToBuilderMethod());
-    assertThat(builder.getMetadata().getProperties()).isEmpty();
+    assertTrue(builder.getDatatype().getHasToBuilderMethod());
+    assertThat(builder.getDatatype().getProperties()).isEmpty();
   }
 
   @Test
@@ -321,8 +321,8 @@ public class AnalyserTest {
         "  class Builder<K, V> extends DataType_Builder<K, V> { }",
         "}"));
 
-    assertTrue(builder.getMetadata().getHasToBuilderMethod());
-    assertThat(builder.getMetadata().getProperties()).isEmpty();
+    assertTrue(builder.getDatatype().getHasToBuilderMethod());
+    assertThat(builder.getDatatype().getProperties()).isEmpty();
   }
 
   @Test
@@ -366,7 +366,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
 
     Property age = properties.get("age");
@@ -396,7 +396,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
 
     Property age = properties.get("age");
@@ -426,7 +426,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("customURLTemplate", "top50Sites");
     assertEquals("CUSTOM_URL_TEMPLATE", properties.get("customURLTemplate").getAllCapsName());
     assertEquals("TOP50_SITES", properties.get("top50Sites").getAllCapsName());
@@ -442,7 +442,7 @@ public class AnalyserTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals(model.typeMirror(int.class), properties.get("age").getType());
     assertEquals("Age", properties.get("age").getCapitalizedName());
@@ -461,7 +461,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("available");
     assertEquals(model.typeMirror(boolean.class), properties.get("available").getType());
     assertEquals("Available", properties.get("available").getCapitalizedName());
@@ -480,7 +480,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).isEmpty();
+    assertThat(builder.getDatatype().getProperties()).isEmpty();
   }
 
   @Test
@@ -492,7 +492,7 @@ public class AnalyserTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertEquals(DefaultProperty.class, properties.get("name").getCodeGenerator().getClass());
   }
 
@@ -507,7 +507,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).isEmpty();
+    assertThat(builder.getDatatype().getProperties()).isEmpty();
   }
 
   @Test
@@ -521,7 +521,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).isEmpty();
+    assertThat(builder.getDatatype().getProperties()).isEmpty();
   }
 
   @Test
@@ -533,7 +533,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).isEmpty();
+    assertThat(builder.getDatatype().getProperties()).isEmpty();
     messager.verifyError("getName", "Getter methods must not be void on @FreeBuilder types");
   }
 
@@ -546,7 +546,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).isEmpty();
+    assertThat(builder.getDatatype().getProperties()).isEmpty();
     messager.verifyError(
         "isName", "Getter methods starting with 'is' must return a boolean on @FreeBuilder types");
   }
@@ -560,7 +560,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).isEmpty();
+    assertThat(builder.getDatatype().getProperties()).isEmpty();
     messager.verifyError("getName", "Getter methods cannot take parameters on @FreeBuilder types");
   }
 
@@ -573,7 +573,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("get");
     assertEquals("Get", properties.get("get").getCapitalizedName());
     assertEquals("get", properties.get("get").getGetterName());
@@ -589,7 +589,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("getter");
     assertEquals("Getter", properties.get("getter").getCapitalizedName());
     assertEquals("getter", properties.get("getter").getGetterName());
@@ -605,7 +605,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("issue");
     assertEquals("ISSUE", properties.get("issue").getAllCapsName());
     assertEquals("Issue", properties.get("issue").getCapitalizedName());
@@ -622,7 +622,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("getürkt");
     assertEquals("GETÜRKT", properties.get("getürkt").getAllCapsName());
     assertEquals("Getürkt", properties.get("getürkt").getCapitalizedName());
@@ -639,7 +639,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("is");
     assertEquals("IS", properties.get("is").getAllCapsName());
     assertEquals("Is", properties.get("is").getCapitalizedName());
@@ -659,7 +659,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals("AGE", properties.get("age").getAllCapsName());
     assertEquals("Age", properties.get("age").getCapitalizedName());
@@ -687,7 +687,7 @@ public class AnalyserTest {
         "  }",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertEquals(Type.REQUIRED, properties.get("name").getCodeGenerator().getType());
     assertEquals(Type.REQUIRED, properties.get("age").getCodeGenerator().getType());
   }
@@ -706,7 +706,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
   }
 
@@ -723,7 +723,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("property");
     assertEquals("java.lang.String", properties.get("property").getType().toString());
   }
@@ -737,13 +737,13 @@ public class AnalyserTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getGeneratedBuilderAnnotations()).hasSize(1);
-    assertThat(asSource(builder.getMetadata().getGeneratedBuilderAnnotations().get(0)))
+    assertThat(builder.getDatatype().getGeneratedBuilderAnnotations()).hasSize(1);
+    assertThat(asSource(builder.getDatatype().getGeneratedBuilderAnnotations().get(0)))
         .isEqualTo("@GwtCompatible");
-    assertThat(builder.getMetadata().getValueTypeVisibility()).isEqualTo(PRIVATE);
-    assertThat(builder.getMetadata().getValueTypeAnnotations()).isEmpty();
-    assertThat(builder.getMetadata().getNestedClasses()).isEmpty();
-    assertThat(builder.getMetadata().getVisibleNestedTypes()).containsNoneOf(
+    assertThat(builder.getDatatype().getValueTypeVisibility()).isEqualTo(PRIVATE);
+    assertThat(builder.getDatatype().getValueTypeAnnotations()).isEmpty();
+    assertThat(builder.getDatatype().getNestedClasses()).isEmpty();
+    assertThat(builder.getDatatype().getVisibleNestedTypes()).containsNoneOf(
         QualifiedName.of("com.example", "DataType", "Value_CustomFieldSerializer"),
         QualifiedName.of("com.example", "DataType", "GwtWhitelist"));
   }
@@ -757,15 +757,15 @@ public class AnalyserTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getGeneratedBuilderAnnotations()).hasSize(1);
-    assertThat(asSource(builder.getMetadata().getGeneratedBuilderAnnotations().get(0)))
+    assertThat(builder.getDatatype().getGeneratedBuilderAnnotations()).hasSize(1);
+    assertThat(asSource(builder.getDatatype().getGeneratedBuilderAnnotations().get(0)))
         .isEqualTo("@GwtCompatible");
-    assertThat(builder.getMetadata().getValueTypeVisibility()).isEqualTo(PACKAGE);
-    assertThat(builder.getMetadata().getValueTypeAnnotations()).hasSize(1);
-    assertThat(asSource(builder.getMetadata().getValueTypeAnnotations().get(0)))
+    assertThat(builder.getDatatype().getValueTypeVisibility()).isEqualTo(PACKAGE);
+    assertThat(builder.getDatatype().getValueTypeAnnotations()).hasSize(1);
+    assertThat(asSource(builder.getDatatype().getValueTypeAnnotations().get(0)))
         .isEqualTo("@GwtCompatible(serializable = true)");
-    assertThat(builder.getMetadata().getNestedClasses()).hasSize(2);
-    assertThat(builder.getMetadata().getVisibleNestedTypes()).containsAllOf(
+    assertThat(builder.getDatatype().getNestedClasses()).hasSize(2);
+    assertThat(builder.getDatatype().getVisibleNestedTypes()).containsAllOf(
         QualifiedName.of("com.example", "DataType_Builder", "Value_CustomFieldSerializer"),
         QualifiedName.of("com.example", "DataType_Builder", "GwtWhitelist"));
   }
@@ -781,7 +781,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.OVERRIDEABLE));
     messager.verifyError(
         "equals", "hashCode and equals must be implemented together on @FreeBuilder types");
@@ -798,7 +798,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.HASH_CODE, UnderrideLevel.OVERRIDEABLE));
     messager.verifyError(
         "hashCode", "hashCode and equals must be implemented together on @FreeBuilder types");
@@ -818,7 +818,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.OVERRIDEABLE,
         StandardMethod.HASH_CODE, UnderrideLevel.OVERRIDEABLE));
   }
@@ -834,7 +834,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.TO_STRING, UnderrideLevel.OVERRIDEABLE));
   }
 
@@ -855,7 +855,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.OVERRIDEABLE,
         StandardMethod.HASH_CODE, UnderrideLevel.OVERRIDEABLE,
         StandardMethod.TO_STRING, UnderrideLevel.OVERRIDEABLE));
@@ -872,7 +872,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.FINAL));
     messager.verifyError(
         "equals", "hashCode and equals must be implemented together on @FreeBuilder types");
@@ -889,7 +889,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.HASH_CODE, UnderrideLevel.FINAL));
     messager.verifyError(
         "hashCode", "hashCode and equals must be implemented together on @FreeBuilder types");
@@ -909,7 +909,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.FINAL,
         StandardMethod.HASH_CODE, UnderrideLevel.FINAL));
   }
@@ -925,7 +925,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.TO_STRING, UnderrideLevel.FINAL));
   }
 
@@ -946,7 +946,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEqualTo(ImmutableMap.of(
         StandardMethod.EQUALS, UnderrideLevel.FINAL,
         StandardMethod.HASH_CODE, UnderrideLevel.FINAL,
         StandardMethod.TO_STRING, UnderrideLevel.FINAL));
@@ -962,7 +962,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEmpty();
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEmpty();
   }
 
   @Test
@@ -975,7 +975,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEmpty();
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEmpty();
   }
 
   @Test
@@ -988,7 +988,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getStandardMethodUnderrides()).isEmpty();
+    assertThat(builder.getDatatype().getStandardMethodUnderrides()).isEmpty();
   }
 
   @Test
@@ -1051,15 +1051,15 @@ public class AnalyserTest {
         "  public class Builder extends DataType_Builder {}",
         "}"));
 
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name");
     assertEquals("java.lang.String", properties.get("name").getType().toString());
     assertNull(properties.get("name").getBoxedType());
     assertEquals("NAME", properties.get("name").getAllCapsName());
     assertEquals("Name", properties.get("name").getCapitalizedName());
     assertEquals("getName", properties.get("name").getGetterName());
-    assertThat(builder.getMetadata().isExtensible()).isFalse();
-    assertThat(builder.getMetadata().getBuilderFactory()).isAbsent();
+    assertThat(builder.getDatatype().isExtensible()).isFalse();
+    assertThat(builder.getDatatype().getBuilderFactory()).isAbsent();
     messager.verifyError("Builder", "Builder must be static on @FreeBuilder types");
   }
 
@@ -1074,20 +1074,20 @@ public class AnalyserTest {
         "}"));
 
     assertEquals("com.example.DataType.Builder<A, B>",
-        builder.getMetadata().getBuilder().toString());
-    assertThat(builder.getMetadata().isExtensible()).isTrue();
+        builder.getDatatype().getBuilder().toString());
+    assertThat(builder.getDatatype().isExtensible()).isTrue();
     assertEquals(Optional.of(BuilderFactory.NO_ARGS_CONSTRUCTOR),
-        builder.getMetadata().getBuilderFactory());
+        builder.getDatatype().getBuilderFactory());
     assertEquals("com.example.DataType_Builder<A, B>",
-        builder.getMetadata().getGeneratedBuilder().toString());
+        builder.getDatatype().getGeneratedBuilder().toString());
     assertEquals("com.example.DataType_Builder.Partial<A, B>",
-        builder.getMetadata().getPartialType().toString());
+        builder.getDatatype().getPartialType().toString());
     assertEquals("com.example.DataType_Builder.Property",
-        builder.getMetadata().getPropertyEnum().toString());
-    assertEquals("com.example.DataType<A, B>", builder.getMetadata().getType().toString());
+        builder.getDatatype().getPropertyEnum().toString());
+    assertEquals("com.example.DataType<A, B>", builder.getDatatype().getType().toString());
     assertEquals("com.example.DataType_Builder.Value<A, B>",
-        builder.getMetadata().getValueType().toString());
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+        builder.getDatatype().getValueType().toString());
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals("B", properties.get("age").getType().toString());
     assertNull(properties.get("age").getBoxedType());
@@ -1113,9 +1113,9 @@ public class AnalyserTest {
         "}"));
 
     assertEquals("com.example.DataType.Builder<A, B>",
-        builder.getMetadata().getBuilder().toString());
+        builder.getDatatype().getBuilder().toString());
     assertEquals("DataType<A extends CharSequence, B extends Temporal>",
-        SourceStringBuilder.simple().add(builder.getMetadata().getType().declaration()).toString());
+        SourceStringBuilder.simple().add(builder.getDatatype().getType().declaration()).toString());
   }
 
   @Test
@@ -1133,20 +1133,20 @@ public class AnalyserTest {
         "}"));
 
     assertEquals("com.example.DataType.Builder<A, B>",
-        builder.getMetadata().getBuilder().toString());
-    assertThat(builder.getMetadata().isExtensible()).isTrue();
+        builder.getDatatype().getBuilder().toString());
+    assertThat(builder.getDatatype().isExtensible()).isTrue();
     assertEquals(Optional.of(BuilderFactory.NO_ARGS_CONSTRUCTOR),
-        builder.getMetadata().getBuilderFactory());
+        builder.getDatatype().getBuilderFactory());
     assertEquals("com.example.DataType_Builder<A, B>",
-        builder.getMetadata().getGeneratedBuilder().toString());
+        builder.getDatatype().getGeneratedBuilder().toString());
     assertEquals("com.example.DataType_Builder.Partial<A, B>",
-        builder.getMetadata().getPartialType().toString());
+        builder.getDatatype().getPartialType().toString());
     assertEquals("com.example.DataType_Builder.Property",
-        builder.getMetadata().getPropertyEnum().toString());
-    assertEquals("com.example.DataType<A, B>", builder.getMetadata().getType().toString());
+        builder.getDatatype().getPropertyEnum().toString());
+    assertEquals("com.example.DataType<A, B>", builder.getDatatype().getType().toString());
     assertEquals("com.example.DataType_Builder.Value<A, B>",
-        builder.getMetadata().getValueType().toString());
-    Map<String, Property> properties = uniqueIndex(builder.getMetadata().getProperties(), GET_NAME);
+        builder.getDatatype().getValueType().toString());
+    Map<String, Property> properties = uniqueIndex(builder.getDatatype().getProperties(), GET_NAME);
     assertThat(properties.keySet()).containsExactly("name", "age");
     assertEquals("B", properties.get("age").getType().toString());
     assertNull(properties.get("age").getBoxedType());
@@ -1200,7 +1200,7 @@ public class AnalyserTest {
     QualifiedName partialType = expectedBuilder.nestedType("Partial");
     QualifiedName propertyType = expectedBuilder.nestedType("Property");
     QualifiedName valueType = expectedBuilder.nestedType("Value");
-    Metadata expectedMetadata = new Metadata.Builder()
+    Datatype expectedDatatype = new Datatype.Builder()
         .setBuilder(QualifiedName.of("com.example", "DataType", "Builder").withParameters())
         .setExtensible(true)
         .setBuilderFactory(NO_ARGS_CONSTRUCTOR)
@@ -1218,7 +1218,7 @@ public class AnalyserTest {
         .addVisibleNestedTypes(valueType)
         .build();
 
-    assertEquals(expectedMetadata, builder.getMetadata());
+    assertEquals(expectedDatatype, builder.getDatatype());
   }
 
   @Test
@@ -1237,7 +1237,7 @@ public class AnalyserTest {
     QualifiedName partialType = expectedBuilder.nestedType("Partial");
     QualifiedName propertyType = expectedBuilder.nestedType("Property");
     QualifiedName valueType = expectedBuilder.nestedType("Value");
-    Metadata expectedMetadata = new Metadata.Builder()
+    Datatype expectedDatatype = new Datatype.Builder()
         .setBuilder(QualifiedName.of("com.example", "DataType", "Builder").withParameters())
         .setExtensible(true)
         .setBuilderFactory(NO_ARGS_CONSTRUCTOR)
@@ -1255,7 +1255,7 @@ public class AnalyserTest {
         .addVisibleNestedTypes(valueType)
         .build();
 
-    assertEquals(expectedMetadata, builder.getMetadata());
+    assertEquals(expectedDatatype, builder.getDatatype());
   }
 
   @Test
@@ -1331,8 +1331,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    assertThat(builder.getDatatype().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
@@ -1346,8 +1346,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    assertThat(builder.getDatatype().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
@@ -1361,8 +1361,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    assertThat(builder.getDatatype().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
@@ -1376,8 +1376,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    assertThat(builder.getDatatype().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isFalse();
   }
@@ -1391,8 +1391,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    assertThat(builder.getDatatype().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isFalse();
   }
@@ -1406,8 +1406,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    assertThat(builder.getDatatype().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isTrue();
   }
@@ -1421,8 +1421,8 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getProperties()).hasSize(1);
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    assertThat(builder.getDatatype().getProperties()).hasSize(1);
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertEquals("property", property.getName());
     assertThat(property.isFullyCheckedCast()).isFalse();
   }
@@ -1450,7 +1450,7 @@ public class AnalyserTest {
         "  public interface Objects {}",
         "}"));
 
-    assertThat(builder.getMetadata().getVisibleNestedTypes()).containsExactly(
+    assertThat(builder.getDatatype().getVisibleNestedTypes()).containsExactly(
         QualifiedName.of("com.example", "DataType", "Builder"),
         QualifiedName.of("com.example", "DataType", "Objects"),
         QualifiedName.of("com.example", "DataType_Builder", "Partial"),
@@ -1475,7 +1475,7 @@ public class AnalyserTest {
         "  public static class Builder extends DataType_Builder {}",
         "}"));
 
-    assertThat(builder.getMetadata().getVisibleNestedTypes()).containsExactly(
+    assertThat(builder.getDatatype().getVisibleNestedTypes()).containsExactly(
         QualifiedName.of("com.example", "SuperType", "Objects"),
         QualifiedName.of("com.example", "DataType", "Builder"),
         QualifiedName.of("com.example", "DataType_Builder", "Partial"),

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -35,7 +35,6 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import org.inferred.freebuilder.processor.Analyser.CannotGenerateCodeException;
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.Metadata.StandardMethod;
 import org.inferred.freebuilder.processor.Metadata.UnderrideLevel;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
@@ -1287,7 +1287,7 @@ public class DefaultedPropertiesSourceTest {
         .setType(INT)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Metadata metadata = new Metadata.Builder()
+    Datatype datatype = new Datatype.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setExtensible(true)
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -1301,13 +1301,13 @@ public class DefaultedPropertiesSourceTest {
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return new GeneratedBuilder(metadata.toBuilder()
+    return new GeneratedBuilder(datatype.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, name, true, unaryOperator(STRING)))
+            .setCodeGenerator(new DefaultProperty(datatype, name, true, unaryOperator(STRING)))
             .build())
         .addProperties(age.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, age, true, unaryOperator(INTEGER)))
+            .setCodeGenerator(new DefaultProperty(datatype, age, true, unaryOperator(INTEGER)))
             .build())
         .build());
   }

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
@@ -27,7 +27,6 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8
 
 import com.google.common.collect.ImmutableSet;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
@@ -25,6 +25,7 @@ import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.util.QualifiedName;
@@ -1267,6 +1268,20 @@ public class DefaultedPropertiesSourceTest {
     Set<Option> optionSet = ImmutableSet.copyOf(options);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
+
+    Datatype datatype = new Datatype.Builder()
+        .setBuilder(person.nestedType("Builder").withParameters())
+        .setExtensible(true)
+        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
+        .setBuilderSerializable(false)
+        .setGeneratedBuilder(generatedBuilder.withParameters())
+        .setHasToBuilderMethod(optionSet.contains(Option.WITH_TO_BUILDER_METHOD))
+        .setInterfaceType(false)
+        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
+        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
+        .setType(person.withParameters())
+        .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(STRING)
@@ -1287,28 +1302,14 @@ public class DefaultedPropertiesSourceTest {
         .setType(INT)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Datatype datatype = new Datatype.Builder()
-        .setBuilder(person.nestedType("Builder").withParameters())
-        .setExtensible(true)
-        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
-        .setBuilderSerializable(false)
-        .setGeneratedBuilder(generatedBuilder.withParameters())
-        .setHasToBuilderMethod(optionSet.contains(Option.WITH_TO_BUILDER_METHOD))
-        .setInterfaceType(false)
-        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name, age)
-        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
-        .setType(person.withParameters())
-        .setValueType(generatedBuilder.nestedType("Value").withParameters())
-        .build();
-    return new GeneratedBuilder(datatype.toBuilder()
-        .clearProperties()
-        .addProperties(name.toBuilder()
-            .setCodeGenerator(new DefaultProperty(datatype, name, true, unaryOperator(STRING)))
-            .build())
-        .addProperties(age.toBuilder()
-            .setCodeGenerator(new DefaultProperty(datatype, age, true, unaryOperator(INTEGER)))
-            .build())
-        .build());
+    return new GeneratedBuilder(
+        datatype,
+        ImmutableList.of(
+            name.toBuilder()
+                .setCodeGenerator(new DefaultProperty(datatype, name, true, unaryOperator(STRING)))
+                .build(),
+            age.toBuilder()
+                .setCodeGenerator(new DefaultProperty(datatype, age, true, unaryOperator(INTEGER)))
+                .build()));
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
@@ -21,6 +21,8 @@ import static org.inferred.freebuilder.processor.util.TypeParameterElementImpl.n
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
+import com.google.common.collect.ImmutableList;
+
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.TypeParameterElementImpl;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
@@ -841,6 +843,19 @@ public class GenericTypeSourceTest {
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
     TypeParameterElementImpl paramA = newTypeParameterElement("A");
     TypeParameterElementImpl paramB = newTypeParameterElement("B");
+
+    Datatype datatype = new Datatype.Builder()
+        .setBuilder(person.nestedType("Builder").withParameters("A", "B"))
+        .setExtensible(true)
+        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
+        .setBuilderSerializable(false)
+        .setGeneratedBuilder(generatedBuilder.withParameters(paramA, paramB))
+        .setInterfaceType(false)
+        .setPartialType(generatedBuilder.nestedType("Partial").withParameters(paramA, paramB))
+        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
+        .setType(person.withParameters(paramA, paramB))
+        .setValueType(generatedBuilder.nestedType("Value").withParameters(paramA, paramB))
+        .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setCapitalizedName("Name")
@@ -859,29 +874,17 @@ public class GenericTypeSourceTest {
         .setType(paramB.asType())
         .setUsingBeanConvention(true)
         .build();
-    Datatype datatype = new Datatype.Builder()
-        .setBuilder(person.nestedType("Builder").withParameters("A", "B"))
-        .setExtensible(true)
-        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
-        .setBuilderSerializable(false)
-        .setGeneratedBuilder(generatedBuilder.withParameters(paramA, paramB))
-        .setInterfaceType(false)
-        .setPartialType(generatedBuilder.nestedType("Partial").withParameters(paramA, paramB))
-        .addProperties(name, age)
-        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
-        .setType(person.withParameters(paramA, paramB))
-        .setValueType(generatedBuilder.nestedType("Value").withParameters(paramA, paramB))
-        .build();
-    return new GeneratedBuilder(datatype.toBuilder()
-        .clearProperties()
-        .addProperties(name.toBuilder()
-            .setCodeGenerator(new DefaultProperty(
-                datatype, name, false, unaryOperator(paramA.asType())))
-            .build())
-        .addProperties(age.toBuilder()
-            .setCodeGenerator(new DefaultProperty(
-                datatype, age, false, unaryOperator(paramB.asType())))
-            .build())
-        .build());
+
+    return new GeneratedBuilder(
+        datatype,
+        ImmutableList.of(
+            name.toBuilder()
+                .setCodeGenerator(new DefaultProperty(
+                    datatype, name, false, unaryOperator(paramA.asType())))
+                .build(),
+            age.toBuilder()
+                .setCodeGenerator(new DefaultProperty(
+                    datatype, age, false, unaryOperator(paramB.asType())))
+                .build()));
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
@@ -21,7 +21,6 @@ import static org.inferred.freebuilder.processor.util.TypeParameterElementImpl.n
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.TypeParameterElementImpl;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
@@ -859,7 +859,7 @@ public class GenericTypeSourceTest {
         .setType(paramB.asType())
         .setUsingBeanConvention(true)
         .build();
-    Metadata metadata = new Metadata.Builder()
+    Datatype datatype = new Datatype.Builder()
         .setBuilder(person.nestedType("Builder").withParameters("A", "B"))
         .setExtensible(true)
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -872,15 +872,15 @@ public class GenericTypeSourceTest {
         .setType(person.withParameters(paramA, paramB))
         .setValueType(generatedBuilder.nestedType("Value").withParameters(paramA, paramB))
         .build();
-    return new GeneratedBuilder(metadata.toBuilder()
+    return new GeneratedBuilder(datatype.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new DefaultProperty(
-                metadata, name, false, unaryOperator(paramA.asType())))
+                datatype, name, false, unaryOperator(paramA.asType())))
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new DefaultProperty(
-                metadata, age, false, unaryOperator(paramB.asType())))
+                datatype, age, false, unaryOperator(paramB.asType())))
             .build())
         .build());
   }

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
@@ -29,7 +29,6 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8
 import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.OptionalProperty.OptionalType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
@@ -1307,7 +1307,7 @@ public class GuavaOptionalSourceTest {
         .setType(optionalInteger)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Metadata metadata = new Metadata.Builder()
+    Datatype datatype = new Datatype.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setExtensible(true)
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -1320,11 +1320,11 @@ public class GuavaOptionalSourceTest {
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return new GeneratedBuilder(metadata.toBuilder()
+    return new GeneratedBuilder(datatype.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata,
+                datatype,
                 name,
                 OptionalType.GUAVA,
                 STRING,
@@ -1334,7 +1334,7 @@ public class GuavaOptionalSourceTest {
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata,
+                datatype,
                 age,
                 OptionalType.GUAVA,
                 INTEGER,

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
@@ -27,6 +27,7 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.OptionalProperty.OptionalType;
@@ -35,8 +36,6 @@ import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import javax.lang.model.type.TypeMirror;
 
 @RunWith(JUnit4.class)
 public class GuavaOptionalSourceTest {
@@ -1287,6 +1286,19 @@ public class GuavaOptionalSourceTest {
     GenericTypeMirrorImpl optionalString = optional.newMirror(STRING);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
+
+    Datatype datatype = new Datatype.Builder()
+        .setBuilder(person.nestedType("Builder").withParameters())
+        .setExtensible(true)
+        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
+        .setBuilderSerializable(false)
+        .setGeneratedBuilder(generatedBuilder.withParameters())
+        .setInterfaceType(false)
+        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
+        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
+        .setType(person.withParameters())
+        .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(optionalString)
@@ -1307,41 +1319,29 @@ public class GuavaOptionalSourceTest {
         .setType(optionalInteger)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Datatype datatype = new Datatype.Builder()
-        .setBuilder(person.nestedType("Builder").withParameters())
-        .setExtensible(true)
-        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
-        .setBuilderSerializable(false)
-        .setGeneratedBuilder(generatedBuilder.withParameters())
-        .setInterfaceType(false)
-        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name, age)
-        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
-        .setType(person.withParameters())
-        .setValueType(generatedBuilder.nestedType("Value").withParameters())
-        .build();
-    return new GeneratedBuilder(datatype.toBuilder()
-        .clearProperties()
-        .addProperties(name.toBuilder()
-            .setCodeGenerator(new OptionalProperty(
-                datatype,
-                name,
-                OptionalType.GUAVA,
-                STRING,
-                Optional.<TypeMirror>absent(),
-                unaryOperator(STRING),
-                false))
-            .build())
-        .addProperties(age.toBuilder()
-            .setCodeGenerator(new OptionalProperty(
-                datatype,
-                age,
-                OptionalType.GUAVA,
-                INTEGER,
-                Optional.<TypeMirror>of(INT),
-                unaryOperator(INTEGER),
-                false))
-            .build())
-        .build());
+
+    return new GeneratedBuilder(
+        datatype,
+        ImmutableList.of(
+            name.toBuilder()
+                .setCodeGenerator(new OptionalProperty(
+                    datatype,
+                    name,
+                    OptionalType.GUAVA,
+                    STRING,
+                    Optional.absent(),
+                    unaryOperator(STRING),
+                    false))
+                .build(),
+            age.toBuilder()
+                .setCodeGenerator(new OptionalProperty(
+                    datatype,
+                    age,
+                    OptionalType.GUAVA,
+                    INTEGER,
+                    Optional.of(INT),
+                    unaryOperator(INTEGER),
+                    false))
+                .build()));
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/JacksonSupportTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JacksonSupportTest.java
@@ -65,7 +65,7 @@ public class JacksonSupportTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    Property property = getOnlyElement(builder.getProperties());
     assertThat(property.getAccessorAnnotations()).named("property accessor annotations").isEmpty();
   }
 
@@ -81,7 +81,7 @@ public class JacksonSupportTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    Property property = getOnlyElement(builder.getProperties());
     assertPropertyHasAnnotation(property, JsonProperty.class, "@JsonProperty(\"bob\")");
   }
 
@@ -97,7 +97,7 @@ public class JacksonSupportTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    Property property = getOnlyElement(builder.getProperties());
     assertPropertyHasAnnotation(property,
             JacksonXmlProperty.class, "@JacksonXmlProperty(localName = \"b-ob\")");
   }
@@ -113,7 +113,7 @@ public class JacksonSupportTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    Property property = getOnlyElement(builder.getProperties());
     assertPropertyHasAnnotation(property, JsonProperty.class, "@JsonProperty(\"fooBar\")");
   }
 
@@ -128,7 +128,7 @@ public class JacksonSupportTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Property property = getOnlyElement(builder.getDatatype().getProperties());
+    Property property = getOnlyElement(builder.getProperties());
     assertThat(property.getAccessorAnnotations()).named("property accessor annotations").isEmpty();
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/JacksonSupportTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JacksonSupportTest.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 import org.inferred.freebuilder.processor.Analyser.CannotGenerateCodeException;
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.testing.MessagerRule;

--- a/src/test/java/org/inferred/freebuilder/processor/JacksonSupportTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JacksonSupportTest.java
@@ -65,7 +65,7 @@ public class JacksonSupportTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertThat(property.getAccessorAnnotations()).named("property accessor annotations").isEmpty();
   }
 
@@ -81,7 +81,7 @@ public class JacksonSupportTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertPropertyHasAnnotation(property, JsonProperty.class, "@JsonProperty(\"bob\")");
   }
 
@@ -97,7 +97,7 @@ public class JacksonSupportTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertPropertyHasAnnotation(property,
             JacksonXmlProperty.class, "@JacksonXmlProperty(localName = \"b-ob\")");
   }
@@ -113,7 +113,7 @@ public class JacksonSupportTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertPropertyHasAnnotation(property, JsonProperty.class, "@JsonProperty(\"fooBar\")");
   }
 
@@ -128,7 +128,7 @@ public class JacksonSupportTest {
         "  class Builder extends DataType_Builder {}",
         "}"));
 
-    Property property = getOnlyElement(builder.getMetadata().getProperties());
+    Property property = getOnlyElement(builder.getDatatype().getProperties());
     assertThat(property.getAccessorAnnotations()).named("property accessor annotations").isEmpty();
   }
 

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
@@ -26,6 +26,7 @@ import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.OptionalProperty.OptionalType;
@@ -34,8 +35,6 @@ import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import javax.lang.model.type.TypeMirror;
 
 @RunWith(JUnit4.class)
 public class JavaUtilOptionalSourceTest {
@@ -984,6 +983,19 @@ public class JavaUtilOptionalSourceTest {
     GenericTypeMirrorImpl optionalString = optional.newMirror(STRING);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
+
+    Datatype datatype = new Datatype.Builder()
+        .setBuilder(person.nestedType("Builder").withParameters())
+        .setExtensible(true)
+        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
+        .setBuilderSerializable(false)
+        .setGeneratedBuilder(generatedBuilder.withParameters())
+        .setInterfaceType(false)
+        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
+        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
+        .setType(person.withParameters())
+        .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(optionalString)
@@ -1004,41 +1016,29 @@ public class JavaUtilOptionalSourceTest {
         .setType(optionalInteger)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Datatype datatype = new Datatype.Builder()
-        .setBuilder(person.nestedType("Builder").withParameters())
-        .setExtensible(true)
-        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
-        .setBuilderSerializable(false)
-        .setGeneratedBuilder(generatedBuilder.withParameters())
-        .setInterfaceType(false)
-        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name, age)
-        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
-        .setType(person.withParameters())
-        .setValueType(generatedBuilder.nestedType("Value").withParameters())
-        .build();
-    return new GeneratedBuilder(datatype.toBuilder()
-        .clearProperties()
-        .addProperties(name.toBuilder()
-            .setCodeGenerator(new OptionalProperty(
-                datatype,
-                name,
-                OptionalType.JAVA8,
-                STRING,
-                Optional.<TypeMirror>absent(),
-                unaryOperator(STRING),
-                false))
-            .build())
-        .addProperties(age.toBuilder()
-            .setCodeGenerator(new OptionalProperty(
-                datatype,
-                age,
-                OptionalType.JAVA8,
-                INTEGER,
-                Optional.<TypeMirror>of(INT),
-                unaryOperator(INTEGER),
-                false))
-            .build())
-        .build());
+
+    return new GeneratedBuilder(
+        datatype,
+        ImmutableList.of(
+            name.toBuilder()
+                .setCodeGenerator(new OptionalProperty(
+                    datatype,
+                    name,
+                    OptionalType.JAVA8,
+                    STRING,
+                    Optional.absent(),
+                    unaryOperator(STRING),
+                    false))
+                .build(),
+            age.toBuilder()
+                .setCodeGenerator(new OptionalProperty(
+                    datatype,
+                    age,
+                    OptionalType.JAVA8,
+                    INTEGER,
+                    Optional.of(INT),
+                    unaryOperator(INTEGER),
+                    false))
+                .build()));
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
@@ -1004,7 +1004,7 @@ public class JavaUtilOptionalSourceTest {
         .setType(optionalInteger)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Metadata metadata = new Metadata.Builder()
+    Datatype datatype = new Datatype.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setExtensible(true)
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -1017,11 +1017,11 @@ public class JavaUtilOptionalSourceTest {
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return new GeneratedBuilder(metadata.toBuilder()
+    return new GeneratedBuilder(datatype.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata,
+                datatype,
                 name,
                 OptionalType.JAVA8,
                 STRING,
@@ -1031,7 +1031,7 @@ public class JavaUtilOptionalSourceTest {
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new OptionalProperty(
-                metadata,
+                datatype,
                 age,
                 OptionalType.JAVA8,
                 INTEGER,

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
@@ -28,7 +28,6 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8
 import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.OptionalProperty.OptionalType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -1918,7 +1918,7 @@ public class ListSourceTest {
   }
 
   /**
-   * Returns a {@link Metadata} instance for a FreeBuilder type with two properties: name, of
+   * Returns a {@link Datatype} instance for a FreeBuilder type with two properties: name, of
    * type {@code List<String>}; and age, of type {@code List<Integer>}.
    */
   private static GeneratedBuilder builder(NamingConvention convention) {
@@ -1947,7 +1947,7 @@ public class ListSourceTest {
         .setType(listInteger)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Metadata metadata = new Metadata.Builder()
+    Datatype datatype = new Datatype.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setExtensible(true)
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -1960,11 +1960,11 @@ public class ListSourceTest {
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return new GeneratedBuilder(metadata.toBuilder()
+    return new GeneratedBuilder(datatype.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new ListProperty(
-                metadata,
+                datatype,
                 name,
                 false,
                 false,
@@ -1975,7 +1975,7 @@ public class ListSourceTest {
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new ListProperty(
-                metadata,
+                datatype,
                 age,
                 false,
                 false,

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -27,6 +27,7 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.util.FunctionalType;
@@ -1927,6 +1928,18 @@ public class ListSourceTest {
     GenericTypeMirrorImpl listString = list.newMirror(STRING);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
+    Datatype datatype = new Datatype.Builder()
+        .setBuilder(person.nestedType("Builder").withParameters())
+        .setExtensible(true)
+        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
+        .setBuilderSerializable(false)
+        .setGeneratedBuilder(generatedBuilder.withParameters())
+        .setInterfaceType(false)
+        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
+        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
+        .setType(person.withParameters())
+        .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(listString)
@@ -1947,43 +1960,30 @@ public class ListSourceTest {
         .setType(listInteger)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Datatype datatype = new Datatype.Builder()
-        .setBuilder(person.nestedType("Builder").withParameters())
-        .setExtensible(true)
-        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
-        .setBuilderSerializable(false)
-        .setGeneratedBuilder(generatedBuilder.withParameters())
-        .setInterfaceType(false)
-        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name, age)
-        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
-        .setType(person.withParameters())
-        .setValueType(generatedBuilder.nestedType("Value").withParameters())
-        .build();
-    return new GeneratedBuilder(datatype.toBuilder()
-        .clearProperties()
-        .addProperties(name.toBuilder()
-            .setCodeGenerator(new ListProperty(
-                datatype,
-                name,
-                false,
-                false,
-                false,
-                STRING,
-                Optional.<TypeMirror>absent(),
-                FunctionalType.consumer(wildcardSuper(listString))))
-            .build())
-        .addProperties(age.toBuilder()
-            .setCodeGenerator(new ListProperty(
-                datatype,
-                age,
-                false,
-                false,
-                false,
-                INTEGER,
-                Optional.<TypeMirror>of(INT),
-                FunctionalType.consumer(wildcardSuper(listInteger))))
-            .build())
-        .build());
+    return new GeneratedBuilder(
+        datatype,
+        ImmutableList.of(
+            name.toBuilder()
+                .setCodeGenerator(new ListProperty(
+                    datatype,
+                    name,
+                    false,
+                    false,
+                    false,
+                    STRING,
+                    Optional.<TypeMirror>absent(),
+                    FunctionalType.consumer(wildcardSuper(listString))))
+                .build(),
+            age.toBuilder()
+                .setCodeGenerator(new ListProperty(
+                    datatype,
+                    age,
+                    false,
+                    false,
+                    false,
+                    INTEGER,
+                    Optional.<TypeMirror>of(INT),
+                    FunctionalType.consumer(wildcardSuper(listInteger))))
+                .build()));
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -29,7 +29,6 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8
 import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.FunctionalType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -27,6 +27,7 @@ import static org.inferred.freebuilder.processor.util.WildcardTypeImpl.wildcardS
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.util.QualifiedName;
@@ -1035,6 +1036,19 @@ public class MapSourceTest {
     GenericTypeMirrorImpl mapIntString = map.newMirror(INTEGER, STRING);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
+
+    Datatype datatype = new Datatype.Builder()
+        .setBuilder(person.nestedType("Builder").withParameters())
+        .setExtensible(true)
+        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
+        .setBuilderSerializable(false)
+        .setGeneratedBuilder(generatedBuilder.withParameters())
+        .setInterfaceType(false)
+        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
+        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
+        .setType(person.withParameters())
+        .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(mapIntString)
@@ -1045,32 +1059,20 @@ public class MapSourceTest {
         .setType(mapIntString)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Datatype datatype = new Datatype.Builder()
-        .setBuilder(person.nestedType("Builder").withParameters())
-        .setExtensible(true)
-        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
-        .setBuilderSerializable(false)
-        .setGeneratedBuilder(generatedBuilder.withParameters())
-        .setInterfaceType(false)
-        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name)
-        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
-        .setType(person.withParameters())
-        .setValueType(generatedBuilder.nestedType("Value").withParameters())
-        .build();
-    return new GeneratedBuilder(datatype.toBuilder()
-        .clearProperties()
-        .addProperties(name.toBuilder()
-            .setCodeGenerator(new MapProperty(
-                datatype,
-                name,
-                false,
-                INTEGER,
-                Optional.<TypeMirror>of(INT),
-                STRING,
-                Optional.<TypeMirror>absent(),
-                consumer(wildcardSuper(mapIntString))))
-            .build())
-        .build());
+
+    return new GeneratedBuilder(
+        datatype,
+        ImmutableList.of(
+            name.toBuilder()
+                .setCodeGenerator(new MapProperty(
+                    datatype,
+                    name,
+                    false,
+                    INTEGER,
+                    Optional.<TypeMirror>of(INT),
+                    STRING,
+                    Optional.<TypeMirror>absent(),
+                    consumer(wildcardSuper(mapIntString))))
+                .build()));
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -1045,7 +1045,7 @@ public class MapSourceTest {
         .setType(mapIntString)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Metadata metadata = new Metadata.Builder()
+    Datatype datatype = new Datatype.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setExtensible(true)
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -1058,11 +1058,11 @@ public class MapSourceTest {
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return new GeneratedBuilder(metadata.toBuilder()
+    return new GeneratedBuilder(datatype.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new MapProperty(
-                metadata,
+                datatype,
                 name,
                 false,
                 INTEGER,

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -29,7 +29,6 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7
 import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;

--- a/src/test/java/org/inferred/freebuilder/processor/NullablePropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullablePropertyFactoryTest.java
@@ -48,11 +48,11 @@ public class NullablePropertyFactoryTest {
   @Rule public final ModelRule model = new ModelRule();
   @Mock(answer = RETURNS_SMART_NULLS) private Config config;
   private final NullableProperty.Factory factory = new NullableProperty.Factory();
-  @Mock(answer = RETURNS_SMART_NULLS) private Metadata metadata;
+  @Mock(answer = RETURNS_SMART_NULLS) private Datatype datatype;
 
   @Before
   public void setUp() {
-    when(config.getMetadata()).thenReturn(metadata);
+    when(config.getDatatype()).thenReturn(datatype);
   }
 
   @Test
@@ -97,7 +97,7 @@ public class NullablePropertyFactoryTest {
     Optional<NullableProperty> codeGenerator = factory.create(config);
 
     assertThat(codeGenerator).hasValue(new NullableProperty(
-        metadata,
+        datatype,
         property,
         ImmutableSet.of(model.typeElement(Nullable.class)),
         unaryOperator(model.typeMirror(String.class))));
@@ -129,7 +129,7 @@ public class NullablePropertyFactoryTest {
     Optional<NullableProperty> codeGenerator = factory.create(config);
 
     assertThat(codeGenerator).hasValue(new NullableProperty(
-        metadata,
+        datatype,
         property,
         ImmutableSet.of(model.typeElement("foo.bar.Nullable")),
         unaryOperator(model.typeMirror(String.class))));
@@ -164,7 +164,7 @@ public class NullablePropertyFactoryTest {
     Optional<NullableProperty> codeGenerator = factory.create(config);
 
     assertThat(codeGenerator).hasValue(new NullableProperty(
-        metadata,
+        datatype,
         property,
         ImmutableSet.of(
             model.typeElement(Nullable.class),

--- a/src/test/java/org/inferred/freebuilder/processor/NullablePropertyFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullablePropertyFactoryTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
 import org.inferred.freebuilder.processor.util.testing.ModelRule;
 import org.junit.Before;

--- a/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
@@ -27,7 +27,6 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8
 
 import com.google.common.collect.ImmutableSet;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.ClassTypeImpl.ClassElementImpl;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;

--- a/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
@@ -964,7 +964,7 @@ public class NullableSourceTest {
         .setType(INTEGER)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Metadata metadata = new Metadata.Builder()
+    Datatype datatype = new Datatype.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setExtensible(true)
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -977,15 +977,15 @@ public class NullableSourceTest {
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return new GeneratedBuilder(metadata.toBuilder()
+    return new GeneratedBuilder(datatype.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new NullableProperty(
-                metadata, name, ImmutableSet.of(nullable), unaryOperator(STRING)))
+                datatype, name, ImmutableSet.of(nullable), unaryOperator(STRING)))
             .build())
         .addProperties(age.toBuilder()
             .setCodeGenerator(new NullableProperty(
-                metadata, age, ImmutableSet.of(nullable), unaryOperator(INTEGER)))
+                datatype, age, ImmutableSet.of(nullable), unaryOperator(INTEGER)))
             .build())
         .build());
   }

--- a/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
@@ -25,6 +25,7 @@ import static org.inferred.freebuilder.processor.util.FunctionalType.unaryOperat
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.util.ClassTypeImpl.ClassElementImpl;
@@ -944,6 +945,19 @@ public class NullableSourceTest {
     ClassElementImpl nullable = newTopLevelClass("javax.annotation.Nullable").asElement();
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
+
+    Datatype datatype = new Datatype.Builder()
+        .setBuilder(person.nestedType("Builder").withParameters())
+        .setExtensible(true)
+        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
+        .setBuilderSerializable(false)
+        .setGeneratedBuilder(generatedBuilder.withParameters())
+        .setInterfaceType(false)
+        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
+        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
+        .setType(person.withParameters())
+        .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(STRING)
@@ -964,29 +978,17 @@ public class NullableSourceTest {
         .setType(INTEGER)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Datatype datatype = new Datatype.Builder()
-        .setBuilder(person.nestedType("Builder").withParameters())
-        .setExtensible(true)
-        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
-        .setBuilderSerializable(false)
-        .setGeneratedBuilder(generatedBuilder.withParameters())
-        .setInterfaceType(false)
-        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name, age)
-        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
-        .setType(person.withParameters())
-        .setValueType(generatedBuilder.nestedType("Value").withParameters())
-        .build();
-    return new GeneratedBuilder(datatype.toBuilder()
-        .clearProperties()
-        .addProperties(name.toBuilder()
-            .setCodeGenerator(new NullableProperty(
-                datatype, name, ImmutableSet.of(nullable), unaryOperator(STRING)))
-            .build())
-        .addProperties(age.toBuilder()
-            .setCodeGenerator(new NullableProperty(
-                datatype, age, ImmutableSet.of(nullable), unaryOperator(INTEGER)))
-            .build())
-        .build());
+
+    return new GeneratedBuilder(
+        datatype,
+        ImmutableList.of(
+            name.toBuilder()
+                .setCodeGenerator(new NullableProperty(
+                    datatype, name, ImmutableSet.of(nullable), unaryOperator(STRING)))
+                .build(),
+            age.toBuilder()
+                .setCodeGenerator(new NullableProperty(
+                    datatype, age, ImmutableSet.of(nullable), unaryOperator(INTEGER)))
+                .build()));
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
@@ -1651,7 +1651,7 @@ public class RequiredPropertiesSourceTest {
         .setType(INT)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Metadata metadata = new Metadata.Builder()
+    Datatype datatype = new Datatype.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setExtensible(true)
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -1664,13 +1664,13 @@ public class RequiredPropertiesSourceTest {
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return new GeneratedBuilder(metadata.toBuilder()
+    return new GeneratedBuilder(datatype.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, name, false, unaryOperator(STRING)))
+            .setCodeGenerator(new DefaultProperty(datatype, name, false, unaryOperator(STRING)))
             .build())
         .addProperties(age.toBuilder()
-            .setCodeGenerator(new DefaultProperty(metadata, age, false, unaryOperator(INTEGER)))
+            .setCodeGenerator(new DefaultProperty(datatype, age, false, unaryOperator(INTEGER)))
             .build())
         .build());
   }

--- a/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
@@ -25,6 +25,8 @@ import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
+import com.google.common.collect.ImmutableList;
+
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;
@@ -1631,6 +1633,19 @@ public class RequiredPropertiesSourceTest {
   private static GeneratedBuilder builder(NamingConvention convention) {
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
+
+    Datatype datatype = new Datatype.Builder()
+        .setBuilder(person.nestedType("Builder").withParameters())
+        .setExtensible(true)
+        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
+        .setBuilderSerializable(false)
+        .setGeneratedBuilder(generatedBuilder.withParameters())
+        .setInterfaceType(false)
+        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
+        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
+        .setType(person.withParameters())
+        .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(STRING)
@@ -1651,27 +1666,15 @@ public class RequiredPropertiesSourceTest {
         .setType(INT)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Datatype datatype = new Datatype.Builder()
-        .setBuilder(person.nestedType("Builder").withParameters())
-        .setExtensible(true)
-        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
-        .setBuilderSerializable(false)
-        .setGeneratedBuilder(generatedBuilder.withParameters())
-        .setInterfaceType(false)
-        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name, age)
-        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
-        .setType(person.withParameters())
-        .setValueType(generatedBuilder.nestedType("Value").withParameters())
-        .build();
-    return new GeneratedBuilder(datatype.toBuilder()
-        .clearProperties()
-        .addProperties(name.toBuilder()
-            .setCodeGenerator(new DefaultProperty(datatype, name, false, unaryOperator(STRING)))
-            .build())
-        .addProperties(age.toBuilder()
-            .setCodeGenerator(new DefaultProperty(datatype, age, false, unaryOperator(INTEGER)))
-            .build())
-        .build());
+
+    return new GeneratedBuilder(
+        datatype,
+        ImmutableList.of(
+            name.toBuilder()
+                .setCodeGenerator(new DefaultProperty(datatype, name, false, unaryOperator(STRING)))
+                .build(),
+            age.toBuilder()
+                .setCodeGenerator(new DefaultProperty(datatype, age, false, unaryOperator(INTEGER)))
+                .build()));
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
@@ -25,7 +25,6 @@ import static org.inferred.freebuilder.processor.util.PrimitiveTypeImpl.INT;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -1421,7 +1421,7 @@ public class SetSourceTest {
         .setType(setString)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Metadata metadata = new Metadata.Builder()
+    Datatype datatype = new Datatype.Builder()
         .setBuilder(person.nestedType("Builder").withParameters())
         .setExtensible(true)
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
@@ -1434,11 +1434,11 @@ public class SetSourceTest {
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
         .build();
-    return new GeneratedBuilder(metadata.toBuilder()
+    return new GeneratedBuilder(datatype.toBuilder()
         .clearProperties()
         .addProperties(name.toBuilder()
             .setCodeGenerator(new SetProperty(
-                metadata,
+                datatype,
                 name,
                 STRING,
                 Optional.<TypeMirror>absent(),

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -28,7 +28,6 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8
 import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 import org.junit.Test;

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -26,6 +26,7 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_8;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 import org.inferred.freebuilder.processor.GenericTypeElementImpl.GenericTypeMirrorImpl;
 import org.inferred.freebuilder.processor.util.QualifiedName;
@@ -1411,6 +1412,19 @@ public class SetSourceTest {
     GenericTypeMirrorImpl setString = set.newMirror(STRING);
     QualifiedName person = QualifiedName.of("com.example", "Person");
     QualifiedName generatedBuilder = QualifiedName.of("com.example", "Person_Builder");
+
+    Datatype datatype = new Datatype.Builder()
+        .setBuilder(person.nestedType("Builder").withParameters())
+        .setExtensible(true)
+        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
+        .setBuilderSerializable(false)
+        .setGeneratedBuilder(generatedBuilder.withParameters())
+        .setInterfaceType(false)
+        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
+        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
+        .setType(person.withParameters())
+        .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")
         .setBoxedType(setString)
@@ -1421,32 +1435,19 @@ public class SetSourceTest {
         .setType(setString)
         .setUsingBeanConvention(convention == BEAN)
         .build();
-    Datatype datatype = new Datatype.Builder()
-        .setBuilder(person.nestedType("Builder").withParameters())
-        .setExtensible(true)
-        .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
-        .setBuilderSerializable(false)
-        .setGeneratedBuilder(generatedBuilder.withParameters())
-        .setInterfaceType(false)
-        .setPartialType(generatedBuilder.nestedType("Partial").withParameters())
-        .addProperties(name)
-        .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
-        .setType(person.withParameters())
-        .setValueType(generatedBuilder.nestedType("Value").withParameters())
-        .build();
-    return new GeneratedBuilder(datatype.toBuilder()
-        .clearProperties()
-        .addProperties(name.toBuilder()
-            .setCodeGenerator(new SetProperty(
-                datatype,
-                name,
-                STRING,
-                Optional.<TypeMirror>absent(),
-                consumer(wildcardSuper(setString)),
-                false,
-                false,
-                false))
-            .build())
-        .build());
+    return new GeneratedBuilder(
+        datatype,
+        ImmutableList.of(
+            name.toBuilder()
+                .setCodeGenerator(new SetProperty(
+                    datatype,
+                    name,
+                    STRING,
+                    Optional.<TypeMirror>absent(),
+                    consumer(wildcardSuper(setString)),
+                    false,
+                    false,
+                    false))
+                .build()));
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/ToStringGeneratorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ToStringGeneratorTest.java
@@ -19,14 +19,14 @@ public class ToStringGeneratorTest {
 
   @Test
   public void noProperties() {
-    Metadata metadata = datatype("Person").build();
+    ToStringBuilder builder = builderFor("Person");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"partial Person{}\";\n"
@@ -35,14 +35,14 @@ public class ToStringGeneratorTest {
 
   @Test
   public void defaultProperty() {
-    Metadata metadata = datatype("Person").withDefault("name").build();
+    ToStringBuilder builder = builderFor("Person").withDefault("name");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"partial Person{name=\" + name + \"}\";\n"
@@ -51,14 +51,14 @@ public class ToStringGeneratorTest {
 
   @Test
   public void requiredProperty() {
-    Metadata metadata = datatype("Person").withRequired("name").build();
+    ToStringBuilder builder = builderFor("Person").withRequired("name");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -71,9 +71,9 @@ public class ToStringGeneratorTest {
 
   @Test
   public void optionalProperty() {
-    Metadata metadata = datatype("Person").withOptional("name").build();
+    ToStringBuilder builder = builderFor("Person").withOptional("name");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"Person{\");\n"
@@ -82,7 +82,7 @@ public class ToStringGeneratorTest {
         + "  }\n"
         + "  return result.append(\"}\").toString();\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -95,14 +95,14 @@ public class ToStringGeneratorTest {
 
   @Test
   public void twoDefaults() {
-    Metadata metadata = datatype("Person").withDefault("name").withDefault("age").build();
+    ToStringBuilder builder = builderFor("Person").withDefault("name").withDefault("age");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \", age=\" + age + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"partial Person{name=\" + name + \", age=\" + age + \"}\";\n"
@@ -111,14 +111,14 @@ public class ToStringGeneratorTest {
 
   @Test
   public void twoRequired() {
-    Metadata metadata = datatype("Person").withRequired("name").withRequired("age").build();
+    ToStringBuilder builder = builderFor("Person").withRequired("name").withRequired("age");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \", age=\" + age + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -136,9 +136,9 @@ public class ToStringGeneratorTest {
 
   @Test
   public void twoOptional() {
-    Metadata metadata = datatype("Person").withOptional("name").withOptional("age").build();
+    ToStringBuilder builder = builderFor("Person").withOptional("name").withOptional("age");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"Person{\");\n"
@@ -152,7 +152,7 @@ public class ToStringGeneratorTest {
         + "  }\n"
         + "  return result.append(\"}\").toString();\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -170,14 +170,14 @@ public class ToStringGeneratorTest {
 
   @Test
   public void defaultThenRequired() {
-    Metadata metadata = datatype("Person").withDefault("name").withRequired("age").build();
+    ToStringBuilder builder = builderFor("Person").withDefault("name").withRequired("age");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \", age=\" + age + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{name=\").append(name);\n"
@@ -190,14 +190,14 @@ public class ToStringGeneratorTest {
 
   @Test
   public void requiredThenDefault() {
-    Metadata metadata = datatype("Person").withRequired("name").withDefault("age").build();
+    ToStringBuilder builder = builderFor("Person").withRequired("name").withDefault("age");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \", age=\" + age + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -210,9 +210,9 @@ public class ToStringGeneratorTest {
 
   @Test
   public void defaultThenOptional() {
-    Metadata metadata = datatype("Person").withDefault("name").withOptional("age").build();
+    ToStringBuilder builder = builderFor("Person").withDefault("name").withOptional("age");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"Person{name=\").append(name);\n"
@@ -221,7 +221,7 @@ public class ToStringGeneratorTest {
         + "  }\n"
         + "  return result.append(\"}\").toString();\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{name=\").append(name);\n"
@@ -234,9 +234,9 @@ public class ToStringGeneratorTest {
 
   @Test
   public void optionalThenDefault() {
-    Metadata metadata = datatype("Person").withOptional("name").withDefault("age").build();
+    ToStringBuilder builder = builderFor("Person").withOptional("name").withDefault("age");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"Person{\");\n"
@@ -245,7 +245,7 @@ public class ToStringGeneratorTest {
         + "  }\n"
         + "  return result.append(\"age=\").append(age).append(\"}\").toString();\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -258,9 +258,9 @@ public class ToStringGeneratorTest {
 
   @Test
   public void requiredThenOptional() {
-    Metadata metadata = datatype("Person").withRequired("name").withOptional("age").build();
+    ToStringBuilder builder = builderFor("Person").withRequired("name").withOptional("age");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"Person{name=\").append(name);\n"
@@ -269,7 +269,7 @@ public class ToStringGeneratorTest {
         + "  }\n"
         + "  return result.append(\"}\").toString();\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -287,9 +287,9 @@ public class ToStringGeneratorTest {
 
   @Test
   public void optionalThenRequired() {
-    Metadata metadata = datatype("Person").withOptional("name").withRequired("age").build();
+    ToStringBuilder builder = builderFor("Person").withOptional("name").withRequired("age");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"Person{\");\n"
@@ -298,7 +298,7 @@ public class ToStringGeneratorTest {
         + "  }\n"
         + "  return result.append(\"age=\").append(age).append(\"}\").toString();\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -316,19 +316,18 @@ public class ToStringGeneratorTest {
 
   @Test
   public void threeDefaults() {
-    Metadata metadata = datatype("Person")
+    ToStringBuilder builder = builderFor("Person")
         .withDefault("name")
         .withDefault("age")
-        .withDefault("shoeSize")
-        .build();
+        .withDefault("shoeSize");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \", age=\" + age + \", shoeSize=\" + shoeSize"
             + " + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"partial Person{name=\" + name + \", age=\" + age + \", shoeSize=\" + shoeSize"
@@ -338,19 +337,18 @@ public class ToStringGeneratorTest {
 
   @Test
   public void threeRequired() {
-    Metadata metadata = datatype("Person")
+    ToStringBuilder builder = builderFor("Person")
         .withRequired("name")
         .withRequired("age")
-        .withRequired("shoeSize")
-        .build();
+        .withRequired("shoeSize");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \", age=\" + age + \", shoeSize=\" + shoeSize"
             + " + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -372,13 +370,12 @@ public class ToStringGeneratorTest {
 
   @Test
   public void threeOptional() {
-    Metadata metadata = datatype("Person")
+    ToStringBuilder builder = builderFor("Person")
         .withOptional("name")
         .withOptional("age")
-        .withOptional("shoeSize")
-        .build();
+        .withOptional("shoeSize");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"Person{\");\n"
@@ -396,7 +393,7 @@ public class ToStringGeneratorTest {
         + "  }\n"
         + "  return result.append(\"}\").toString();\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -418,19 +415,18 @@ public class ToStringGeneratorTest {
 
   @Test
   public void requiredDefaultRequired() {
-    Metadata metadata = datatype("Person")
+    ToStringBuilder builder = builderFor("Person")
         .withRequired("name")
         .withDefault("age")
-        .withRequired("shoeSize")
-        .build();
+        .withRequired("shoeSize");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \", age=\" + age + \","
             + " shoeSize=\" + shoeSize + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -447,19 +443,18 @@ public class ToStringGeneratorTest {
 
   @Test
   public void defaultDefaultRequired() {
-    Metadata metadata = datatype("Person")
+    ToStringBuilder builder = builderFor("Person")
         .withDefault("name")
         .withDefault("age")
-        .withRequired("shoeSize")
-        .build();
+        .withRequired("shoeSize");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \", age=\" + age + \","
             + " shoeSize=\" + shoeSize + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{name=\").append(name)"
@@ -473,19 +468,18 @@ public class ToStringGeneratorTest {
 
   @Test
   public void defaultRequiredDefault() {
-    Metadata metadata = datatype("Person")
+    ToStringBuilder builder = builderFor("Person")
         .withDefault("name")
         .withRequired("age")
-        .withDefault("shoeSize")
-        .build();
+        .withDefault("shoeSize");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \", age=\" + age + \","
             + " shoeSize=\" + shoeSize + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{name=\").append(name);\n"
@@ -498,19 +492,18 @@ public class ToStringGeneratorTest {
 
   @Test
   public void requiredDefaultDefault() {
-    Metadata metadata = datatype("Person")
+    ToStringBuilder builder = builderFor("Person")
         .withRequired("name")
         .withDefault("age")
-        .withDefault("shoeSize")
-        .build();
+        .withDefault("shoeSize");
 
-    assertThat(valueToString(metadata)).isEqualTo("\n"
+    assertThat(builder.valueToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  return \"Person{name=\" + name + \", age=\" + age + \","
             + " shoeSize=\" + shoeSize + \"}\";\n"
         + "}\n");
-    assertThat(partialToString(metadata)).isEqualTo("\n"
+    assertThat(builder.partialToString()).isEqualTo("\n"
         + "@Override\n"
         + "public String toString() {\n"
         + "  StringBuilder result = new StringBuilder(\"partial Person{\");\n"
@@ -522,45 +515,45 @@ public class ToStringGeneratorTest {
         + "}\n");
   }
 
-  private static String valueToString(Metadata metadata) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple();
-    ToStringGenerator.addToString(sourceBuilder, metadata, false);
-    return sourceBuilder.toString();
+  private static ToStringBuilder builderFor(String typename) {
+    return new ToStringBuilder(typename);
   }
 
-  private static String partialToString(Metadata metadata) {
-    SourceBuilder sourceBuilder = SourceStringBuilder.simple();
-    ToStringGenerator.addToString(sourceBuilder, metadata, true);
-    return sourceBuilder.toString();
-  }
-
-  private static PartialMetadataBuilder datatype(String typename) {
-    return new PartialMetadataBuilder(typename);
-  }
-
-  private static class PartialMetadataBuilder {
+  private static class ToStringBuilder {
     private final Metadata.Builder builder;
 
-    PartialMetadataBuilder(String typename) {
+    ToStringBuilder(String typename) {
       builder = new Metadata.Builder()
           .setType(QualifiedName.of("com.example", typename).withParameters())
           .setPropertyEnum(
               QualifiedName.of("com.example", typename + "_Builder", "Property").withParameters());
     }
 
-    PartialMetadataBuilder withRequired(String name) {
+    ToStringBuilder withRequired(String name) {
       return with(Type.REQUIRED, name);
     }
 
-    PartialMetadataBuilder withOptional(String name) {
+    ToStringBuilder withOptional(String name) {
       return with(Type.OPTIONAL, name);
     }
 
-    PartialMetadataBuilder withDefault(String name) {
+    ToStringBuilder withDefault(String name) {
       return with(Type.HAS_DEFAULT, name);
     }
 
-    private PartialMetadataBuilder with(PropertyCodeGenerator.Type type, String name) {
+    String valueToString() {
+      SourceBuilder code = SourceStringBuilder.simple();
+      ToStringGenerator.addToString(code, builder.buildPartial(), false);
+      return code.toString();
+    }
+
+    String partialToString() {
+      SourceBuilder code = SourceStringBuilder.simple();
+      ToStringGenerator.addToString(code, builder.buildPartial(), true);
+      return code.toString();
+    }
+
+    private ToStringBuilder with(PropertyCodeGenerator.Type type, String name) {
       PropertyCodeGenerator mock = mock(PropertyCodeGenerator.class, new ReturnsSmartNulls());
       when(mock.getType()).thenReturn(type);
       builder.addProperties(new Property.Builder()
@@ -569,10 +562,6 @@ public class ToStringGeneratorTest {
           .setCodeGenerator(mock)
           .buildPartial());
       return this;
-    }
-
-    Metadata build() {
-      return builder.buildPartial();
     }
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/ToStringGeneratorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ToStringGeneratorTest.java
@@ -13,6 +13,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsSmartNulls;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RunWith(JUnit4.class)
 public class ToStringGeneratorTest {
 
@@ -519,13 +522,16 @@ public class ToStringGeneratorTest {
   }
 
   private static class ToStringBuilder {
-    private final Datatype.Builder builder;
+
+    private final Datatype datatype;
+    private final List<Property> properties = new ArrayList<>();
 
     ToStringBuilder(String typename) {
-      builder = new Datatype.Builder()
+      datatype = new Datatype.Builder()
           .setType(QualifiedName.of("com.example", typename).withParameters())
           .setPropertyEnum(
-              QualifiedName.of("com.example", typename + "_Builder", "Property").withParameters());
+              QualifiedName.of("com.example", typename + "_Builder", "Property").withParameters())
+          .buildPartial();
     }
 
     ToStringBuilder withRequired(String name) {
@@ -542,20 +548,20 @@ public class ToStringGeneratorTest {
 
     String valueToString() {
       SourceBuilder code = SourceStringBuilder.simple();
-      ToStringGenerator.addToString(code, builder.buildPartial(), false);
+      ToStringGenerator.addToString(code, datatype, properties, false);
       return code.toString();
     }
 
     String partialToString() {
       SourceBuilder code = SourceStringBuilder.simple();
-      ToStringGenerator.addToString(code, builder.buildPartial(), true);
+      ToStringGenerator.addToString(code, datatype, properties, true);
       return code.toString();
     }
 
     private ToStringBuilder with(PropertyCodeGenerator.Type type, String name) {
       PropertyCodeGenerator mock = mock(PropertyCodeGenerator.class, new ReturnsSmartNulls());
       when(mock.getType()).thenReturn(type);
-      builder.addProperties(new Property.Builder()
+      properties.add(new Property.Builder()
           .setName(name)
           .setAllCapsName(name.replaceAll("([A-Z])", "_$1").toUpperCase())
           .setCodeGenerator(mock)

--- a/src/test/java/org/inferred/freebuilder/processor/ToStringGeneratorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ToStringGeneratorTest.java
@@ -519,10 +519,10 @@ public class ToStringGeneratorTest {
   }
 
   private static class ToStringBuilder {
-    private final Metadata.Builder builder;
+    private final Datatype.Builder builder;
 
     ToStringBuilder(String typename) {
-      builder = new Metadata.Builder()
+      builder = new Datatype.Builder()
           .setType(QualifiedName.of("com.example", typename).withParameters())
           .setPropertyEnum(
               QualifiedName.of("com.example", typename + "_Builder", "Property").withParameters());

--- a/src/test/java/org/inferred/freebuilder/processor/ToStringGeneratorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ToStringGeneratorTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.inferred.freebuilder.processor.Metadata.Property;
 import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;


### PR DESCRIPTION
Property code generators need general metadata about the datatype plus their own property metadata, but not a list of all properties. Separating Metadata makes the data flow clearer.