### PR TITLE
Track type body blocks automatically when emitting code

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
@@ -22,7 +22,6 @@ import static org.inferred.freebuilder.processor.Datatype.UnderrideLevel.ABSENT;
 import static org.inferred.freebuilder.processor.Datatype.UnderrideLevel.FINAL;
 import static org.inferred.freebuilder.processor.ToStringGenerator.addToString;
 import static org.inferred.freebuilder.processor.util.Block.methodBody;
-import static org.inferred.freebuilder.processor.util.Block.typeBody;
 import static org.inferred.freebuilder.processor.util.LazyName.addLazyDefinitions;
 import static org.inferred.freebuilder.processor.util.ObjectsExcerpts.Nullability.NOT_NULLABLE;
 import static org.inferred.freebuilder.processor.util.ObjectsExcerpts.Nullability.NULLABLE;
@@ -313,22 +312,21 @@ class GeneratedBuilder extends GeneratedType {
         datatype.getValueTypeVisibility(),
         datatype.getValueType().declaration(),
         extending(datatype.getType(), datatype.isInterfaceType()));
-    SourceBuilder body = typeBody(code, datatype.getValueType(), datatype.getType());
     for (Property property : generatorsByProperty.keySet()) {
-      generatorsByProperty.get(property).addValueFieldDeclaration(body, property.getField());
+      generatorsByProperty.get(property).addValueFieldDeclaration(code, property.getField());
     }
-    addValueTypeConstructor(body);
-    addValueTypeGetters(body);
+    addValueTypeConstructor(code);
+    addValueTypeGetters(code);
     if (datatype.getHasToBuilderMethod()) {
-      addValueTypeToBuilder(body);
+      addValueTypeToBuilder(code);
     }
     switch (datatype.standardMethodUnderride(StandardMethod.EQUALS)) {
       case ABSENT:
-        addValueTypeEquals(body);
+        addValueTypeEquals(code);
         break;
 
       case OVERRIDEABLE:
-        addValueTypeEqualsOverride(body);
+        addValueTypeEqualsOverride(code);
         break;
 
       case FINAL:
@@ -337,14 +335,13 @@ class GeneratedBuilder extends GeneratedType {
     }
     // Hash code
     if (datatype.standardMethodUnderride(StandardMethod.HASH_CODE) == ABSENT) {
-      addValueTypeHashCode(body);
+      addValueTypeHashCode(code);
     }
     // toString
     if (datatype.standardMethodUnderride(StandardMethod.TO_STRING) == ABSENT) {
-      addToString(body, datatype, generatorsByProperty, false);
+      addToString(code, datatype, generatorsByProperty, false);
     }
-    code.add(body.toString())
-        .addLine("}");
+    code.addLine("}");
   }
 
   private void addValueTypeConstructor(SourceBuilder code) {
@@ -458,22 +455,20 @@ class GeneratedBuilder extends GeneratedType {
         .addLine("private static final class %s %s {",
             datatype.getPartialType().declaration(),
             extending(datatype.getType(), datatype.isInterfaceType()));
-    SourceBuilder body = typeBody(code, datatype.getPartialType(), datatype.getType());
-    addPartialFields(body);
-    addPartialConstructor(body);
-    addPartialGetters(body);
-    addPartialToBuilderMethod(body);
+    addPartialFields(code);
+    addPartialConstructor(code);
+    addPartialGetters(code);
+    addPartialToBuilderMethod(code);
     if (datatype.standardMethodUnderride(StandardMethod.EQUALS) != FINAL) {
-      addPartialEquals(body);
+      addPartialEquals(code);
     }
     if (datatype.standardMethodUnderride(StandardMethod.HASH_CODE) != FINAL) {
-      addPartialHashCode(body);
+      addPartialHashCode(code);
     }
     if (datatype.standardMethodUnderride(StandardMethod.TO_STRING) != FINAL) {
-      addToString(body, datatype, generatorsByProperty, true);
+      addToString(code, datatype, generatorsByProperty, true);
     }
-    code.add(body.toString())
-        .addLine("}");
+    code.addLine("}");
   }
 
   private void addPartialFields(SourceBuilder code) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/AbstractSourceBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/AbstractSourceBuilder.java
@@ -10,7 +10,6 @@ import org.inferred.freebuilder.processor.util.feature.FeatureType;
 
 import java.io.IOException;
 import java.util.MissingFormatArgumentException;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -93,11 +92,6 @@ public abstract class AbstractSourceBuilder<B extends AbstractSourceBuilder<B>>
   @Override
   public SourceStringBuilder subBuilder() {
     return new SourceStringBuilder(getShortener(), features, scope);
-  }
-
-  @Override
-  public SourceStringBuilder nestedType(QualifiedName type, Set<QualifiedName> supertypes) {
-    return new SourceStringBuilder(getShortener().inScope(type, supertypes), features, scope);
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/util/Block.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Block.java
@@ -3,36 +3,15 @@ package org.inferred.freebuilder.processor.util;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Maps.newLinkedHashMap;
 
-import com.google.common.collect.ImmutableSet;
-
 import org.inferred.freebuilder.processor.util.feature.Feature;
 import org.inferred.freebuilder.processor.util.feature.FeatureType;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A Block contains a preamble of lazily-added declarations followed by a body.
  */
 public class Block extends Excerpt implements SourceBuilder {
-
-  /**
-   * Returns a source builder that will not illegal shorten hidden types.
-   *
-   * @param parent the enclosing source builder
-   * @param type the type this is the body of
-   * @param supertypes all supertypes of {@code type}
-   */
-  public static SourceBuilder typeBody(
-      SourceBuilder parent,
-      TypeClass type,
-      Type... supertypes) {
-    ImmutableSet.Builder<QualifiedName> supertypeNames = ImmutableSet.builder();
-    for (Type supertype : supertypes) {
-      supertypeNames.add(supertype.getQualifiedName());
-    }
-    return parent.nestedType(type.getQualifiedName(), supertypeNames.build());
-  }
 
   public static Block methodBody(SourceBuilder parent, String... paramNames) {
     Scope methodScope = new Scope.MethodScope(parent.scope());
@@ -130,11 +109,6 @@ public class Block extends Excerpt implements SourceBuilder {
   @Override
   public SourceStringBuilder subBuilder() {
     return body.subBuilder();
-  }
-
-  @Override
-  public SourceStringBuilder nestedType(QualifiedName type, Set<QualifiedName> supertypes) {
-    throw new UnsupportedOperationException("Cannot declare a named type inside a method block");
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/util/ScopeAwareTypeShortener.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ScopeAwareTypeShortener.java
@@ -1,5 +1,9 @@
 package org.inferred.freebuilder.processor.util;
 
+import static com.google.common.collect.Sets.newHashSet;
+
+import com.google.common.base.Optional;
+
 import org.inferred.freebuilder.processor.util.ScopeHandler.ScopeState;
 import org.inferred.freebuilder.processor.util.ScopeHandler.Visibility;
 import org.inferred.freebuilder.processor.util.TypeShortener.AbstractTypeShortener;
@@ -12,15 +16,20 @@ import javax.lang.model.element.TypeElement;
 class ScopeAwareTypeShortener extends AbstractTypeShortener {
 
   private final TypeShortener delegate;
+  private final String pkg;
   private final QualifiedName scope;
   private final ScopeHandler handler;
 
-  ScopeAwareTypeShortener(TypeShortener delegate, ScopeHandler handler) {
-    this(delegate, null, handler);
+  ScopeAwareTypeShortener(TypeShortener delegate, ScopeHandler handler, String pkg) {
+    this.delegate = delegate;
+    this.pkg = pkg;
+    this.scope = null;
+    this.handler = handler;
   }
 
   ScopeAwareTypeShortener(TypeShortener delegate, QualifiedName scope, ScopeHandler handler) {
     this.delegate = delegate;
+    this.pkg = scope.getPackage();
     this.scope = scope;
     this.handler = handler;
   }
@@ -47,13 +56,47 @@ class ScopeAwareTypeShortener extends AbstractTypeShortener {
   }
 
   @Override
+  public Optional<QualifiedName> lookup(String shortenedType) {
+    if (scope == null) {
+      return delegate.lookup(shortenedType);
+    }
+    String[] simpleNames = shortenedType.split("\\.");
+    QualifiedName result;
+    if (scope != null) {
+      result = handler.typeInScope(scope, simpleNames[0]).orNull();
+    } else {
+      result = handler.typeInScope(pkg, simpleNames[0]).orNull();
+    }
+    if (result != null) {
+      for (int i = 1; i < simpleNames.length; i++) {
+        result = result.nestedType(simpleNames[i]);
+      }
+      return Optional.of(result);
+    }
+    result = delegate.lookup(shortenedType).orNull();
+    if (result != null) {
+      return Optional.of(result);
+    }
+    return handler.lookup(shortenedType);
+  }
+
+  @Override
   public void appendShortened(Appendable a, TypeElement type) throws IOException {
     appendShortened(a, QualifiedName.of(type));
   }
 
-  @Override
-  public TypeShortener inScope(QualifiedName type, Set<QualifiedName> supertypes) {
-    handler.declareGeneratedType(Visibility.UNKNOWN, type, supertypes);
-    return new ScopeAwareTypeShortener(delegate, type, handler);
+  public ScopeAwareTypeShortener inScope(String simpleName, Set<String> supertypes) {
+    QualifiedName newScope = (scope == null)
+        ? QualifiedName.of(pkg, simpleName)
+        : scope.nestedType(simpleName);
+    Set<QualifiedName> qualifiedSupertypes = newHashSet();
+    for (String supertype : supertypes) {
+      QualifiedName qualifiedSupertype = lookup(supertype).orNull();
+      if (qualifiedSupertype != null) {
+        qualifiedSupertypes.add(qualifiedSupertype);
+      }
+    }
+    handler.declareGeneratedType(Visibility.UNKNOWN, newScope, qualifiedSupertypes);
+    return new ScopeAwareTypeShortener(delegate, newScope, handler);
   }
 }

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
@@ -19,8 +19,6 @@ import org.inferred.freebuilder.processor.util.feature.Feature;
 import org.inferred.freebuilder.processor.util.feature.FeatureType;
 import org.inferred.freebuilder.processor.util.feature.GuavaLibrary;
 
-import java.util.Set;
-
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -75,13 +73,6 @@ public interface SourceBuilder {
    * will be included in the imports for this builder (and its parents).
    */
   SourceStringBuilder subBuilder();
-
-  /**
-   * Returns a {@code SourceStringBuilder} with the same configuration as this builder, but with
-   * the {@code TypeShortener} using scoping rules for {@code type}. Any types added to the
-   * sub-builder will be included in the imports for this builder (and its parents).
-   */
-  SourceStringBuilder nestedType(QualifiedName type, Set<QualifiedName> supertypes);
 
   /**
    * Returns a {@code SourceStringBuilder} with the same configuration as this builder, but with

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceParser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceParser.java
@@ -1,0 +1,197 @@
+package org.inferred.freebuilder.processor.util;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * API for parsing Java source with callbacks.
+ */
+class SourceParser {
+
+  /**
+   * Receive notifications of gross Java structure events.
+   */
+  interface EventHandler {
+    void onTypeBlockStart(String keyword, String simpleName, Set<String> supertypes);
+    void onOtherBlockStart();
+    void onBlockEnd();
+  }
+
+  private static final Pattern TYPE = Pattern.compile(
+      "\\b(class|interface|enum|@interface)\\s*(\\w+)");
+  private static final Pattern IDENTIFIER = Pattern.compile("\\S+");
+
+  private enum State {
+    CODE,
+    SLASH,
+    STRING_LITERAL,
+    STRING_LITERAL_ESCAPE,
+    CHAR_LITERAL,
+    CHAR_LITERAL_ESCAPE,
+    LINE_COMMENT,
+    BLOCK_COMMENT,
+    BLOCK_COMMENT_STAR
+  }
+
+  private final EventHandler eventHandler;
+  private final StringBuilder statement;
+  private State state;
+
+  SourceParser(EventHandler eventHandler) {
+    this.eventHandler = eventHandler;
+    statement = new StringBuilder();
+    state = State.CODE;
+  }
+
+  public void parse(char c) {
+    switch (state) {
+      case CODE:
+      case SLASH:
+        statement.append(c);
+        switch (c) {
+          case '{':
+            statement.deleteCharAt(statement.length() - 1);
+            onBlockStart(statement.toString().trim());
+            statement.setLength(0);
+            break;
+          case '}':
+            eventHandler.onBlockEnd();
+            statement.setLength(0);
+            break;
+          case ';':
+            statement.setLength(0);
+            break;
+          case '"':
+            state = State.STRING_LITERAL;
+            break;
+          case '/':
+            if (state == State.CODE) {
+              state = State.SLASH;
+            } else {
+              state = State.LINE_COMMENT;
+              statement.delete(statement.length() - 2, statement.length());
+            }
+            break;
+          case '*':
+            if (state == State.CODE) {
+              state = State.CODE;
+            } else {
+              state = State.BLOCK_COMMENT;
+              statement.delete(statement.length() - 2, statement.length());
+            }
+            break;
+        }
+        break;
+
+      case STRING_LITERAL:
+        switch (c) {
+          case '\\':
+            state = State.STRING_LITERAL_ESCAPE;
+            break;
+
+          case '"':
+            statement.append(c);
+            state = State.CODE;
+            break;
+        }
+        break;
+
+      case STRING_LITERAL_ESCAPE:
+        statement.append(c);
+        state = State.STRING_LITERAL;
+        break;
+
+      case CHAR_LITERAL:
+        switch (c) {
+          case '\\':
+            state = State.CHAR_LITERAL_ESCAPE;
+            break;
+
+          case '\'':
+            statement.append(c);
+            state = State.CODE;
+            break;
+        }
+        break;
+
+      case CHAR_LITERAL_ESCAPE:
+        state = State.CHAR_LITERAL;
+        break;
+
+      case LINE_COMMENT:
+        if (c == '\n') {
+          state = State.CODE;
+        }
+        break;
+
+      case BLOCK_COMMENT:
+      case BLOCK_COMMENT_STAR:
+        switch (c) {
+          case '*':
+            state = State.BLOCK_COMMENT_STAR;
+            break;
+
+          case '/':
+            if (state == State.BLOCK_COMMENT_STAR) {
+              state = State.CODE;
+            }
+            break;
+
+          default:
+            state = State.BLOCK_COMMENT;
+            break;
+        }
+        break;
+    }
+  }
+
+  private void onBlockStart(CharSequence chars) {
+    Matcher typeMatcher = TYPE.matcher(chars);
+    if (typeMatcher.find()) {
+      Set<String> supertypes = supertypes(chars.subSequence(typeMatcher.end(), chars.length()));
+      eventHandler.onTypeBlockStart(typeMatcher.group(1), typeMatcher.group(2), supertypes);
+      return;
+    }
+    eventHandler.onOtherBlockStart();
+  }
+
+  private static Set<String> supertypes(CharSequence chars) {
+    Set<String> types = new HashSet<String>();
+    Matcher rawTypeMatcher = IDENTIFIER.matcher(withoutTypeParams(chars));
+    while (rawTypeMatcher.find()) {
+      types.add(rawTypeMatcher.group());
+    }
+    types.remove("extends");
+    types.remove("implements");
+    return types;
+  }
+
+  private static CharSequence withoutTypeParams(CharSequence chars) {
+    StringBuilder result = new StringBuilder();
+    int depth = 0;
+    for (int i = 0; i < chars.length(); i++) {
+      char c = chars.charAt(i);
+      switch (c) {
+        case '<':
+          depth++;
+          break;
+
+        case '>':
+          depth--;
+          checkState(depth >= 0, "Unexpected > in '%s'", chars);
+          break;
+
+        default:
+          if (depth == 0) {
+            result.append(c);
+          }
+          break;
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/TypeShortener.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/TypeShortener.java
@@ -17,8 +17,9 @@ package org.inferred.freebuilder.processor.util;
 
 import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
 
+import com.google.common.base.Optional;
+
 import java.io.IOException;
-import java.util.Set;
 
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
@@ -36,7 +37,7 @@ interface TypeShortener {
   void appendShortened(Appendable a, TypeMirror mirror) throws IOException;
   void appendShortened(Appendable a, QualifiedName type) throws IOException;
 
-  TypeShortener inScope(QualifiedName type, Set<QualifiedName> supertypes);
+  Optional<QualifiedName> lookup(String shortenedType);
 
   abstract class AbstractTypeShortener
       extends SimpleTypeVisitor6<Void, Appendable>
@@ -134,8 +135,8 @@ interface TypeShortener {
     }
 
     @Override
-    public NeverShorten inScope(QualifiedName type, Set<QualifiedName> supertypes) {
-      return this;
+    public Optional<QualifiedName> lookup(String shortenedType) {
+      throw new UnsupportedOperationException();
     }
   }
 
@@ -161,8 +162,8 @@ interface TypeShortener {
     }
 
     @Override
-    public AlwaysShorten inScope(QualifiedName type, Set<QualifiedName> supertypes) {
-      return this;
+    public Optional<QualifiedName> lookup(String shortenedType) {
+      throw new UnsupportedOperationException();
     }
   }
 }


### PR DESCRIPTION
Currently, code generators have to explicitly create new source objects to track when they are generating code inside a type block. They also need to redeclare supertype information that's already been written once to the source. We could make the type block source objects automatically generate the source code, but that requires passing in even more metadata, and modifying all existing code generators to use the new approach. I also struggled to find a general solution that was as readable and flexible as the traditional "append code" approach.

Instead, reparse the generated code to detect {}-delimited blocks, and pull type declarations, including supertype information, back out as well. This lets us keep the code generators clean, and build smarts once-and-only-once in the SourceBuilder framework.

The core responsibility of tracking block starts and ends, together with detecting class declarations, falls to SourceParser, which (like the SAX framework) emits callbacks to CompilationUnitBuilder to allow it to keep track of the stack of scopes.