### PR TITLE
 Rename PropertyCodeGenerator.Type as Initially

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/DefaultProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/DefaultProperty.java
@@ -79,8 +79,8 @@ class DefaultProperty extends PropertyCodeGenerator {
   }
 
   @Override
-  public Type getType() {
-    return hasDefault ? Type.HAS_DEFAULT : Type.REQUIRED;
+  public Initially initialState() {
+    return hasDefault ? Initially.HAS_DEFAULT : Initially.REQUIRED;
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.Datatype.StandardMethod;
-import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
+import org.inferred.freebuilder.processor.PropertyCodeGenerator.Initially;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.Excerpts;
@@ -283,7 +283,7 @@ class GeneratedBuilder extends GeneratedType {
     code.addLine("")
         .addLine("private enum %s {", datatype.getPropertyEnum().getSimpleName());
     for (Property property : generatorsByProperty.keySet()) {
-      if (generatorsByProperty.get(property).getType() == Type.REQUIRED) {
+      if (generatorsByProperty.get(property).initialState() == Initially.REQUIRED) {
         code.addLine("  %s(\"%s\"),", property.getAllCapsName(), property.getName());
       }
     }
@@ -456,7 +456,7 @@ class GeneratedBuilder extends GeneratedType {
       generatorsByProperty.get(property).addAccessorAnnotations(code);
       generatorsByProperty.get(property).addGetterAnnotations(code);
       code.addLine("  public %s %s() {", property.getType(), property.getGetterName());
-      if (generatorsByProperty.get(property).getType() == Type.REQUIRED) {
+      if (generatorsByProperty.get(property).initialState() == Initially.REQUIRED) {
         code.addLine("    if (%s.contains(%s.%s)) {",
                 UNSET_PROPERTIES, datatype.getPropertyEnum(), property.getAllCapsName())
             .addLine("      throw new %s(\"%s not set\");",
@@ -597,7 +597,7 @@ class GeneratedBuilder extends GeneratedType {
   }
 
   private static Nullability nullabilityOf(PropertyCodeGenerator generator, boolean inPartial) {
-    switch (generator.getType()) {
+    switch (generator.initialState()) {
       case HAS_DEFAULT:
         return NOT_NULLABLE;
 
@@ -607,7 +607,7 @@ class GeneratedBuilder extends GeneratedType {
       case REQUIRED:
         return inPartial ? NULLABLE : NOT_NULLABLE;
     }
-    throw new IllegalStateException("Unexpected property type " + generator.getType());
+    throw new IllegalStateException("Unexpected initial state " + generator.initialState());
   }
 
   /** Returns an {@link Excerpt} of "implements/extends {@code type}". */
@@ -655,7 +655,7 @@ class GeneratedBuilder extends GeneratedType {
   private static final Predicate<PropertyCodeGenerator> IS_REQUIRED =
       new Predicate<PropertyCodeGenerator>() {
         @Override public boolean apply(PropertyCodeGenerator generator) {
-          return generator.getType() == Type.REQUIRED;
+          return generator.initialState() == Initially.REQUIRED;
         }
       };
 }

--- a/src/main/java/org/inferred/freebuilder/processor/NullableProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/NullableProperty.java
@@ -95,8 +95,8 @@ class NullableProperty extends PropertyCodeGenerator {
   }
 
   @Override
-  public Type getType() {
-    return Type.OPTIONAL;
+  public Initially initialState() {
+    return Initially.OPTIONAL;
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/OptionalProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/OptionalProperty.java
@@ -202,8 +202,8 @@ class OptionalProperty extends PropertyCodeGenerator {
   }
 
   @Override
-  public Type getType() {
-    return Type.OPTIONAL;
+  public Initially initialState() {
+    return Initially.OPTIONAL;
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
@@ -91,7 +91,34 @@ public abstract class PropertyCodeGenerator {
   }
 
   /** General behaviour type for a fresh or reset property. */
-  public enum Initially { REQUIRED, OPTIONAL, HAS_DEFAULT }
+  public enum Initially {
+
+    /**
+     * The property must have a value set before build can be called.
+     *
+     * <p>This may simply mean we have not detected the property being set in the builder's
+     * constructor. The property's field may be null in the builder or on a partial, but will never
+     * be null on a value instance.
+     */
+    REQUIRED,
+
+    /**
+     * The property need not be set.
+     *
+     * <p>This may mean the user chose an explicit Optional type (e.g. Java 8's Optional), or it
+     * may mean a Nullable annotation has been spotted. The property's field may be null.
+     */
+    OPTIONAL,
+
+    /**
+     * The property is known to have a default value.
+     *
+     * <p>This may be because we detected the property being set in the builder's constructor,
+     * or because the type itself has a reasonable default (e.g. an empty collection). The
+     * property's field will never be null.
+     */
+    HAS_DEFAULT
+  }
 
   /** Returns whether the property is required, optional, or has a default. */
   public Initially initialState() {

--- a/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/PropertyCodeGenerator.java
@@ -90,12 +90,12 @@ public abstract class PropertyCodeGenerator {
     this.property = property;
   }
 
-  /** Property type. */
-  public enum Type { REQUIRED, OPTIONAL, HAS_DEFAULT }
+  /** General behaviour type for a fresh or reset property. */
+  public enum Initially { REQUIRED, OPTIONAL, HAS_DEFAULT }
 
   /** Returns whether the property is required, optional, or has a default. */
-  public Type getType() {
-    return Type.HAS_DEFAULT;
+  public Initially initialState() {
+    return Initially.HAS_DEFAULT;
   }
 
   /** Add the field declaration for the property to the value's source code. */

--- a/src/main/java/org/inferred/freebuilder/processor/ToStringGenerator.java
+++ b/src/main/java/org/inferred/freebuilder/processor/ToStringGenerator.java
@@ -11,7 +11,7 @@ import static org.inferred.freebuilder.processor.util.Block.methodBody;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
-import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
+import org.inferred.freebuilder.processor.PropertyCodeGenerator.Initially;
 import org.inferred.freebuilder.processor.util.Block;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.Variable;
@@ -33,8 +33,8 @@ class ToStringGenerator {
     Predicate<PropertyCodeGenerator> isOptional = new Predicate<PropertyCodeGenerator>() {
       @Override
       public boolean apply(PropertyCodeGenerator generator) {
-        Type type = generator.getType();
-        return (type == Type.OPTIONAL || (type == Type.REQUIRED && forPartial));
+        Initially initially = generator.initialState();
+        return (initially == Initially.OPTIONAL || (initially == Initially.REQUIRED && forPartial));
       }
     };
     boolean anyOptional = any(generatorsByProperty.values(), isOptional);
@@ -119,7 +119,7 @@ class ToStringGenerator {
           code.add(";%n  ");
         }
         code.add("if (");
-        if (generator.getType() == Type.OPTIONAL) {
+        if (generator.initialState() == Initially.OPTIONAL) {
           code.add("%s != null", property.getField());
         } else {
           code.add("!%s.contains(%s.%s)",
@@ -198,7 +198,7 @@ class ToStringGenerator {
     Property last = Iterables.getLast(generatorsByProperty.keySet());
     for (Property property : generatorsByProperty.keySet()) {
       PropertyCodeGenerator generator = generatorsByProperty.get(property);
-      switch (generator.getType()) {
+      switch (generator.initialState()) {
         case HAS_DEFAULT:
           throw new RuntimeException("Internal error: unexpected default field");
 

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -35,7 +35,7 @@ import com.google.common.collect.ImmutableMap;
 import org.inferred.freebuilder.processor.Analyser.CannotGenerateCodeException;
 import org.inferred.freebuilder.processor.Datatype.StandardMethod;
 import org.inferred.freebuilder.processor.Datatype.UnderrideLevel;
-import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
+import org.inferred.freebuilder.processor.PropertyCodeGenerator.Initially;
 import org.inferred.freebuilder.processor.util.Excerpt;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
@@ -702,8 +702,8 @@ public class AnalyserTest {
         "}"));
 
     Map<String, PropertyCodeGenerator> generators = generatorsByName(builder);
-    assertEquals(Type.REQUIRED, generators.get("name").getType());
-    assertEquals(Type.REQUIRED, generators.get("age").getType());
+    assertEquals(Initially.REQUIRED, generators.get("name").initialState());
+    assertEquals(Initially.REQUIRED, generators.get("age").initialState());
   }
 
   @Test

--- a/src/test/java/org/inferred/freebuilder/processor/ToStringGeneratorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ToStringGeneratorTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.inferred.freebuilder.processor.PropertyCodeGenerator.Type;
+import org.inferred.freebuilder.processor.PropertyCodeGenerator.Initially;
 import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
 import org.inferred.freebuilder.processor.util.SourceStringBuilder;
@@ -535,15 +535,15 @@ public class ToStringGeneratorTest {
     }
 
     ToStringBuilder withRequired(String name) {
-      return with(Type.REQUIRED, name);
+      return with(Initially.REQUIRED, name);
     }
 
     ToStringBuilder withOptional(String name) {
-      return with(Type.OPTIONAL, name);
+      return with(Initially.OPTIONAL, name);
     }
 
     ToStringBuilder withDefault(String name) {
-      return with(Type.HAS_DEFAULT, name);
+      return with(Initially.HAS_DEFAULT, name);
     }
 
     String valueToString() {
@@ -558,13 +558,13 @@ public class ToStringGeneratorTest {
       return code.toString();
     }
 
-    private ToStringBuilder with(PropertyCodeGenerator.Type type, String name) {
+    private ToStringBuilder with(PropertyCodeGenerator.Initially initially, String name) {
       Property property = new Property.Builder()
           .setName(name)
           .setAllCapsName(name.replaceAll("([A-Z])", "_$1").toUpperCase())
           .buildPartial();
       PropertyCodeGenerator generator = mock(PropertyCodeGenerator.class, new ReturnsSmartNulls());
-      when(generator.getType()).thenReturn(type);
+      when(generator.initialState()).thenReturn(initially);
       generatorsByProperty.put(property, generator);
       return this;
     }


### PR DESCRIPTION
The tri-state "type" of a property has always looked a little ugly and unclear. "initialState" is more readable to me, and calling the enum "Initially" scans a little better ("initially has default"). This also frees up the 'Type' name for a more appropriate use.

Also fleshed out the JavaDoc to make it clear what the distinctions are between the three options, as the nullability implications are otherwise only obvious on scanning the codebase.