### PR TITLE
Avoid illegally shortening hidden types

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/Block.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Block.java
@@ -3,15 +3,36 @@ package org.inferred.freebuilder.processor.util;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Maps.newLinkedHashMap;
 
+import com.google.common.collect.ImmutableSet;
+
 import org.inferred.freebuilder.processor.util.feature.Feature;
 import org.inferred.freebuilder.processor.util.feature.FeatureType;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A Block contains a preamble of lazily-added declarations followed by a body.
  */
 public class Block extends Excerpt implements SourceBuilder {
+
+  /**
+   * Returns a source builder that will not illegal shorten hidden types.
+   *
+   * @param parent the enclosing source builder
+   * @param type the type this is the body of
+   * @param supertypes all supertypes of {@code type}
+   */
+  public static SourceBuilder typeBody(
+      SourceBuilder parent,
+      TypeClass type,
+      Type... supertypes) {
+    ImmutableSet.Builder<QualifiedName> supertypeNames = ImmutableSet.builder();
+    for (Type supertype : supertypes) {
+      supertypeNames.add(supertype.getQualifiedName());
+    }
+    return parent.nestedType(type.getQualifiedName(), supertypeNames.build());
+  }
 
   public static Block methodBody(SourceBuilder parent, String... paramNames) {
     Scope methodScope = new Scope.MethodScope(parent.scope());
@@ -109,6 +130,11 @@ public class Block extends Excerpt implements SourceBuilder {
   @Override
   public SourceStringBuilder subBuilder() {
     return body.subBuilder();
+  }
+
+  @Override
+  public SourceStringBuilder nestedType(QualifiedName type, Set<QualifiedName> supertypes) {
+    throw new UnsupportedOperationException("Cannot declare a named type inside a method block");
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
@@ -118,6 +118,11 @@ class ImportManager extends AbstractTypeShortener {
     a.append(type.getSimpleName());
   }
 
+  @Override
+  public TypeShortener inScope(QualifiedName type, Set<QualifiedName> supertypes) {
+    return this;
+  }
+
   private void appendPackageForTopLevelClass(Appendable a, String pkg, CharSequence name)
       throws IOException {
     if (pkg.startsWith(PACKAGE_PREFIX)) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -132,6 +132,12 @@ public class QualifiedName extends ValueType {
     return simpleNames.size() == 1;
   }
 
+  public boolean isNestedIn(QualifiedName other) {
+    return packageName.equals(other.packageName)
+        && (simpleNames.size() > other.simpleNames.size())
+        && simpleNames.subList(0, other.simpleNames.size()).equals(other.simpleNames);
+  }
+
   /**
    * Returns the {@link QualifiedName} of a type called {@code simpleName} nested in this one.
    */

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -16,15 +16,20 @@
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getLast;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import org.inferred.freebuilder.processor.util.Type.TypeImpl;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
@@ -65,21 +70,34 @@ public class QualifiedName extends ValueType {
    * Returns a {@link QualifiedName} for {@code type}.
    */
   public static QualifiedName of(TypeElement type) {
-    if (type.getNestingKind().isNested()) {
-      QualifiedName enclosingElement = QualifiedName.of((TypeElement) type.getEnclosingElement());
-      return enclosingElement.nestedType(type.getSimpleName().toString());
-    } else {
-      PackageElement pkg = (PackageElement) type.getEnclosingElement();
-      return QualifiedName.of(pkg.getQualifiedName().toString(), type.getSimpleName().toString());
+    switch (type.getNestingKind()) {
+      case TOP_LEVEL:
+        PackageElement pkg = (PackageElement) type.getEnclosingElement();
+        return QualifiedName.of(pkg.getQualifiedName().toString(), type.getSimpleName().toString());
+
+      case MEMBER:
+        List<String> reversedNames = new ArrayList<String>();
+        reversedNames.add(type.getSimpleName().toString());
+        Element parent = type.getEnclosingElement();
+        while (parent.getKind() != ElementKind.PACKAGE) {
+          reversedNames.add(parent.getSimpleName().toString());
+          parent = parent.getEnclosingElement();
+        }
+        return new QualifiedName(
+            ((PackageElement) parent).getQualifiedName().toString(),
+            ImmutableList.copyOf(Lists.reverse(reversedNames)));
+
+      default:
+        throw new IllegalArgumentException("Cannot determine qualified name of " + type);
     }
   }
 
   private final String packageName;
   private final ImmutableList<String> simpleNames;
 
-  private QualifiedName(String packageName, Iterable<String> simpleNames) {
+  private QualifiedName(String packageName, ImmutableList<String> simpleNames) {
     this.packageName = packageName;
-    this.simpleNames = ImmutableList.copyOf(simpleNames);
+    this.simpleNames = simpleNames;
   }
 
   /**
@@ -95,6 +113,11 @@ public class QualifiedName extends ValueType {
 
   public String getPackage() {
     return packageName;
+  }
+
+  public QualifiedName enclosingType() {
+    checkState(!isTopLevel(), "Cannot return enclosing type of top-level type");
+    return new QualifiedName(packageName, simpleNames.subList(0, simpleNames.size() - 1));
   }
 
   public ImmutableList<String> getSimpleNames() {
@@ -113,7 +136,8 @@ public class QualifiedName extends ValueType {
    * Returns the {@link QualifiedName} of a type called {@code simpleName} nested in this one.
    */
   public QualifiedName nestedType(String simpleName) {
-    return new QualifiedName(packageName, concat(simpleNames, ImmutableList.of(simpleName)));
+    return new QualifiedName(packageName,
+        ImmutableList.<String>builder().addAll(simpleNames).add(simpleName).build());
   }
 
   public TypeClass withParameters(TypeParameterElement... parameters) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/ScopeAwareTypeShortener.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ScopeAwareTypeShortener.java
@@ -1,0 +1,59 @@
+package org.inferred.freebuilder.processor.util;
+
+import org.inferred.freebuilder.processor.util.ScopeHandler.ScopeState;
+import org.inferred.freebuilder.processor.util.ScopeHandler.Visibility;
+import org.inferred.freebuilder.processor.util.TypeShortener.AbstractTypeShortener;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.lang.model.element.TypeElement;
+
+class ScopeAwareTypeShortener extends AbstractTypeShortener {
+
+  private final TypeShortener delegate;
+  private final QualifiedName scope;
+  private final ScopeHandler handler;
+
+  ScopeAwareTypeShortener(TypeShortener delegate, ScopeHandler handler) {
+    this(delegate, null, handler);
+  }
+
+  ScopeAwareTypeShortener(TypeShortener delegate, QualifiedName scope, ScopeHandler handler) {
+    this.delegate = delegate;
+    this.scope = scope;
+    this.handler = handler;
+  }
+
+  @Override
+  public void appendShortened(Appendable a, QualifiedName type) throws IOException {
+    if (scope == null) {
+      delegate.appendShortened(a, type);
+      return;
+    }
+    ScopeState scopeState = handler.visibilityIn(scope, type);
+    if (scopeState == ScopeState.IMPORTABLE) {
+      delegate.appendShortened(a, type);
+    } else if (type.isTopLevel() && scopeState == ScopeState.IN_SCOPE) {
+      delegate.appendShortened(a, type);
+    } else {
+      if (type.isTopLevel()) {
+        a.append(type.getPackage());
+      } else {
+        appendShortened(a, type.getEnclosingType());
+      }
+      a.append('.').append(type.getSimpleName());
+    }
+  }
+
+  @Override
+  public void appendShortened(Appendable a, TypeElement type) throws IOException {
+    appendShortened(a, QualifiedName.of(type));
+  }
+
+  @Override
+  public TypeShortener inScope(QualifiedName type, Set<QualifiedName> supertypes) {
+    handler.declareGeneratedType(Visibility.UNKNOWN, type, supertypes);
+    return new ScopeAwareTypeShortener(delegate, type, handler);
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/ScopeHandler.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ScopeHandler.java
@@ -1,0 +1,226 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Sets.newHashSet;
+
+import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.SetMultimap;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVisitor;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.SimpleTypeVisitor6;
+
+/**
+ * Handles the byzantine rules of Java scoping.
+ */
+class ScopeHandler {
+
+  enum ScopeState {
+    /** Type is already visible due to scoping rules. */
+    IN_SCOPE,
+    /** Type is hidden by another type of the same name. */
+    HIDDEN,
+    /** Type can safely be imported. */
+    IMPORTABLE
+  }
+  enum Visibility { PUBLIC, PROTECTED, PACKAGE, PRIVATE, UNKNOWN }
+
+  private final Elements elements;
+
+  /** Type ↦ visibility in parent scope */
+  private final Map<QualifiedName, Visibility> typeVisibility = newHashMap();
+  /** Package ↦ simple names */
+  private final Map<String, Set<String>> topLevelTypes = newHashMap();
+  /** Scope ↦ simple name ↦ type */
+  private final Map<QualifiedName, SetMultimap<String, QualifiedName>> visibleTypes = newHashMap();
+
+  ScopeHandler(Elements elements) {
+    this.elements = elements;
+  }
+
+  /**
+   * Returns whether {@code type} is visible in, or can be imported into, a compilation unit in
+   * {@code pkg}.
+   */
+  ScopeState visibilityIn(String pkg, QualifiedName type) {
+    if (type.isTopLevel() && type.getPackage().equals(pkg)) {
+      return ScopeState.IN_SCOPE;
+    } else if (typesInPackage(pkg).contains(type.getSimpleName())) {
+      return ScopeState.HIDDEN;
+    } else {
+      return ScopeState.IMPORTABLE;
+    }
+  }
+
+  /**
+   * Returns whether {@code type} is visible in, or can be imported into, the body of {@code type}.
+   */
+  ScopeState visibilityIn(QualifiedName scope, QualifiedName type) {
+    Set<QualifiedName> possibleConflicts = typesInScope(scope).get(type.getSimpleName());
+    if (possibleConflicts.equals(ImmutableSet.of(type))) {
+      return ScopeState.IN_SCOPE;
+    } else if (!possibleConflicts.isEmpty()) {
+      return ScopeState.HIDDEN;
+    } else if (!scope.isTopLevel()) {
+      return visibilityIn(scope.enclosingType(), type);
+    } else {
+      return visibilityIn(scope.getPackage(), type);
+    }
+  }
+
+  void predeclareGeneratedType(QualifiedName generatedType) {
+    declareGeneratedType(Visibility.UNKNOWN, generatedType, ImmutableSet.<QualifiedName>of());
+  }
+
+  void declareGeneratedType(
+      Visibility visibility,
+      QualifiedName generatedType,
+      Set<QualifiedName> supertypes) {
+    typeVisibility.put(generatedType, visibility);
+    if (generatedType.isTopLevel()) {
+      typesInPackage(generatedType.getPackage()).add(generatedType.getSimpleName());
+    } else {
+      get(visibleTypes, generatedType.enclosingType())
+          .put(generatedType.getSimpleName(), generatedType);
+    }
+    SetMultimap<String, QualifiedName> visibleInScope = get(visibleTypes, generatedType);
+    for (QualifiedName supertype : supertypes) {
+      for (QualifiedName type : typesInScope(supertype).values()) {
+        if (maybeVisibleInScope(generatedType, type)) {
+          visibleInScope.put(type.getSimpleName(), type);
+        }
+      }
+    }
+  }
+
+  private static <K1, K2, V> SetMultimap<K2, V> get(Map<K1, SetMultimap<K2, V>> map, K1 key) {
+    SetMultimap<K2, V> result = map.get(key);
+    if (result == null) {
+      result = HashMultimap.create();
+      map.put(key, result);
+    }
+    return result;
+  }
+
+  private Set<String> typesInPackage(String pkg) {
+    Set<String> result = topLevelTypes.get(pkg);
+    if (result == null) {
+      result = newHashSet();
+      PackageElement packageElement = elements.getPackageElement(pkg);
+      if (packageElement != null) {
+        for (TypeElement type : ElementFilter.typesIn(packageElement.getEnclosedElements())) {
+          result.add(type.getSimpleName().toString());
+        }
+      }
+      topLevelTypes.put(pkg, result);
+    }
+    return result;
+  }
+
+  private SetMultimap<String, QualifiedName> typesInScope(QualifiedName scope) {
+    SetMultimap<String, QualifiedName> result = visibleTypes.get(scope);
+    if (result != null) {
+      return result;
+    }
+    TypeElement scopeElement = elements.getTypeElement(scope.toString());
+    return cacheTypesInScope(scope, scopeElement);
+  }
+
+  private SetMultimap<String, QualifiedName> cacheTypesInScope(
+      QualifiedName scope,
+      TypeElement element) {
+    SetMultimap<String, QualifiedName> visibleInScope = HashMultimap.create();
+    if (element != null) {
+      for (QualifiedName type : TYPES_IN_SCOPE.visit(element.getSuperclass(), this)) {
+        if (maybeVisibleInScope(scope, type)) {
+          visibleInScope.put(type.getSimpleName(), type);
+        }
+      }
+      for (TypeMirror iface : element.getInterfaces()) {
+        for (QualifiedName type : TYPES_IN_SCOPE.visit(iface, this)) {
+          if (maybeVisibleInScope(scope, type)) {  // In case interfaces ever get private members
+            visibleInScope.put(type.getSimpleName(), type);
+          }
+        }
+      }
+      for (TypeElement nested : ElementFilter.typesIn(element.getEnclosedElements())) {
+        visibleInScope.put(nested.getSimpleName().toString(), QualifiedName.of(nested));
+      }
+    }
+    visibleTypes.put(scope, visibleInScope);
+    return visibleInScope;
+  }
+
+  private boolean maybeVisibleInScope(QualifiedName scope, QualifiedName type) {
+    switch (visibilityOf(type)) {
+      case PUBLIC:
+      case PROTECTED:
+        // type is either nested in scope or a supertype of scope.
+        // Either way, it's visible.
+        return true;
+      case PACKAGE:
+        return scope.getPackage().equals(type.getPackage());
+      case PRIVATE:
+        // Private types are only visible in their enclosing type.
+        // Inheriting from the enclosing type is not sufficient.
+        return type.enclosingType().equals(scope);
+      case UNKNOWN:
+        return true;
+    }
+    throw new IllegalStateException("Unknown visibility " + visibilityOf(type));
+  }
+
+  private Visibility visibilityOf(QualifiedName type) {
+    Visibility visibility = typeVisibility.get(type);
+    if (visibility == null) {
+      TypeElement element = elements.getTypeElement(type.toString());
+      Set<Modifier> modifiers = element.getModifiers();
+      if (modifiers.contains(Modifier.PUBLIC)) {
+        visibility = Visibility.PUBLIC;
+      } else if (modifiers.contains(Modifier.PROTECTED)) {
+        visibility = Visibility.PROTECTED;
+      } else if (modifiers.contains(Modifier.PRIVATE)) {
+        visibility = Visibility.PRIVATE;
+      } else  {
+        visibility = Visibility.PACKAGE;
+      }
+      typeVisibility.put(type, visibility);
+    }
+    return visibility;
+  }
+
+  private static final TypeVisitor<Collection<QualifiedName>, ScopeHandler>
+      TYPES_IN_SCOPE =
+          new SimpleTypeVisitor6<Collection<QualifiedName>, ScopeHandler>() {
+            @Override
+            public Collection<QualifiedName> visitDeclared(
+                DeclaredType type,
+                ScopeHandler scopeHandler) {
+              QualifiedName typename = QualifiedName.of(asElement(type));
+              SetMultimap<String, QualifiedName> visibleInScope =
+                  scopeHandler.visibleTypes.get(typename);
+              if (visibleInScope != null) {
+                return visibleInScope.values();
+              }
+              return scopeHandler.cacheTypesInScope(typename, asElement(type)).values();
+            }
+
+            @Override
+            protected Collection<QualifiedName> defaultAction(TypeMirror e, ScopeHandler p) {
+              return ImmutableSet.of();
+            }
+          };
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
@@ -19,6 +19,8 @@ import org.inferred.freebuilder.processor.util.feature.Feature;
 import org.inferred.freebuilder.processor.util.feature.FeatureType;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 
+import java.util.Set;
+
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -73,6 +75,13 @@ public interface SourceBuilder {
    * will be included in the imports for this builder (and its parents).
    */
   SourceStringBuilder subBuilder();
+
+  /**
+   * Returns a {@code SourceStringBuilder} with the same configuration as this builder, but with
+   * the {@code TypeShortener} using scoping rules for {@code type}. Any types added to the
+   * sub-builder will be included in the imports for this builder (and its parents).
+   */
+  SourceStringBuilder nestedType(QualifiedName type, Set<QualifiedName> supertypes);
 
   /**
    * Returns a {@code SourceStringBuilder} with the same configuration as this builder, but with

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceStringBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceStringBuilder.java
@@ -27,6 +27,7 @@ import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
 
 import java.io.IOException;
 import java.util.MissingFormatArgumentException;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -120,6 +121,11 @@ public class SourceStringBuilder implements SourceBuilder, Appendable {
   @Override
   public SourceStringBuilder subBuilder() {
     return new SourceStringBuilder(shortener, features, scope);
+  }
+
+  @Override
+  public SourceStringBuilder nestedType(QualifiedName type, Set<QualifiedName> supertypes) {
+    return new SourceStringBuilder(shortener.inScope(type, supertypes), features, scope);
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/util/TypeShortener.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/TypeShortener.java
@@ -18,6 +18,7 @@ package org.inferred.freebuilder.processor.util;
 import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
 
 import java.io.IOException;
+import java.util.Set;
 
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
@@ -34,6 +35,8 @@ interface TypeShortener {
   void appendShortened(Appendable a, TypeElement type) throws IOException;
   void appendShortened(Appendable a, TypeMirror mirror) throws IOException;
   void appendShortened(Appendable a, QualifiedName type) throws IOException;
+
+  TypeShortener inScope(QualifiedName type, Set<QualifiedName> supertypes);
 
   abstract class AbstractTypeShortener
       extends SimpleTypeVisitor6<Void, Appendable>
@@ -129,6 +132,11 @@ interface TypeShortener {
     public void appendShortened(Appendable a, TypeElement type) throws IOException {
       a.append(type.toString());
     }
+
+    @Override
+    public NeverShorten inScope(QualifiedName type, Set<QualifiedName> supertypes) {
+      return this;
+    }
   }
 
   /** A {@link TypeShortener} that always shortens types, even if that causes conflicts. */
@@ -150,6 +158,11 @@ interface TypeShortener {
         a.append('.');
       }
       a.append(type.getSimpleName());
+    }
+
+    @Override
+    public AlwaysShorten inScope(QualifiedName type, Set<QualifiedName> supertypes) {
+      return this;
     }
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/GeneratedTypeSubject.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GeneratedTypeSubject.java
@@ -2,7 +2,13 @@ package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.THROW_ASSERTION_ERROR;
 
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 import com.google.common.truth.FailureStrategy;
 import com.google.common.truth.Subject;
@@ -10,6 +16,8 @@ import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.FormatterException;
 
 import org.inferred.freebuilder.processor.util.CompilationUnitBuilder;
+import org.inferred.freebuilder.processor.util.NoTypes;
+import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.Feature;
 import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
 import org.junit.ComparisonFailure;
@@ -18,9 +26,14 @@ import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeVisitor;
 
 class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> {
 
@@ -42,7 +55,7 @@ class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> 
   public void generates(String... code) {
     String expected = Arrays.stream(code).collect(joining("\n", "", "\n"));
     CompilationUnitBuilder compilationUnitBuilder = new CompilationUnitBuilder(
-            Mockito.mock(ProcessingEnvironment.class, new ReturnsDeepStubs()),
+            mockEnvironment(getSubject().getName(), getSubject().getVisibleNestedTypes()),
             getSubject().getName(),
             getSubject().getVisibleNestedTypes(),
             new StaticFeatureSet(environmentFeatures.toArray(new Feature<?>[0])));
@@ -61,5 +74,38 @@ class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> 
       }
       failWithRawMessage("%s", e.getMessage());
     }
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static ProcessingEnvironment mockEnvironment(
+      QualifiedName generatedType,
+      Set<QualifiedName> visibleTypes) {
+    ProcessingEnvironment env = Mockito.mock(ProcessingEnvironment.class, new ReturnsDeepStubs());
+    when(env.getElementUtils().getTypeElement(any()).getSuperclass().accept(any(), any()))
+        .thenAnswer(invocation -> {
+          TypeVisitor visitor = invocation.getArgumentAt(0, TypeVisitor.class);
+          Object param = invocation.getArgumentAt(1, Object.class);
+          return visitor.visitNoType(NoTypes.NONE, param);
+        });
+    when(env.getElementUtils().getPackageElement(any())).thenAnswer(invocation -> {
+      CharSequence pkg = invocation.getArgumentAt(0, CharSequence.class);
+      return mockPackageElement(pkg, generatedType, visibleTypes);
+    });
+    return env;
+  }
+
+  private static PackageElement mockPackageElement(
+      CharSequence name,
+      QualifiedName generatedType,
+      Set<QualifiedName> visibleTypes) {
+    List<TypeElement> topLevelTypes = visibleTypes.stream()
+        .filter(type -> type.getPackage().contentEquals(name))
+        .filter(QualifiedName::isTopLevel)
+        .filter(Predicate.isEqual(generatedType).negate())
+        .map(type -> newTopLevelClass(type.toString()).asElement())
+        .collect(toList());
+    PackageElement pkgElement = Mockito.mock(PackageElement.class, new ReturnsDeepStubs());
+    doReturn(topLevelTypes).when(pkgElement).getEnclosedElements();
+    return pkgElement;
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/ScopeHandlerTests.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ScopeHandlerTests.java
@@ -1,0 +1,355 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.inferred.freebuilder.processor.util.ScopeHandler.ScopeState;
+import org.inferred.freebuilder.processor.util.ScopeHandler.Visibility;
+import org.inferred.freebuilder.processor.util.testing.ModelRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ScopeHandlerTests {
+
+  @Rule public ModelRule model = new ModelRule();
+  private ScopeHandler handler;
+
+  @Before
+  public void setUp() {
+    handler = new ScopeHandler(model.elementUtils());
+  }
+
+  @Test
+  public void typeCanBeImportedIntoAnotherPackage() {
+    ScopeState result = handler.visibilityIn("com.example", QualifiedName.of(Set.class));
+    assertThat(result).isEqualTo(ScopeState.IMPORTABLE);
+  }
+
+  @Test
+  public void typeInThisPackageIsInScope() {
+    ScopeState result = handler.visibilityIn("java.util", QualifiedName.of(Set.class));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void generatedTypeInThisPackageIsInScope() {
+    QualifiedName myType = QualifiedName.of("com.example", "MyType");
+    handler.declareGeneratedType(Visibility.PACKAGE, myType, ImmutableSet.of());
+    ScopeState result = handler.visibilityIn("com.example", myType);
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void nestedTypeInThisPackageIsImportable() {
+    ScopeState result = handler.visibilityIn("java.util", QualifiedName.of(Map.Entry.class));
+    assertThat(result).isEqualTo(ScopeState.IMPORTABLE);
+  }
+
+  @Test
+  public void typeInThisPackageHidesTypesInOtherPackages() {
+    ScopeState result = handler.visibilityIn("java.util", QualifiedName.of("com.example", "Set"));
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void typeCanBeImportedIntoAnotherScope() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of("com.example", "FooBar"), QualifiedName.of(Set.class));
+    assertThat(result).isEqualTo(ScopeState.IMPORTABLE);
+  }
+
+  @Test
+  public void typeInSamePackageAsScopeIsInScope() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(Map.class), QualifiedName.of(Set.class));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void generatedTypeInSamePackageAsScopeIsInScope() {
+    QualifiedName myType = QualifiedName.of("com.example", "MyType");
+    handler.declareGeneratedType(Visibility.PACKAGE, myType, ImmutableSet.of());
+    ScopeState result = handler.visibilityIn(QualifiedName.of("com.example", "FooBar"), myType);
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void nestedTypeInSamePackageAsScopeIsImportable() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(Set.class), QualifiedName.of(Map.Entry.class));
+    assertThat(result).isEqualTo(ScopeState.IMPORTABLE);
+  }
+
+  @Test
+  public void typeInSamePackageAsScopeHidesTypesInOtherPackages() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(Map.class), QualifiedName.of("com.example", "Set"));
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void typeInScopeIsInScope() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(Map.class), QualifiedName.of(Map.Entry.class));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void typeInOuterScopeIsInScope() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(Map.Entry.class),
+        QualifiedName.of(Map.Entry.class));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  // HashMap extends AbstractMap, pulling in SimpleImmutableEntry, and implements Map, pulling in
+  // Entry.
+
+  @Test
+  public void typeCanBeImportedIntoScopeWithSupertypes() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(HashMap.class), QualifiedName.of("com.example", "FooBar"));
+    assertThat(result).isEqualTo(ScopeState.IMPORTABLE);
+  }
+
+  @Test
+  public void typeInSamePackageAsScopeWithSupertypesIsInScope() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(HashMap.class), QualifiedName.of(Set.class));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void nestedTypeInSamePackageAsScopeWithSupertypesIsImportable() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(HashSet.class), QualifiedName.of(Map.Entry.class));
+    assertThat(result).isEqualTo(ScopeState.IMPORTABLE);
+  }
+
+  @Test
+  public void typeInSuperclassIsImportable() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(HashMap.class), QualifiedName.of(AbstractMap.SimpleImmutableEntry.class));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void typeInInterfaceIsImportable() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(HashMap.class), QualifiedName.of(Map.Entry.class));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void typeInSuperclassHidesTypesInOtherPackages() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(HashMap.class), QualifiedName.of("com.example", "SimpleImmutableEntry"));
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void typeInInterfaceHidesTypesInOtherPackages() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(HashMap.class), QualifiedName.of("com.example", "Entry"));
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void typeInScopeWithSupertypesIsInScope() {
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of(HashMap.class), QualifiedName.of(Map.Entry.class));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void promisedNestedTypeHidesTypeInSameNamespace() {
+    QualifiedName outerType = QualifiedName.of("com.example", "A");
+    QualifiedName scopeType = outerType.nestedType("B");
+    QualifiedName nestedType = outerType.nestedType("Set");
+    QualifiedName hiddenType = QualifiedName.of(Set.class);
+    handler.predeclareGeneratedType(outerType);
+    handler.predeclareGeneratedType(scopeType);
+    handler.predeclareGeneratedType(nestedType);
+
+    ScopeState result = handler.visibilityIn(scopeType, hiddenType);
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void promisedNestedTypeInScopeOfSubtype() {
+    QualifiedName outerType = QualifiedName.of("com.example", "A");
+    QualifiedName nestedType = outerType.nestedType("Set");
+    QualifiedName scopeType = QualifiedName.of("com.example", "B");
+    handler.predeclareGeneratedType(outerType);
+    handler.predeclareGeneratedType(nestedType);
+    handler.declareGeneratedType(Visibility.PACKAGE, scopeType, ImmutableSet.of(outerType));
+
+    ScopeState result = handler.visibilityIn(scopeType, nestedType);
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void typeInSuperclassHidesTypeInEnclosingClass() {
+    model.newType(
+        "package com.example;",
+        "class A {",
+        "  abstract class B extends java.util.AbstractMap<Object, Object> {}",
+        "  interface Entry {}",
+        "}");
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of("com.example", "A", "B"), QualifiedName.of("com.example", "A", "Entry"));
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void typeInInterfaceHidesTypeInEnclosingClass() {
+    model.newType(
+        "package com.example;",
+        "class A {",
+        "  abstract class B implements java.util.Map<Object, Object> {}",
+        "  interface Entry {}",
+        "}");
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of("com.example", "A", "B"), QualifiedName.of("com.example", "A", "Entry"));
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void typeInSuperclassHidesTypeInGeneratedEnclosingClass() {
+    QualifiedName generatedType = QualifiedName.of("com.example", "A");
+    QualifiedName scopeType = generatedType.nestedType("B");
+    QualifiedName supertype = QualifiedName.of(AbstractMap.class);
+    QualifiedName hiddenNestedType = generatedType.nestedType("Entry");
+
+    handler.declareGeneratedType(Visibility.PACKAGE, generatedType, ImmutableSet.of());
+    handler.declareGeneratedType(Visibility.PACKAGE, scopeType, ImmutableSet.of(supertype));
+    handler.declareGeneratedType(Visibility.PACKAGE, hiddenNestedType, ImmutableSet.of());
+
+    ScopeState result = handler.visibilityIn(scopeType, hiddenNestedType);
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void typeInInterfaceHidesTypeInGeneratedEnclosingClass() {
+    QualifiedName generatedType = QualifiedName.of("com.example", "A");
+    QualifiedName scopeType = generatedType.nestedType("B");
+    QualifiedName interfaceType = QualifiedName.of(Map.class);
+    QualifiedName hiddenNestedType = generatedType.nestedType("Entry");
+
+    handler.declareGeneratedType(Visibility.PACKAGE, generatedType, ImmutableSet.of());
+    handler.declareGeneratedType(Visibility.PACKAGE, scopeType, ImmutableSet.of(interfaceType));
+    handler.declareGeneratedType(Visibility.PACKAGE, hiddenNestedType, ImmutableSet.of());
+
+    ScopeState result = handler.visibilityIn(scopeType, hiddenNestedType);
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void ambiguousSupertypeScopeReferenceConsideredHidden() {
+    model.newType(
+        "package com.example;",
+        "interface I {",
+        "  interface X {}",
+        "}",
+        "interface J {",
+        "  interface X {}",
+        "}",
+        "class A {",
+        "  abstract class B implements I, J {}",
+        "}");
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of("com.example", "A", "B"), QualifiedName.of("com.example", "I", "X"));
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void packageProtectedTypeInSupertypeInSamePackageIsInScope() {
+    model.newType(
+        "package com.example;",
+        "class S {",
+        "  class X {}",
+        "}",
+        "class A {",
+        "  abstract class B extends S {}",
+        "}");
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of("com.example", "A", "B"), QualifiedName.of("com.example", "S", "X"));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void packageProtectedTypeInSupertypeInSamePackageHidesTypeInOuterScope() {
+    model.newType(
+        "package com.example;",
+        "class S {",
+        "  class X {}",
+        "}",
+        "class A {",
+        "  abstract class B extends S {}",
+        "  class X {}",
+        "}");
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of("com.example", "A", "B"), QualifiedName.of("com.example", "A", "X"));
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+
+  @Test
+  public void privateTypeInSupertypeInSamePackageDoesNotHideTypeInOuterScope() {
+    model.newType(
+        "package com.example;",
+        "class S {",
+        "  private class X {}",
+        "}",
+        "class A {",
+        "  abstract class B extends S {}",
+        "  class X {}",
+        "}");
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of("com.example", "A", "B"), QualifiedName.of("com.example", "A", "X"));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void packageProtectedTypeInSupertypeInDifferentPackageDoesNotHideTypeInOuterScope() {
+    model.newType(
+        "package com.example.n;",
+        "class S {",
+        "  class X {}",
+        "}");
+    model.newType(
+        "package com.example;",
+        "class A {",
+        "  abstract class B extends com.example.n.S {}",
+        "  class X {}",
+        "}");
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of("com.example", "A", "B"), QualifiedName.of("com.example", "A", "X"));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
+  public void protectedTypeInSupertypeInDifferentPackageHidesTypeInOuterScope() {
+    model.newType(
+        "package com.example.n;",
+        "public class S {",
+        "  protected class X {}",
+        "}");
+    model.newType(
+        "package com.example;",
+        "class A {",
+        "  abstract class B extends com.example.n.S {}",
+        "  class X {}",
+        "}");
+    ScopeState result = handler.visibilityIn(
+        QualifiedName.of("com.example", "A", "B"), QualifiedName.of("com.example", "A", "X"));
+    assertThat(result).isEqualTo(ScopeState.HIDDEN);
+  }
+}


### PR DESCRIPTION
Java scopes are rather complex. Encapsulate a complete set of rules for how visibility, nesting and inheritance interact into a new ScopeHandler type, and integrate it into the SourceBuilder/TypeShortener hierarchies, to ensure generated code does not accidentally refer to the wrong type by mistake.

This includes an integration test of a superclass scope import bug that, fortunately, would be very unlikely to crop up in the field, and is anyway now fixed. However, the real goal is to move towards smarter name shortening that exploits scope to produce more readable code.