### PR TITLE
Split ParameterizedType in two

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -47,8 +47,8 @@ import org.inferred.freebuilder.processor.PropertyCodeGenerator.Config;
 import org.inferred.freebuilder.processor.naming.NamingConvention;
 import org.inferred.freebuilder.processor.util.MethodFinder.ErrorTypeHandling;
 import org.inferred.freebuilder.processor.util.ModelUtils;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
+import org.inferred.freebuilder.processor.util.Type;
 
 import java.io.Serializable;
 import java.util.LinkedHashMap;
@@ -173,7 +173,7 @@ class Analyser {
         .setHasToBuilderMethod(hasToBuilderMethod(
             builder, constructionAndExtension.isExtensible(), methods))
         .setBuilderSerializable(shouldBuilderBeSerializable(builder))
-        .setBuilder(ParameterizedType.from(builder));
+        .setBuilder(Type.from(builder));
     Datatype baseDatatype = datatypeBuilder.build();
     Map<Property, PropertyCodeGenerator> generatorsByProperty = pickPropertyGenerators(
         type, baseDatatype, builder, removeNonGetterMethods(builder, methods));

--- a/src/main/java/org/inferred/freebuilder/processor/BuildableProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildableProperty.java
@@ -43,6 +43,7 @@ import org.inferred.freebuilder.processor.util.ModelUtils;
 import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.Type;
+import org.inferred.freebuilder.processor.util.TypeClass;
 import org.inferred.freebuilder.processor.util.Variable;
 
 import java.util.List;
@@ -174,7 +175,7 @@ class BuildableProperty extends PropertyCodeGenerator {
       return Optional.of(new BuildableProperty(
           config.getDatatype(),
           config.getProperty(),
-          Type.from(builder.get()),
+          TypeClass.from(builder.get()),
           builderFactory.get(),
           mutatorType,
           mergeFromBuilderMethod,

--- a/src/main/java/org/inferred/freebuilder/processor/BuildableProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildableProperty.java
@@ -40,9 +40,9 @@ import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.FunctionalType;
 import org.inferred.freebuilder.processor.util.ModelUtils;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.Type;
 import org.inferred.freebuilder.processor.util.Variable;
 
 import java.util.List;
@@ -174,7 +174,7 @@ class BuildableProperty extends PropertyCodeGenerator {
       return Optional.of(new BuildableProperty(
           config.getDatatype(),
           config.getProperty(),
-          ParameterizedType.from(builder.get()),
+          Type.from(builder.get()),
           builderFactory.get(),
           mutatorType,
           mergeFromBuilderMethod,
@@ -182,7 +182,7 @@ class BuildableProperty extends PropertyCodeGenerator {
     }
   }
 
-  private final ParameterizedType builderType;
+  private final Type builderType;
   private final BuilderFactory builderFactory;
   private final FunctionalType mutatorType;
   private final MergeBuilderMethod mergeFromBuilderMethod;
@@ -192,7 +192,7 @@ class BuildableProperty extends PropertyCodeGenerator {
   private BuildableProperty(
       Datatype datatype,
       Property property,
-      ParameterizedType builderType,
+      Type builderType,
       BuilderFactory builderFactory,
       FunctionalType mutatorType,
       MergeBuilderMethod mergeFromBuilderMethod,

--- a/src/main/java/org/inferred/freebuilder/processor/BuilderFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuilderFactory.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.Excerpts;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
+import org.inferred.freebuilder.processor.util.Type;
 
 import java.util.Set;
 
@@ -37,9 +37,7 @@ public enum BuilderFactory {
 
   /** A new Builder can be made by calling the class' no-args constructor. */
   NO_ARGS_CONSTRUCTOR {
-    @Override public Excerpt newBuilder(
-        final ParameterizedType builderType,
-        final TypeInference typeInference) {
+    @Override public Excerpt newBuilder(Type builderType, TypeInference typeInference) {
       if (typeInference == TypeInference.INFERRED_TYPES) {
         return Excerpts.add("%s()", builderType.constructor());
       } else {
@@ -50,9 +48,7 @@ public enum BuilderFactory {
 
   /** The enclosing class provides a static builder() factory method. */
   BUILDER_METHOD {
-    @Override public Excerpt newBuilder(
-        final ParameterizedType builderType,
-        final TypeInference typeInference) {
+    @Override public Excerpt newBuilder(Type builderType, TypeInference typeInference) {
       if (typeInference == TypeInference.INFERRED_TYPES) {
         return Excerpts.add("%s.builder()", builderType.getQualifiedName().getEnclosingType());
       } else {
@@ -64,9 +60,7 @@ public enum BuilderFactory {
 
   /** The enclosing class provides a static newBuilder() factory method. */
   NEW_BUILDER_METHOD {
-    @Override public Excerpt newBuilder(
-        final ParameterizedType builderType,
-        final TypeInference typeInference) {
+    @Override public Excerpt newBuilder(Type builderType, TypeInference typeInference) {
       if (typeInference == TypeInference.INFERRED_TYPES) {
         return Excerpts.add("%s.newBuilder()", builderType.getQualifiedName().getEnclosingType());
       } else {
@@ -112,7 +106,7 @@ public enum BuilderFactory {
   }
 
   /** Returns an excerpt calling the Builder factory method. */
-  public abstract Excerpt newBuilder(ParameterizedType builderType, TypeInference typeInference);
+  public abstract Excerpt newBuilder(Type builderType, TypeInference typeInference);
 
   private static boolean typeIsAbstract(TypeElement type) {
     return type.getModifiers().contains(Modifier.ABSTRACT);

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -23,9 +23,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.util.Excerpt;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.Type;
 
 /**
  * Metadata about a user's datatype.
@@ -84,7 +84,7 @@ public abstract class Datatype {
   }
 
   /** Returns the type itself. */
-  public abstract ParameterizedType getType();
+  public abstract Type getType();
 
   /** Returns true if the type is an interface. */
   public abstract boolean isInterfaceType();
@@ -94,7 +94,7 @@ public abstract class Datatype {
    *
    * @throws IllegalStateException if {@link #hasBuilder} returns false.
    */
-  public abstract ParameterizedType getBuilder();
+  public abstract Type getBuilder();
 
   /** Whether there is a package-visible, no-args constructor so we can subclass the Builder. */
   public abstract boolean isExtensible();
@@ -103,13 +103,13 @@ public abstract class Datatype {
   public abstract Optional<BuilderFactory> getBuilderFactory();
 
   /** Returns the builder class that should be generated. */
-  public abstract ParameterizedType getGeneratedBuilder();
+  public abstract Type getGeneratedBuilder();
 
   /** Returns the value class that should be generated. */
-  public abstract ParameterizedType getValueType();
+  public abstract Type getValueType();
 
   /** Returns the partial value class that should be generated. */
-  public abstract ParameterizedType getPartialType();
+  public abstract Type getPartialType();
 
   /**
    * Returns a set of nested types that will be visible in the generated class, either because they
@@ -118,7 +118,7 @@ public abstract class Datatype {
   public abstract ImmutableSet<QualifiedName> getVisibleNestedTypes();
 
   /** Returns the Property enum that may be generated. */
-  public abstract ParameterizedType getPropertyEnum();
+  public abstract Type getPropertyEnum();
 
   public UnderrideLevel standardMethodUnderride(StandardMethod standardMethod) {
     UnderrideLevel underrideLevel = getStandardMethodUnderrides().get(standardMethod);

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -26,6 +26,7 @@ import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.Type;
+import org.inferred.freebuilder.processor.util.TypeClass;
 
 /**
  * Metadata about a user's datatype.
@@ -84,7 +85,7 @@ public abstract class Datatype {
   }
 
   /** Returns the type itself. */
-  public abstract Type getType();
+  public abstract TypeClass getType();
 
   /** Returns true if the type is an interface. */
   public abstract boolean isInterfaceType();
@@ -103,13 +104,13 @@ public abstract class Datatype {
   public abstract Optional<BuilderFactory> getBuilderFactory();
 
   /** Returns the builder class that should be generated. */
-  public abstract Type getGeneratedBuilder();
+  public abstract TypeClass getGeneratedBuilder();
 
   /** Returns the value class that should be generated. */
-  public abstract Type getValueType();
+  public abstract TypeClass getValueType();
 
   /** Returns the partial value class that should be generated. */
-  public abstract Type getPartialType();
+  public abstract TypeClass getPartialType();
 
   /**
    * Returns a set of nested types that will be visible in the generated class, either because they
@@ -118,7 +119,7 @@ public abstract class Datatype {
   public abstract ImmutableSet<QualifiedName> getVisibleNestedTypes();
 
   /** Returns the Property enum that may be generated. */
-  public abstract Type getPropertyEnum();
+  public abstract TypeClass getPropertyEnum();
 
   public UnderrideLevel standardMethodUnderride(StandardMethod standardMethod) {
     UnderrideLevel underrideLevel = getStandardMethodUnderrides().get(standardMethod);

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
 import org.inferred.freebuilder.processor.util.Excerpt;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
+import org.inferred.freebuilder.processor.util.Type;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 
 /**
@@ -60,19 +60,19 @@ abstract class Datatype_Builder {
     }
   }
 
-  private ParameterizedType type;
+  private Type type;
   private boolean interfaceType;
-  private ParameterizedType builder;
+  private Type builder;
   private boolean extensible;
   // Store a nullable object instead of an Optional. Escape analysis then
   // allows the JVM to optimize away the Optional objects created by and
   // passed to our API.
   private BuilderFactory builderFactory = null;
-  private ParameterizedType generatedBuilder;
-  private ParameterizedType valueType;
-  private ParameterizedType partialType;
+  private Type generatedBuilder;
+  private Type valueType;
+  private Type partialType;
   private Set<QualifiedName> visibleNestedTypes = ImmutableSet.of();
-  private ParameterizedType propertyEnum;
+  private Type propertyEnum;
   private final LinkedHashMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
       standardMethodUnderrides =
           new LinkedHashMap<Datatype.StandardMethod, Datatype.UnderrideLevel>();
@@ -91,7 +91,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code type} is null
    */
-  public Datatype.Builder setType(ParameterizedType type) {
+  public Datatype.Builder setType(Type type) {
     this.type = Preconditions.checkNotNull(type);
     _unsetProperties.remove(Datatype_Builder.Property.TYPE);
     return (Datatype.Builder) this;
@@ -102,7 +102,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public ParameterizedType getType() {
+  public Type getType() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.TYPE), "type not set");
     return type;
@@ -137,7 +137,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code builder} is null
    */
-  public Datatype.Builder setBuilder(ParameterizedType builder) {
+  public Datatype.Builder setBuilder(Type builder) {
     this.builder = Preconditions.checkNotNull(builder);
     _unsetProperties.remove(Datatype_Builder.Property.BUILDER);
     return (Datatype.Builder) this;
@@ -148,7 +148,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public ParameterizedType getBuilder() {
+  public Type getBuilder() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.BUILDER), "builder not set");
     return builder;
@@ -235,7 +235,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code generatedBuilder} is null
    */
-  public Datatype.Builder setGeneratedBuilder(ParameterizedType generatedBuilder) {
+  public Datatype.Builder setGeneratedBuilder(Type generatedBuilder) {
     this.generatedBuilder = Preconditions.checkNotNull(generatedBuilder);
     _unsetProperties.remove(Datatype_Builder.Property.GENERATED_BUILDER);
     return (Datatype.Builder) this;
@@ -246,7 +246,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public ParameterizedType getGeneratedBuilder() {
+  public Type getGeneratedBuilder() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.GENERATED_BUILDER),
         "generatedBuilder not set");
@@ -259,7 +259,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code valueType} is null
    */
-  public Datatype.Builder setValueType(ParameterizedType valueType) {
+  public Datatype.Builder setValueType(Type valueType) {
     this.valueType = Preconditions.checkNotNull(valueType);
     _unsetProperties.remove(Datatype_Builder.Property.VALUE_TYPE);
     return (Datatype.Builder) this;
@@ -270,7 +270,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public ParameterizedType getValueType() {
+  public Type getValueType() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE), "valueType not set");
     return valueType;
@@ -282,7 +282,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code partialType} is null
    */
-  public Datatype.Builder setPartialType(ParameterizedType partialType) {
+  public Datatype.Builder setPartialType(Type partialType) {
     this.partialType = Preconditions.checkNotNull(partialType);
     _unsetProperties.remove(Datatype_Builder.Property.PARTIAL_TYPE);
     return (Datatype.Builder) this;
@@ -293,7 +293,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public ParameterizedType getPartialType() {
+  public Type getPartialType() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.PARTIAL_TYPE), "partialType not set");
     return partialType;
@@ -388,7 +388,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code propertyEnum} is null
    */
-  public Datatype.Builder setPropertyEnum(ParameterizedType propertyEnum) {
+  public Datatype.Builder setPropertyEnum(Type propertyEnum) {
     this.propertyEnum = Preconditions.checkNotNull(propertyEnum);
     _unsetProperties.remove(Datatype_Builder.Property.PROPERTY_ENUM);
     return (Datatype.Builder) this;
@@ -399,7 +399,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public ParameterizedType getPropertyEnum() {
+  public Type getPropertyEnum() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM),
         "propertyEnum not set");
@@ -965,19 +965,19 @@ abstract class Datatype_Builder {
   }
 
   private static final class Value extends Datatype {
-    private final ParameterizedType type;
+    private final Type type;
     private final boolean interfaceType;
-    private final ParameterizedType builder;
+    private final Type builder;
     private final boolean extensible;
     // Store a nullable object instead of an Optional. Escape analysis then
     // allows the JVM to optimize away the Optional objects created by our
     // getter method.
     private final BuilderFactory builderFactory;
-    private final ParameterizedType generatedBuilder;
-    private final ParameterizedType valueType;
-    private final ParameterizedType partialType;
+    private final Type generatedBuilder;
+    private final Type valueType;
+    private final Type partialType;
     private final ImmutableSet<QualifiedName> visibleNestedTypes;
-    private final ParameterizedType propertyEnum;
+    private final Type propertyEnum;
     private final ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         standardMethodUnderrides;
     private final boolean builderSerializable;
@@ -1008,7 +1008,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ParameterizedType getType() {
+    public Type getType() {
       return type;
     }
 
@@ -1018,7 +1018,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ParameterizedType getBuilder() {
+    public Type getBuilder() {
       return builder;
     }
 
@@ -1033,17 +1033,17 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ParameterizedType getGeneratedBuilder() {
+    public Type getGeneratedBuilder() {
       return generatedBuilder;
     }
 
     @Override
-    public ParameterizedType getValueType() {
+    public Type getValueType() {
       return valueType;
     }
 
     @Override
-    public ParameterizedType getPartialType() {
+    public Type getPartialType() {
       return partialType;
     }
 
@@ -1053,7 +1053,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ParameterizedType getPropertyEnum() {
+    public Type getPropertyEnum() {
       return propertyEnum;
     }
 
@@ -1223,19 +1223,19 @@ abstract class Datatype_Builder {
   }
 
   private static final class Partial extends Datatype {
-    private final ParameterizedType type;
+    private final Type type;
     private final boolean interfaceType;
-    private final ParameterizedType builder;
+    private final Type builder;
     private final boolean extensible;
     // Store a nullable object instead of an Optional. Escape analysis then
     // allows the JVM to optimize away the Optional objects created by our
     // getter method.
     private final BuilderFactory builderFactory;
-    private final ParameterizedType generatedBuilder;
-    private final ParameterizedType valueType;
-    private final ParameterizedType partialType;
+    private final Type generatedBuilder;
+    private final Type valueType;
+    private final Type partialType;
     private final ImmutableSet<QualifiedName> visibleNestedTypes;
-    private final ParameterizedType propertyEnum;
+    private final Type propertyEnum;
     private final ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         standardMethodUnderrides;
     private final boolean builderSerializable;
@@ -1268,7 +1268,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ParameterizedType getType() {
+    public Type getType() {
       if (_unsetProperties.contains(Datatype_Builder.Property.TYPE)) {
         throw new UnsupportedOperationException("type not set");
       }
@@ -1284,7 +1284,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ParameterizedType getBuilder() {
+    public Type getBuilder() {
       if (_unsetProperties.contains(Datatype_Builder.Property.BUILDER)) {
         throw new UnsupportedOperationException("builder not set");
       }
@@ -1305,7 +1305,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ParameterizedType getGeneratedBuilder() {
+    public Type getGeneratedBuilder() {
       if (_unsetProperties.contains(Datatype_Builder.Property.GENERATED_BUILDER)) {
         throw new UnsupportedOperationException("generatedBuilder not set");
       }
@@ -1313,7 +1313,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ParameterizedType getValueType() {
+    public Type getValueType() {
       if (_unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE)) {
         throw new UnsupportedOperationException("valueType not set");
       }
@@ -1321,7 +1321,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ParameterizedType getPartialType() {
+    public Type getPartialType() {
       if (_unsetProperties.contains(Datatype_Builder.Property.PARTIAL_TYPE)) {
         throw new UnsupportedOperationException("partialType not set");
       }
@@ -1334,7 +1334,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public ParameterizedType getPropertyEnum() {
+    public Type getPropertyEnum() {
       if (_unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM)) {
         throw new UnsupportedOperationException("propertyEnum not set");
       }

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
@@ -20,8 +20,9 @@ import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
 import org.inferred.freebuilder.processor.util.Excerpt;
-import org.inferred.freebuilder.processor.util.Type;
 import org.inferred.freebuilder.processor.util.QualifiedName;
+import org.inferred.freebuilder.processor.util.Type;
+import org.inferred.freebuilder.processor.util.TypeClass;
 
 /**
  * Auto-generated superclass of {@link Datatype.Builder}, derived from the API of {@link Datatype}.
@@ -60,7 +61,7 @@ abstract class Datatype_Builder {
     }
   }
 
-  private Type type;
+  private TypeClass type;
   private boolean interfaceType;
   private Type builder;
   private boolean extensible;
@@ -68,11 +69,11 @@ abstract class Datatype_Builder {
   // allows the JVM to optimize away the Optional objects created by and
   // passed to our API.
   private BuilderFactory builderFactory = null;
-  private Type generatedBuilder;
-  private Type valueType;
-  private Type partialType;
+  private TypeClass generatedBuilder;
+  private TypeClass valueType;
+  private TypeClass partialType;
   private Set<QualifiedName> visibleNestedTypes = ImmutableSet.of();
-  private Type propertyEnum;
+  private TypeClass propertyEnum;
   private final LinkedHashMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
       standardMethodUnderrides =
           new LinkedHashMap<Datatype.StandardMethod, Datatype.UnderrideLevel>();
@@ -91,7 +92,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code type} is null
    */
-  public Datatype.Builder setType(Type type) {
+  public Datatype.Builder setType(TypeClass type) {
     this.type = Preconditions.checkNotNull(type);
     _unsetProperties.remove(Datatype_Builder.Property.TYPE);
     return (Datatype.Builder) this;
@@ -102,7 +103,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public Type getType() {
+  public TypeClass getType() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.TYPE), "type not set");
     return type;
@@ -235,7 +236,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code generatedBuilder} is null
    */
-  public Datatype.Builder setGeneratedBuilder(Type generatedBuilder) {
+  public Datatype.Builder setGeneratedBuilder(TypeClass generatedBuilder) {
     this.generatedBuilder = Preconditions.checkNotNull(generatedBuilder);
     _unsetProperties.remove(Datatype_Builder.Property.GENERATED_BUILDER);
     return (Datatype.Builder) this;
@@ -246,7 +247,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public Type getGeneratedBuilder() {
+  public TypeClass getGeneratedBuilder() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.GENERATED_BUILDER),
         "generatedBuilder not set");
@@ -259,7 +260,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code valueType} is null
    */
-  public Datatype.Builder setValueType(Type valueType) {
+  public Datatype.Builder setValueType(TypeClass valueType) {
     this.valueType = Preconditions.checkNotNull(valueType);
     _unsetProperties.remove(Datatype_Builder.Property.VALUE_TYPE);
     return (Datatype.Builder) this;
@@ -270,7 +271,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public Type getValueType() {
+  public TypeClass getValueType() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE), "valueType not set");
     return valueType;
@@ -282,7 +283,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code partialType} is null
    */
-  public Datatype.Builder setPartialType(Type partialType) {
+  public Datatype.Builder setPartialType(TypeClass partialType) {
     this.partialType = Preconditions.checkNotNull(partialType);
     _unsetProperties.remove(Datatype_Builder.Property.PARTIAL_TYPE);
     return (Datatype.Builder) this;
@@ -293,7 +294,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public Type getPartialType() {
+  public TypeClass getPartialType() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.PARTIAL_TYPE), "partialType not set");
     return partialType;
@@ -388,7 +389,7 @@ abstract class Datatype_Builder {
    * @return this {@code Builder} object
    * @throws NullPointerException if {@code propertyEnum} is null
    */
-  public Datatype.Builder setPropertyEnum(Type propertyEnum) {
+  public Datatype.Builder setPropertyEnum(TypeClass propertyEnum) {
     this.propertyEnum = Preconditions.checkNotNull(propertyEnum);
     _unsetProperties.remove(Datatype_Builder.Property.PROPERTY_ENUM);
     return (Datatype.Builder) this;
@@ -399,7 +400,7 @@ abstract class Datatype_Builder {
    *
    * @throws IllegalStateException if the field has not been set
    */
-  public Type getPropertyEnum() {
+  public TypeClass getPropertyEnum() {
     Preconditions.checkState(
         !_unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM),
         "propertyEnum not set");
@@ -965,7 +966,7 @@ abstract class Datatype_Builder {
   }
 
   private static final class Value extends Datatype {
-    private final Type type;
+    private final TypeClass type;
     private final boolean interfaceType;
     private final Type builder;
     private final boolean extensible;
@@ -973,11 +974,11 @@ abstract class Datatype_Builder {
     // allows the JVM to optimize away the Optional objects created by our
     // getter method.
     private final BuilderFactory builderFactory;
-    private final Type generatedBuilder;
-    private final Type valueType;
-    private final Type partialType;
+    private final TypeClass generatedBuilder;
+    private final TypeClass valueType;
+    private final TypeClass partialType;
     private final ImmutableSet<QualifiedName> visibleNestedTypes;
-    private final Type propertyEnum;
+    private final TypeClass propertyEnum;
     private final ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         standardMethodUnderrides;
     private final boolean builderSerializable;
@@ -1008,7 +1009,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public Type getType() {
+    public TypeClass getType() {
       return type;
     }
 
@@ -1033,17 +1034,17 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public Type getGeneratedBuilder() {
+    public TypeClass getGeneratedBuilder() {
       return generatedBuilder;
     }
 
     @Override
-    public Type getValueType() {
+    public TypeClass getValueType() {
       return valueType;
     }
 
     @Override
-    public Type getPartialType() {
+    public TypeClass getPartialType() {
       return partialType;
     }
 
@@ -1053,7 +1054,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public Type getPropertyEnum() {
+    public TypeClass getPropertyEnum() {
       return propertyEnum;
     }
 
@@ -1223,7 +1224,7 @@ abstract class Datatype_Builder {
   }
 
   private static final class Partial extends Datatype {
-    private final Type type;
+    private final TypeClass type;
     private final boolean interfaceType;
     private final Type builder;
     private final boolean extensible;
@@ -1231,11 +1232,11 @@ abstract class Datatype_Builder {
     // allows the JVM to optimize away the Optional objects created by our
     // getter method.
     private final BuilderFactory builderFactory;
-    private final Type generatedBuilder;
-    private final Type valueType;
-    private final Type partialType;
+    private final TypeClass generatedBuilder;
+    private final TypeClass valueType;
+    private final TypeClass partialType;
     private final ImmutableSet<QualifiedName> visibleNestedTypes;
-    private final Type propertyEnum;
+    private final TypeClass propertyEnum;
     private final ImmutableMap<Datatype.StandardMethod, Datatype.UnderrideLevel>
         standardMethodUnderrides;
     private final boolean builderSerializable;
@@ -1268,7 +1269,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public Type getType() {
+    public TypeClass getType() {
       if (_unsetProperties.contains(Datatype_Builder.Property.TYPE)) {
         throw new UnsupportedOperationException("type not set");
       }
@@ -1305,7 +1306,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public Type getGeneratedBuilder() {
+    public TypeClass getGeneratedBuilder() {
       if (_unsetProperties.contains(Datatype_Builder.Property.GENERATED_BUILDER)) {
         throw new UnsupportedOperationException("generatedBuilder not set");
       }
@@ -1313,7 +1314,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public Type getValueType() {
+    public TypeClass getValueType() {
       if (_unsetProperties.contains(Datatype_Builder.Property.VALUE_TYPE)) {
         throw new UnsupportedOperationException("valueType not set");
       }
@@ -1321,7 +1322,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public Type getPartialType() {
+    public TypeClass getPartialType() {
       if (_unsetProperties.contains(Datatype_Builder.Property.PARTIAL_TYPE)) {
         throw new UnsupportedOperationException("partialType not set");
       }
@@ -1334,7 +1335,7 @@ abstract class Datatype_Builder {
     }
 
     @Override
-    public Type getPropertyEnum() {
+    public TypeClass getPropertyEnum() {
       if (_unsetProperties.contains(Datatype_Builder.Property.PROPERTY_ENUM)) {
         throw new UnsupportedOperationException("propertyEnum not set");
       }

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedStub.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedStub.java
@@ -5,16 +5,16 @@ import com.google.common.collect.ImmutableSet;
 import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
-import org.inferred.freebuilder.processor.util.Type;
+import org.inferred.freebuilder.processor.util.TypeClass;
 
 import java.util.Set;
 
 class GeneratedStub extends GeneratedType {
 
   private final QualifiedName datatype;
-  private final Type stub;
+  private final TypeClass stub;
 
-  GeneratedStub(QualifiedName datatype, Type stub) {
+  GeneratedStub(QualifiedName datatype, TypeClass stub) {
     this.datatype = datatype;
     this.stub = stub;
   }

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedStub.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedStub.java
@@ -3,18 +3,18 @@ package org.inferred.freebuilder.processor;
 import com.google.common.collect.ImmutableSet;
 
 import org.inferred.freebuilder.processor.util.Excerpts;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.Type;
 
 import java.util.Set;
 
 class GeneratedStub extends GeneratedType {
 
   private final QualifiedName datatype;
-  private final ParameterizedType stub;
+  private final Type stub;
 
-  GeneratedStub(QualifiedName datatype, ParameterizedType stub) {
+  GeneratedStub(QualifiedName datatype, Type stub) {
     this.datatype = datatype;
     this.stub = stub;
   }

--- a/src/main/java/org/inferred/freebuilder/processor/ListProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListProperty.java
@@ -46,9 +46,9 @@ import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.FunctionalType;
 import org.inferred.freebuilder.processor.util.LazyName;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.Type;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -129,7 +129,7 @@ class ListProperty extends PropertyCodeGenerator {
     }
   }
 
-  private static final ParameterizedType COLLECTION =
+  private static final Type COLLECTION =
       QualifiedName.of(Collection.class).withParameters("E");
 
   private final boolean needsSafeVarargs;

--- a/src/main/java/org/inferred/freebuilder/processor/ListProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ListProperty.java
@@ -129,9 +129,6 @@ class ListProperty extends PropertyCodeGenerator {
     }
   }
 
-  private static final Type COLLECTION =
-      QualifiedName.of(Collection.class).withParameters("E");
-
   private final boolean needsSafeVarargs;
   private final boolean overridesAddMethod;
   private final boolean overridesVarargsAddMethod;
@@ -383,7 +380,7 @@ class ListProperty extends PropertyCodeGenerator {
         .addLine(" * <p>This method mutates the list in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
         .addLine(" * not to call pure functions, like %s.",
-            COLLECTION.javadocNoArgMethodLink("stream"))
+            Type.from(Collection.class).javadocNoArgMethodLink("stream"))
         .addLine(" *")
         .addLine(" * @return this {@code Builder} object")
         .addLine(" * @throws NullPointerException if {@code mutator} is null")

--- a/src/main/java/org/inferred/freebuilder/processor/MapProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MapProperty.java
@@ -42,10 +42,10 @@ import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.FunctionalType;
 import org.inferred.freebuilder.processor.util.LazyName;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.Type;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -117,7 +117,7 @@ class MapProperty extends PropertyCodeGenerator {
     }
   }
 
-  private static final ParameterizedType COLLECTION =
+  private static final Type COLLECTION =
       QualifiedName.of(Collection.class).withParameters("E");
 
   private final boolean overridesPutMethod;

--- a/src/main/java/org/inferred/freebuilder/processor/MapProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MapProperty.java
@@ -43,7 +43,6 @@ import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.FunctionalType;
 import org.inferred.freebuilder.processor.util.LazyName;
 import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
-import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.Type;
 
@@ -116,9 +115,6 @@ class MapProperty extends PropertyCodeGenerator {
       return types.getWildcardType(null, types.getDeclaredType(mapType, keyType, valueType));
     }
   }
-
-  private static final Type COLLECTION =
-      QualifiedName.of(Collection.class).withParameters("E");
 
   private final boolean overridesPutMethod;
   private final TypeMirror keyType;
@@ -267,7 +263,7 @@ class MapProperty extends PropertyCodeGenerator {
         .addLine(" * <p>This method mutates the map in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
         .addLine(" * not to call pure functions, like %s.",
-            COLLECTION.javadocNoArgMethodLink("stream"))
+            Type.from(Collection.class).javadocNoArgMethodLink("stream"))
         .addLine(" *")
         .addLine(" * @return this {@code Builder} object")
         .addLine(" * @throws NullPointerException if {@code mutator} is null")

--- a/src/main/java/org/inferred/freebuilder/processor/MultisetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MultisetProperty.java
@@ -125,8 +125,6 @@ class MultisetProperty extends PropertyCodeGenerator {
     }
   }
 
-  private static final Type COLLECTION =
-      QualifiedName.of(Collection.class).withParameters("E");
   private final boolean needsSafeVarargs;
   private final boolean overridesSetCountMethod;
   private final boolean overridesVarargsAddMethod;
@@ -338,7 +336,7 @@ class MultisetProperty extends PropertyCodeGenerator {
         .addLine(" * <p>This method mutates the multiset in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
         .addLine(" * not to call pure functions, like %s.",
-            COLLECTION.javadocNoArgMethodLink("stream"))
+            Type.from(Collection.class).javadocNoArgMethodLink("stream"))
         .addLine(" *")
         .addLine(" * @return this {@code Builder} object")
         .addLine(" * @throws NullPointerException if {@code mutator} is null")

--- a/src/main/java/org/inferred/freebuilder/processor/MultisetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/MultisetProperty.java
@@ -45,9 +45,9 @@ import org.inferred.freebuilder.processor.excerpt.CheckedMultiset;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.FunctionalType;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.Type;
 
 import java.util.Collection;
 
@@ -125,7 +125,7 @@ class MultisetProperty extends PropertyCodeGenerator {
     }
   }
 
-  private static final ParameterizedType COLLECTION =
+  private static final Type COLLECTION =
       QualifiedName.of(Collection.class).withParameters("E");
   private final boolean needsSafeVarargs;
   private final boolean overridesSetCountMethod;

--- a/src/main/java/org/inferred/freebuilder/processor/SetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetProperty.java
@@ -125,8 +125,6 @@ class SetProperty extends PropertyCodeGenerator {
     }
   }
 
-  private static final Type COLLECTION =
-      QualifiedName.of(Collection.class).withParameters("E");
   private final TypeMirror elementType;
   private final Optional<TypeMirror> unboxedType;
   private final FunctionalType mutatorType;
@@ -360,7 +358,7 @@ class SetProperty extends PropertyCodeGenerator {
         .addLine(" * <p>This method mutates the set in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
         .addLine(" * not to call pure functions, like %s.",
-            COLLECTION.javadocNoArgMethodLink("stream"))
+            Type.from(Collection.class).javadocNoArgMethodLink("stream"))
         .addLine(" *")
         .addLine(" * @return this {@code Builder} object")
         .addLine(" * @throws NullPointerException if {@code mutator} is null")

--- a/src/main/java/org/inferred/freebuilder/processor/SetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SetProperty.java
@@ -46,9 +46,9 @@ import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.FunctionalType;
 import org.inferred.freebuilder.processor.util.LazyName;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.Type;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -125,7 +125,7 @@ class SetProperty extends PropertyCodeGenerator {
     }
   }
 
-  private static final ParameterizedType COLLECTION =
+  private static final Type COLLECTION =
       QualifiedName.of(Collection.class).withParameters("E");
   private final TypeMirror elementType;
   private final Optional<TypeMirror> unboxedType;

--- a/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
@@ -129,8 +129,6 @@ class SortedSetProperty extends PropertyCodeGenerator {
     }
   }
 
-  private static final Type COLLECTION =
-      QualifiedName.of(Collection.class).withParameters("E");
   private final TypeMirror elementType;
   private final Optional<TypeMirror> unboxedType;
   private final FunctionalType mutatorType;
@@ -408,7 +406,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
         .addLine(" * <p>This method mutates the set in-place. {@code mutator} is a void")
         .addLine(" * consumer, so any value returned from a lambda will be ignored. Take care")
         .addLine(" * not to call pure functions, like %s.",
-            COLLECTION.javadocNoArgMethodLink("stream"))
+            Type.from(Collection.class).javadocNoArgMethodLink("stream"))
         .addLine(" *")
         .addLine(" * @return this {@code Builder} object")
         .addLine(" * @throws NullPointerException if {@code mutator} is null")

--- a/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
@@ -47,10 +47,10 @@ import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.FunctionalType;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
+import org.inferred.freebuilder.processor.util.Type;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -129,7 +129,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
     }
   }
 
-  private static final ParameterizedType COLLECTION =
+  private static final Type COLLECTION =
       QualifiedName.of(Collection.class).withParameters("E");
   private final TypeMirror elementType;
   private final Optional<TypeMirror> unboxedType;

--- a/src/main/java/org/inferred/freebuilder/processor/util/FunctionalType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/FunctionalType.java
@@ -124,7 +124,7 @@ public class FunctionalType extends ValueType {
     ExecutableElement method = getOnlyElement(abstractMethods);
     ExecutableType methodType = (ExecutableType) types.asMemberOf(type, method);
     return Optional.of(new FunctionalType(
-        ParameterizedType.from(type),
+        Type.from(type),
         method.getSimpleName().toString(),
         methodType.getParameterTypes(),
         methodType.getReturnType()));
@@ -159,13 +159,13 @@ public class FunctionalType extends ValueType {
     return type == null || type.getKind() == TypeKind.VOID;
   }
 
-  private final ParameterizedType functionalInterface;
+  private final Type functionalInterface;
   private final String methodName;
   private final List<TypeMirror> parameters;
   private final TypeMirror returnType;
 
   private FunctionalType(
-      ParameterizedType functionalInterface,
+      Type functionalInterface,
       String methodName,
       Collection<? extends TypeMirror> parameters,
       TypeMirror returnType) {
@@ -175,7 +175,7 @@ public class FunctionalType extends ValueType {
     this.returnType = returnType;
   }
 
-  public ParameterizedType getFunctionalInterface() {
+  public Type getFunctionalInterface() {
     return functionalInterface;
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ParameterizedType.java
@@ -15,15 +15,16 @@
  */
 package org.inferred.freebuilder.processor.util;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Iterables.transform;
-import static java.util.Arrays.asList;
-import static java.util.Collections.nCopies;
+
 import static org.inferred.freebuilder.processor.util.ModelUtils.maybeAsTypeElement;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.diamondOperator;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.nCopies;
 
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
@@ -78,16 +79,6 @@ public class ParameterizedType extends Excerpt {
   @Override
   public void addTo(SourceBuilder source) {
     source.add("%s%s", qualifiedName, typeParameters());
-  }
-
-  /**
-   * Returns a new {@link ParameterizedType} of the same length as this type, filled with
-   * {@code parameters}.
-   */
-  public ParameterizedType withParameters(TypeMirror... parameters) {
-    checkArgument(typeParameters.size() == parameters.length,
-        "Need %s parameters for %s but got %s", typeParameters.size(), this, parameters.length);
-    return new ParameterizedType(qualifiedName, ImmutableList.copyOf(parameters));
   }
 
   /**

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -23,6 +23,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
+import org.inferred.freebuilder.processor.util.Type.TypeImpl;
+
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
@@ -115,28 +117,28 @@ public class QualifiedName extends ValueType {
   }
 
   public Type withParameters() {
-    return new Type(this, ImmutableList.of());
+    return new TypeImpl(this, ImmutableList.of());
   }
 
   public Type withParameters(String first, String... rest) {
-    return new Type(
+    return new TypeImpl(
         this, ImmutableList.<String>builder().add(first).add(rest).build());
   }
 
   public Type withParameters(TypeMirror first, TypeMirror... rest) {
-    return new Type(
+    return new TypeImpl(
         this, ImmutableList.<TypeMirror>builder().add(first).add(rest).build());
   }
 
   public Type withParameters(
       TypeParameterElement first,
       TypeParameterElement... rest) {
-    return new Type(
+    return new TypeImpl(
         this, ImmutableList.<TypeParameterElement>builder().add(first).add(rest).build());
   }
 
   public Type withParameters(Iterable<? extends TypeParameterElement> typeParameters) {
-    return new Type(this, ImmutableList.copyOf(typeParameters));
+    return new TypeImpl(this, ImmutableList.copyOf(typeParameters));
   }
 
   /**

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -116,8 +116,8 @@ public class QualifiedName extends ValueType {
     return new QualifiedName(packageName, concat(simpleNames, ImmutableList.of(simpleName)));
   }
 
-  public Type withParameters() {
-    return new TypeImpl(this, ImmutableList.of());
+  public TypeClass withParameters() {
+    return new TypeClass(this, ImmutableList.<TypeParameterElement>of());
   }
 
   public Type withParameters(String first, String... rest) {
@@ -130,15 +130,15 @@ public class QualifiedName extends ValueType {
         this, ImmutableList.<TypeMirror>builder().add(first).add(rest).build());
   }
 
-  public Type withParameters(
+  public TypeClass withParameters(
       TypeParameterElement first,
       TypeParameterElement... rest) {
-    return new TypeImpl(
+    return new TypeClass(
         this, ImmutableList.<TypeParameterElement>builder().add(first).add(rest).build());
   }
 
-  public Type withParameters(Iterable<? extends TypeParameterElement> typeParameters) {
-    return new TypeImpl(this, ImmutableList.copyOf(typeParameters));
+  public TypeClass withParameters(Iterable<? extends TypeParameterElement> typeParameters) {
+    return new TypeClass(this, ImmutableList.copyOf(typeParameters));
   }
 
   /**

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -114,24 +114,29 @@ public class QualifiedName extends ValueType {
     return new QualifiedName(packageName, concat(simpleNames, ImmutableList.of(simpleName)));
   }
 
-  public ParameterizedType withParameters(String... typeParameters) {
-    return new ParameterizedType(this, ImmutableList.copyOf(typeParameters));
+  public ParameterizedType withParameters() {
+    return new ParameterizedType(this, ImmutableList.of());
+  }
+
+  public ParameterizedType withParameters(String first, String... rest) {
+    return new ParameterizedType(
+        this, ImmutableList.<String>builder().add(first).add(rest).build());
   }
 
   public ParameterizedType withParameters(TypeMirror first, TypeMirror... rest) {
-    return new ParameterizedType(this, ImmutableList.builder().add(first).add(rest).build());
+    return new ParameterizedType(
+        this, ImmutableList.<TypeMirror>builder().add(first).add(rest).build());
+  }
+
+  public ParameterizedType withParameters(
+      TypeParameterElement first,
+      TypeParameterElement... rest) {
+    return new ParameterizedType(
+        this, ImmutableList.<TypeParameterElement>builder().add(first).add(rest).build());
   }
 
   public ParameterizedType withParameters(Iterable<? extends TypeParameterElement> typeParameters) {
     return new ParameterizedType(this, ImmutableList.copyOf(typeParameters));
-  }
-
-  public ParameterizedType withParameters(
-      TypeParameterElement typeParameter, TypeParameterElement... typeParameters) {
-    return withParameters(ImmutableList.<TypeParameterElement>builder()
-        .add(typeParameter)
-        .add(typeParameters)
-        .build());
   }
 
   /**

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -116,20 +116,13 @@ public class QualifiedName extends ValueType {
     return new QualifiedName(packageName, concat(simpleNames, ImmutableList.of(simpleName)));
   }
 
-  public TypeClass withParameters() {
-    return new TypeClass(this, ImmutableList.<TypeParameterElement>of());
+  public TypeClass withParameters(TypeParameterElement... parameters) {
+    return new TypeClass(this, ImmutableList.copyOf(parameters));
   }
 
   public Type withParameters(TypeMirror first, TypeMirror... rest) {
     return new TypeImpl(
         this, ImmutableList.<TypeMirror>builder().add(first).add(rest).build());
-  }
-
-  public TypeClass withParameters(
-      TypeParameterElement first,
-      TypeParameterElement... rest) {
-    return new TypeClass(
-        this, ImmutableList.<TypeParameterElement>builder().add(first).add(rest).build());
   }
 
   public TypeClass withParameters(Iterable<? extends TypeParameterElement> typeParameters) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -114,29 +114,29 @@ public class QualifiedName extends ValueType {
     return new QualifiedName(packageName, concat(simpleNames, ImmutableList.of(simpleName)));
   }
 
-  public ParameterizedType withParameters() {
-    return new ParameterizedType(this, ImmutableList.of());
+  public Type withParameters() {
+    return new Type(this, ImmutableList.of());
   }
 
-  public ParameterizedType withParameters(String first, String... rest) {
-    return new ParameterizedType(
+  public Type withParameters(String first, String... rest) {
+    return new Type(
         this, ImmutableList.<String>builder().add(first).add(rest).build());
   }
 
-  public ParameterizedType withParameters(TypeMirror first, TypeMirror... rest) {
-    return new ParameterizedType(
+  public Type withParameters(TypeMirror first, TypeMirror... rest) {
+    return new Type(
         this, ImmutableList.<TypeMirror>builder().add(first).add(rest).build());
   }
 
-  public ParameterizedType withParameters(
+  public Type withParameters(
       TypeParameterElement first,
       TypeParameterElement... rest) {
-    return new ParameterizedType(
+    return new Type(
         this, ImmutableList.<TypeParameterElement>builder().add(first).add(rest).build());
   }
 
-  public ParameterizedType withParameters(Iterable<? extends TypeParameterElement> typeParameters) {
-    return new ParameterizedType(this, ImmutableList.copyOf(typeParameters));
+  public Type withParameters(Iterable<? extends TypeParameterElement> typeParameters) {
+    return new Type(this, ImmutableList.copyOf(typeParameters));
   }
 
   /**

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -120,11 +120,6 @@ public class QualifiedName extends ValueType {
     return new TypeClass(this, ImmutableList.<TypeParameterElement>of());
   }
 
-  public Type withParameters(String first, String... rest) {
-    return new TypeImpl(
-        this, ImmutableList.<String>builder().add(first).add(rest).build());
-  }
-
   public Type withParameters(TypeMirror first, TypeMirror... rest) {
     return new TypeImpl(
         this, ImmutableList.<TypeMirror>builder().add(first).add(rest).build());

--- a/src/main/java/org/inferred/freebuilder/processor/util/Type.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Type.java
@@ -29,6 +29,7 @@ import static java.util.Collections.nCopies;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 
+import org.inferred.freebuilder.processor.util.feature.SourceLevel;
 import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
 
 import java.util.List;
@@ -38,26 +39,26 @@ import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
-public class ParameterizedType extends Excerpt {
+public class Type extends Excerpt {
 
-  public static ParameterizedType from(TypeElement typeElement) {
-    return new ParameterizedType(QualifiedName.of(typeElement), typeElement.getTypeParameters());
+  public static Type from(TypeElement typeElement) {
+    return new Type(QualifiedName.of(typeElement), typeElement.getTypeParameters());
   }
 
-  public static ParameterizedType from(DeclaredType declaredType) {
-    return new ParameterizedType(
+  public static Type from(DeclaredType declaredType) {
+    return new Type(
         QualifiedName.of(asElement(declaredType)),
         declaredType.getTypeArguments());
   }
 
-  public static ParameterizedType from(Class<?> cls) {
-    return new ParameterizedType(QualifiedName.of(cls), asList(cls.getTypeParameters()));
+  public static Type from(Class<?> cls) {
+    return new Type(QualifiedName.of(cls), asList(cls.getTypeParameters()));
   }
 
   private final QualifiedName qualifiedName;
   private final List<?> typeParameters;
 
-  ParameterizedType(QualifiedName qualifiedName, List<?> typeParameters) {
+  Type(QualifiedName qualifiedName, List<?> typeParameters) {
     this.qualifiedName = checkNotNull(qualifiedName);
     this.typeParameters = ImmutableList.copyOf(typeParameters);
   }
@@ -152,11 +153,11 @@ public class ParameterizedType extends Excerpt {
    *
    * <p>If the type class is not generic, the returned object will be equal to this one.
    */
-  public ParameterizedType withWildcards() {
+  public Type withWildcards() {
     if (typeParameters.isEmpty()) {
       return this;
     }
-    return new ParameterizedType(qualifiedName, nCopies(typeParameters.size(), "?"));
+    return new Type(qualifiedName, nCopies(typeParameters.size(), "?"));
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/util/TypeClass.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/TypeClass.java
@@ -1,0 +1,136 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeAsTypeElement;
+
+import com.google.common.collect.ImmutableList;
+
+import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Representation of a class or interface element.
+ *
+ * <p>When used as an excerpt or {@link Type}, it acts as a <i>prototypical</i> type of the class.
+ * This is the element's invocation on the type variables corresponding to its own formal type
+ * parameters. For example, the {@code TypeClass} of {@link EnumSet} would appear in code as
+ * {@code EnumSet<E>}. This is probably the most common use of a type class in code generation.
+ *
+ * <p>The {@link #declaration()} and {@link #declarationParameters()} methods, on the other hand,
+ * return excerpts reflecting the type element. For example, the declaration of {@link EnumSet}
+ * would be {@code EnumSet<E extends Enum<E>>}.
+ *
+ * <p>A hybrid of a {@link TypeElement} and its prototypical {@link DeclaredType}.
+ *
+ * @see Element#asType()
+ */
+public class TypeClass extends Type {
+
+  public static TypeClass from(TypeElement typeElement) {
+    return new TypeClass(QualifiedName.of(typeElement), typeElement.getTypeParameters());
+  }
+
+  private final QualifiedName qualifiedName;
+  private final List<TypeParameterElement> typeParameters;
+
+  TypeClass(
+      QualifiedName qualifiedName,
+      Collection<? extends TypeParameterElement> typeParameters) {
+    this.qualifiedName = qualifiedName;
+    this.typeParameters = ImmutableList.copyOf(typeParameters);
+  }
+
+  @Override
+  public QualifiedName getQualifiedName() {
+    return qualifiedName;
+  }
+
+  /**
+   * Returns a source excerpt suitable for declaring this type element.
+   *
+   * <p>e.g. {@code MyType<N extends Number, C extends Consumer<N>>}
+   */
+  public Excerpt declaration() {
+    return Excerpts.add("%s%s", getSimpleName(), declarationParameters());
+  }
+
+  /**
+   * Returns a source excerpt of the type parameters of this type element, including bounds and
+   * angle brackets.
+   *
+   * <p>e.g. {@code <N extends Number, C extends Consumer<N>>}
+   */
+  public Excerpt declarationParameters() {
+    return new DeclarationParameters(getTypeParameters());
+  }
+
+  @Override
+  protected List<TypeParameterElement> getTypeParameters() {
+    return typeParameters;
+  }
+
+  @Override
+  protected void addFields(FieldReceiver fields) {
+    fields.add("qualifiedName", qualifiedName);
+    fields.add("typeParameters", typeParameters);
+  }
+
+  @Override
+  public String toString() {
+    // Only used when debugging, so an empty feature set is fine.
+    return SourceStringBuilder.compilable(new StaticFeatureSet()).add(declaration()).toString();
+  }
+
+  private static class DeclarationParameters extends Excerpt {
+
+    private final List<TypeParameterElement> typeParameters;
+
+    DeclarationParameters(List<TypeParameterElement> typeParameters) {
+      this.typeParameters = typeParameters;
+    }
+
+    @Override public void addTo(SourceBuilder source) {
+      if (!typeParameters.isEmpty()) {
+        String prefix = "<";
+        for (TypeParameterElement typeParameter : typeParameters) {
+          source.add("%s%s", prefix, typeParameter.getSimpleName());
+          if (!extendsObject(typeParameter)) {
+            String separator = " extends ";
+            for (TypeMirror bound : typeParameter.getBounds()) {
+              source.add("%s%s", separator, bound);
+              separator = " & ";
+            }
+          }
+          prefix = ", ";
+        }
+        source.add(">");
+      }
+    }
+
+    @Override
+    protected void addFields(FieldReceiver fields) {
+      fields.add("typeParameters", typeParameters);
+    }
+
+    private static boolean extendsObject(TypeParameterElement element) {
+      if (element.getBounds().size() != 1) {
+        return false;
+      }
+      TypeElement bound = maybeAsTypeElement(getOnlyElement(element.getBounds())).orNull();
+      if (bound == null) {
+        return false;
+      }
+      return bound.getQualifiedName().contentEquals(Object.class.getName());
+    }
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/BuilderFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuilderFactoryTest.java
@@ -16,6 +16,7 @@
 package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.assertThat;
+
 import static org.inferred.freebuilder.processor.BuilderFactory.BUILDER_METHOD;
 import static org.inferred.freebuilder.processor.BuilderFactory.NEW_BUILDER_METHOD;
 import static org.inferred.freebuilder.processor.BuilderFactory.NO_ARGS_CONSTRUCTOR;
@@ -27,9 +28,11 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7
 import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.util.Excerpt;
+import org.inferred.freebuilder.processor.util.GenericElement;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
 import org.inferred.freebuilder.processor.util.Type;
+import org.inferred.freebuilder.processor.util.TypeClass;
 import org.inferred.freebuilder.processor.util.testing.ModelRule;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -42,6 +45,10 @@ import javax.lang.model.element.TypeElement;
 public class BuilderFactoryTest {
 
   @ClassRule public static final ModelRule model = new ModelRule();
+
+  private static final Type FOO_BUILDER = TypeClass.from(
+      new GenericElement.Builder(QualifiedName.of("com.example", "Foo", "Builder"))
+          .addTypeParameter("E").build());
 
   @Test
   public void testImplicitConstructor() {
@@ -341,108 +348,84 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_noArgsConstructor_inferredTypes_j6() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(fooBuilder, INFERRED_TYPES);
+    Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(FOO_BUILDER, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("new Foo.Builder<E>()");
   }
 
   @Test
   public void testNewBuilderForGenericType_noArgsConstructor_explicitTypes_j6() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(fooBuilder, EXPLICIT_TYPES);
+    Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(FOO_BUILDER, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("new Foo.Builder<E>()");
   }
 
   @Test
   public void testNewBuilderForGenericType_noArgsConstructor_inferredTypes_j7() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(fooBuilder, INFERRED_TYPES);
+    Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(FOO_BUILDER, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("new Foo.Builder<>()");
   }
 
   @Test
   public void testNewBuilderForGenericType_noArgsConstructor_explicitTypes_j7() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(fooBuilder, EXPLICIT_TYPES);
+    Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(FOO_BUILDER, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("new Foo.Builder<E>()");
   }
 
   @Test
   public void testNewBuilderForGenericType_builderMethod_inferredTypes_j6() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(fooBuilder, INFERRED_TYPES);
+    Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(FOO_BUILDER, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("Foo.builder()");
   }
 
   @Test
   public void testNewBuilderForGenericType_builderMethod_explicitTypes_j6() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(fooBuilder, EXPLICIT_TYPES);
+    Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(FOO_BUILDER, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("Foo.<E>builder()");
   }
 
   @Test
   public void testNewBuilderForGenericType_builderMethod_inferredTypes_j7() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(fooBuilder, INFERRED_TYPES);
+    Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(FOO_BUILDER, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("Foo.builder()");
   }
 
   @Test
   public void testNewBuilderForGenericType_builderMethod_explicitTypes_j7() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(fooBuilder, EXPLICIT_TYPES);
+    Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(FOO_BUILDER, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("Foo.<E>builder()");
   }
 
   @Test
   public void testNewBuilderForGenericType_newBuilderMethod_inferredTypes_j6() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(fooBuilder, INFERRED_TYPES);
+    Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(FOO_BUILDER, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("Foo.newBuilder()");
   }
 
   @Test
   public void testNewBuilderForGenericType_newBuilderMethod_explicitTypes_j6() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(fooBuilder, EXPLICIT_TYPES);
+    Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(FOO_BUILDER, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("Foo.<E>newBuilder()");
   }
 
   @Test
   public void testNewBuilderForGenericType_newBuilderMethod_inferredTypes_j7() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(fooBuilder, INFERRED_TYPES);
+    Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(FOO_BUILDER, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("Foo.newBuilder()");
   }
 
   @Test
   public void testNewBuilderForGenericType_newBuilderMethod_explicitTypes_j7() {
-    Type fooBuilder =
-        QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
-    Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(fooBuilder, EXPLICIT_TYPES);
+    Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(FOO_BUILDER, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
     assertThat(code).isEqualTo("Foo.<E>newBuilder()");
   }

--- a/src/test/java/org/inferred/freebuilder/processor/BuilderFactoryTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuilderFactoryTest.java
@@ -27,9 +27,9 @@ import static org.inferred.freebuilder.processor.util.feature.SourceLevel.JAVA_7
 import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.util.Excerpt;
-import org.inferred.freebuilder.processor.util.ParameterizedType;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
+import org.inferred.freebuilder.processor.util.Type;
 import org.inferred.freebuilder.processor.util.testing.ModelRule;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -341,7 +341,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_noArgsConstructor_inferredTypes_j6() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(fooBuilder, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
@@ -350,7 +350,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_noArgsConstructor_explicitTypes_j6() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(fooBuilder, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
@@ -359,7 +359,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_noArgsConstructor_inferredTypes_j7() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(fooBuilder, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
@@ -368,7 +368,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_noArgsConstructor_explicitTypes_j7() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = NO_ARGS_CONSTRUCTOR.newBuilder(fooBuilder, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
@@ -377,7 +377,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_builderMethod_inferredTypes_j6() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(fooBuilder, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
@@ -386,7 +386,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_builderMethod_explicitTypes_j6() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(fooBuilder, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
@@ -395,7 +395,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_builderMethod_inferredTypes_j7() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(fooBuilder, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
@@ -404,7 +404,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_builderMethod_explicitTypes_j7() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = BUILDER_METHOD.newBuilder(fooBuilder, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
@@ -413,7 +413,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_newBuilderMethod_inferredTypes_j6() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(fooBuilder, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
@@ -422,7 +422,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_newBuilderMethod_explicitTypes_j6() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(fooBuilder, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_6).add(newFooBuilder).toString();
@@ -431,7 +431,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_newBuilderMethod_inferredTypes_j7() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(fooBuilder, INFERRED_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();
@@ -440,7 +440,7 @@ public class BuilderFactoryTest {
 
   @Test
   public void testNewBuilderForGenericType_newBuilderMethod_explicitTypes_j7() {
-    ParameterizedType fooBuilder =
+    Type fooBuilder =
         QualifiedName.of("com.example", "Foo", "Builder").withParameters("E");
     Excerpt newFooBuilder = NEW_BUILDER_METHOD.newBuilder(fooBuilder, EXPLICIT_TYPES);
     String code = SourceStringBuilder.simple(JAVA_7).add(newFooBuilder).toString();

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
@@ -845,7 +845,7 @@ public class GenericTypeSourceTest {
     TypeParameterElementImpl paramB = newTypeParameterElement("B");
 
     Datatype datatype = new Datatype.Builder()
-        .setBuilder(person.nestedType("Builder").withParameters("A", "B"))
+        .setBuilder(person.nestedType("Builder").withParameters(paramA.asType(), paramB.asType()))
         .setExtensible(true)
         .setBuilderFactory(BuilderFactory.NO_ARGS_CONSTRUCTOR)
         .setBuilderSerializable(false)

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
@@ -15,8 +15,8 @@
  */
 package org.inferred.freebuilder.processor.util;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 
 import com.google.common.collect.ImmutableList;
@@ -67,8 +67,6 @@ public abstract class GenericElement implements TypeElement {
     private AtomicReference<GenericElement> element;
 
     public Builder(QualifiedName qualifiedName) {
-      checkArgument(qualifiedName.isTopLevel(),
-          "GenericElement currently only supports creating top-level classes");
       this.qualifiedName = qualifiedName;
     }
 
@@ -188,7 +186,7 @@ public abstract class GenericElement implements TypeElement {
 
   @Override
   public NestingKind getNestingKind() {
-    return NestingKind.TOP_LEVEL;
+    return qualifiedName.isTopLevel() ? NestingKind.TOP_LEVEL : NestingKind.MEMBER;
   }
 
   @Override
@@ -217,8 +215,12 @@ public abstract class GenericElement implements TypeElement {
   }
 
   @Override
-  public PackageElementImpl getEnclosingElement() {
-    return PackageElementImpl.create(qualifiedName.getPackage());
+  public Element getEnclosingElement() {
+    if (!qualifiedName.isTopLevel()) {
+      return newTopLevelClass(qualifiedName.getEnclosingType().toString()).asElement();
+    } else {
+      return PackageElementImpl.create(qualifiedName.getPackage());
+    }
   }
 
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/ParameterizedTypeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ParameterizedTypeTest.java
@@ -32,7 +32,7 @@ public class ParameterizedTypeTest {
 
   @Test
   public void testFromDeclaredType_simpleType() {
-    ParameterizedType type = ParameterizedType.from(MY_TYPE);
+    Type type = Type.from(MY_TYPE);
     assertEquals(MY_TYPE_NAME, type.getQualifiedName());
     assertFalse(type.isParameterized());
     assertEquals("MyType", prettyPrint(type, SourceLevel.JAVA_7));
@@ -46,7 +46,7 @@ public class ParameterizedTypeTest {
 
   @Test
   public void testFromDeclaredType_nestedType() {
-    ParameterizedType type = ParameterizedType.from(MY_NESTED_TYPE);
+    Type type = Type.from(MY_NESTED_TYPE);
     assertEquals(QualifiedName.of("com.example", "MyType", "MyNestedType"),
         type.getQualifiedName());
     assertFalse(type.isParameterized());
@@ -63,7 +63,7 @@ public class ParameterizedTypeTest {
   @Test
   public void testFromDeclaredType_genericType() {
     GenericElement myType = new GenericElement.Builder(MY_TYPE_NAME).addTypeParameter("V").build();
-    ParameterizedType type = ParameterizedType.from(myType);
+    Type type = Type.from(myType);
     assertEquals(MY_TYPE_NAME, type.getQualifiedName());
     assertTrue(type.isParameterized());
     assertEquals("MyType<V>", prettyPrint(type, SourceLevel.JAVA_7));
@@ -80,7 +80,7 @@ public class ParameterizedTypeTest {
     GenericElement myType = new GenericElement.Builder(MY_TYPE_NAME)
         .addTypeParameter("V", newTopLevelClass("java.lang.Number"))
         .build();
-    ParameterizedType type = ParameterizedType.from(myType);
+    Type type = Type.from(myType);
     assertEquals(MY_TYPE_NAME, type.getQualifiedName());
     assertTrue(type.isParameterized());
     assertEquals("MyType<V>", prettyPrint(type, SourceLevel.JAVA_7));
@@ -100,7 +100,7 @@ public class ParameterizedTypeTest {
             newTopLevelClass("java.lang.Comparable"),
             newTopLevelClass("java.util.Formattable"))
         .build();
-    ParameterizedType type = ParameterizedType.from(myType);
+    Type type = Type.from(myType);
     assertEquals("MyType<V extends Number & Comparable & Formattable>",
         prettyPrint(type.declaration(), SourceLevel.JAVA_7));
   }

--- a/src/test/java/org/inferred/freebuilder/processor/util/TypeClassTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/TypeClassTest.java
@@ -15,24 +15,27 @@
  */
 package org.inferred.freebuilder.processor.util;
 
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newNestedClass;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.inferred.freebuilder.processor.util.ClassTypeImpl.ClassElementImpl;
 import org.inferred.freebuilder.processor.util.feature.SourceLevel;
 import org.junit.Test;
 
-public class ParameterizedTypeTest {
+public class TypeClassTest {
 
   private static final QualifiedName MY_TYPE_NAME = QualifiedName.of("com.example", "MyType");
-  private static final ClassTypeImpl MY_TYPE = newTopLevelClass("com.example.MyType");
-  private static final ClassTypeImpl MY_NESTED_TYPE =
-      ClassTypeImpl.newNestedClass(MY_TYPE.asElement(), "MyNestedType");
+  private static final ClassElementImpl MY_TYPE =
+      newTopLevelClass("com.example.MyType").asElement();
+  private static final ClassElementImpl MY_NESTED_TYPE =
+      newNestedClass(MY_TYPE, "MyNestedType").asElement();
 
   @Test
-  public void testFromDeclaredType_simpleType() {
-    Type type = Type.from(MY_TYPE);
+  public void testFromTypeElement_simpleType() {
+    TypeClass type = TypeClass.from(MY_TYPE);
     assertEquals(MY_TYPE_NAME, type.getQualifiedName());
     assertFalse(type.isParameterized());
     assertEquals("MyType", prettyPrint(type, SourceLevel.JAVA_7));
@@ -45,8 +48,8 @@ public class ParameterizedTypeTest {
   }
 
   @Test
-  public void testFromDeclaredType_nestedType() {
-    Type type = Type.from(MY_NESTED_TYPE);
+  public void testFromTypeElement_nestedType() {
+    TypeClass type = TypeClass.from(MY_NESTED_TYPE);
     assertEquals(QualifiedName.of("com.example", "MyType", "MyNestedType"),
         type.getQualifiedName());
     assertFalse(type.isParameterized());
@@ -61,9 +64,9 @@ public class ParameterizedTypeTest {
   }
 
   @Test
-  public void testFromDeclaredType_genericType() {
+  public void testFromTypeElement_genericType() {
     GenericElement myType = new GenericElement.Builder(MY_TYPE_NAME).addTypeParameter("V").build();
-    Type type = Type.from(myType);
+    TypeClass type = TypeClass.from(myType);
     assertEquals(MY_TYPE_NAME, type.getQualifiedName());
     assertTrue(type.isParameterized());
     assertEquals("MyType<V>", prettyPrint(type, SourceLevel.JAVA_7));
@@ -76,11 +79,11 @@ public class ParameterizedTypeTest {
   }
 
   @Test
-  public void testFromDeclaredType_parameterWithSingleBound() {
+  public void testFromTypeElement_parameterWithSingleBound() {
     GenericElement myType = new GenericElement.Builder(MY_TYPE_NAME)
         .addTypeParameter("V", newTopLevelClass("java.lang.Number"))
         .build();
-    Type type = Type.from(myType);
+    TypeClass type = TypeClass.from(myType);
     assertEquals(MY_TYPE_NAME, type.getQualifiedName());
     assertTrue(type.isParameterized());
     assertEquals("MyType<V>", prettyPrint(type, SourceLevel.JAVA_7));
@@ -93,14 +96,14 @@ public class ParameterizedTypeTest {
   }
 
   @Test
-  public void testFromDeclaredType_parameterWithMultipleBounds() {
+  public void testFromTypeElement_parameterWithMultipleBounds() {
     GenericElement myType = new GenericElement.Builder(MY_TYPE_NAME)
         .addTypeParameter("V",
             newTopLevelClass("java.lang.Number"),
             newTopLevelClass("java.lang.Comparable"),
             newTopLevelClass("java.util.Formattable"))
         .build();
-    Type type = Type.from(myType);
+    TypeClass type = TypeClass.from(myType);
     assertEquals("MyType<V extends Number & Comparable & Formattable>",
         prettyPrint(type.declaration(), SourceLevel.JAVA_7));
   }
@@ -108,5 +111,4 @@ public class ParameterizedTypeTest {
   private static String prettyPrint(Excerpt type, SourceLevel sourceLevel) {
     return SourceStringBuilder.simple(sourceLevel).add(type).toString();
   }
-
 }


### PR DESCRIPTION
When parameterized with TypeParameterElements, a ParameterizedType acts like a "prototypical" type of its class, [as defined in the JavaDoc for Element.asType](https://docs.oracle.com/javase/7/docs/api/javax/lang/model/element/Element.html#asType()). We have been taking advantage of this to combine a TypeElement and its prototypical DeclaredType into a single object, with the declaration and declarationParameters methods returning element-like excerpts, and the remaining methods returning type-like excerpts.

However, this led to subtle bugs when code expecting such a hybrid ParameterisedType was accidentally fed one created from the prototypical DeclaredType, rather than the TypeElement. Generated code would end up losing bound information—a rare enough edge case that it can slip through the gaps when writing automated tests. As a short-term fix (#313), the methods returning element-like excerpts were modified to throw an exception if the parameter list contained anything other than TypeParameterElements. This ensured any bugs were exhibited in any generic code test, not just tests with bounds. Checking for misuse at runtime is smelly code, so the long-term goal was to push this into the type system.

This change replaces ParameterizedType with two types to reflect the two conflated use-cases:

 * `Type` represents a type **invocation**, and contains all the non-hybrid functionality of ParameterizedType. It is effectively once again a plain stand-in for DeclaredType, and its short name reflects how much use it sees in FreeBuilder.
 * `TypeClass` represents a type **element**, and contains the two element-oriented methods with their stop-gap state checks removed. It also extends Type, and when used as one acts like a prototypical type invocation. It is a hybrid of TypeElement and DeclaredType, and its name reflects its 1:1 mapping with java.lang.Class.

Datatype now uses TypeClass to represent the user's type and all generated types; the user's Builder type is still a Type to make clear it is _not_ necessarily prototypical for the Builder.