### PR TITLE
Fix bug causing some generated JavaDoc to be missing

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
@@ -257,7 +257,7 @@ class GeneratedBuilder extends GeneratedType {
           .addLine(" * when accessed via the partial object.");
     }
     if (datatype.getHasToBuilderMethod()
-        && datatype.getBuilderFactory() == Optional.of(BuilderFactory.NO_ARGS_CONSTRUCTOR)) {
+        && datatype.getBuilderFactory().equals(Optional.of(BuilderFactory.NO_ARGS_CONSTRUCTOR))) {
       code.addLine(" *")
           .addLine(" * <p>The builder returned by a partial's {@link %s#toBuilder() toBuilder}",
               datatype.getType())

--- a/src/main/java/org/inferred/freebuilder/processor/util/FunctionalType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/FunctionalType.java
@@ -31,7 +31,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 /**
- * Datatype about a functional interface.
+ * Metadata about a functional interface.
  */
 public class FunctionalType extends ValueType {
 

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
@@ -950,6 +950,12 @@ public class DefaultedPropertiesSourceTest {
             + "State checking will not",
         "   * be performed.",
         "   *",
+        "   * <p>The builder returned by a partial's {@link Person#toBuilder() toBuilder} method "
+            + "overrides",
+        "   * {@link Person.Builder#build() build()} to return another partial. This allows for "
+            + "robust tests",
+        "   * of modify-rebuild code.",
+        "   *",
         "   * <p>Partials should only ever be used in tests. "
             + "They permit writing robust test cases that won't",
         "   * fail if this type gains more application-level constraints "

--- a/src/test/java/org/inferred/freebuilder/processor/GeneratedTypeSubject.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GeneratedTypeSubject.java
@@ -10,6 +10,7 @@ import com.google.googlejavaformat.java.FormatterException;
 
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.feature.Feature;
+import org.junit.ComparisonFailure;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -41,7 +42,7 @@ class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> 
     try {
       String formattedSource = new Formatter().formatSource(rawSource);
       if (!formattedSource.equals(expected)) {
-        failWithCustomSubject("is equal to", expected, formattedSource);
+        throw new ComparisonFailure("Generated code incorrect", expected, formattedSource);
       }
     } catch (FormatterException e) {
       int no = 0;


### PR DESCRIPTION
Used == instead of .equals