### PR TITLE
Fix bug in SourceParser caused by typo of '*' for '+'

### DIFF
--- a/src/test/java/org/inferred/freebuilder/processor/util/SourceParserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/SourceParserTest.java
@@ -1,0 +1,119 @@
+package org.inferred.freebuilder.processor.util;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SourceParserTest {
+
+  @Mock private SourceParser.EventHandler eventHandler;
+  private SourceParser parser;
+
+  @Before
+  public void setup() {
+    parser = new SourceParser(eventHandler);
+  }
+
+  @Test
+  public void ifBlockStart() {
+    parse("if (something < someOtherThing) {");
+    verify(eventHandler).onOtherBlockStart();
+  }
+
+  @Test
+  public void blockEnd() {
+    parse("}");
+    verify(eventHandler).onBlockEnd();
+  }
+
+  @Test
+  public void classDeclaration() {
+    parse("public static abstract class FooBar {");
+    verify(eventHandler).onTypeBlockStart("class", "FooBar", ImmutableSet.of());
+  }
+
+  @Test
+  public void classWithUmlaut() {
+    parse("public class Vögel {");
+    verify(eventHandler).onTypeBlockStart("class", "Vögel", ImmutableSet.of());
+  }
+
+  @Test
+  public void genericClass() {
+    parse("public class Foo<A, B> {");
+    verify(eventHandler).onTypeBlockStart("class", "Foo", ImmutableSet.of());
+  }
+
+  @Test
+  public void classWithSuperclass() {
+    parse("public static abstract class FooBar extends Baz.Bam<Foo, Bar> {");
+    verify(eventHandler).onTypeBlockStart("class", "FooBar", ImmutableSet.of("Baz.Bam"));
+  }
+
+  @Test
+  public void superclassWithOddSpacing() {
+    parse("public static abstract class FooBar extends Baz .Bam<Foo, Bar> {");
+    verify(eventHandler).onTypeBlockStart("class", "FooBar", ImmutableSet.of("Baz.Bam"));
+  }
+
+  @Test
+  public void superclassWithUmlaut() {
+    parse("public static abstract class FooBar extends Vögel {");
+    verify(eventHandler).onTypeBlockStart("class", "FooBar", ImmutableSet.of("Vögel"));
+  }
+
+  @Test
+  public void classImplementingInterface() {
+    parse("public static abstract class FooBar implements Baz.Bam<Foo, Bar> {");
+    verify(eventHandler).onTypeBlockStart("class", "FooBar", ImmutableSet.of("Baz.Bam"));
+  }
+
+  @Test
+  public void interfaceWithOddSpacing() {
+    parse("public static abstract class FooBar implements Baz .Bam<Foo, Bar> {");
+    verify(eventHandler).onTypeBlockStart("class", "FooBar", ImmutableSet.of("Baz.Bam"));
+  }
+
+  @Test
+  public void interfaceWithUmlaut() {
+    parse("public static abstract class FooBar implements Vögel {");
+    verify(eventHandler).onTypeBlockStart("class", "FooBar", ImmutableSet.of("Vögel"));
+  }
+
+  @Test
+  public void classImplementingMultipleInterfaces() {
+    parse("public static abstract class FooBar implements Foo, Bar, Baz {");
+    verify(eventHandler).onTypeBlockStart("class", "FooBar", ImmutableSet.of("Foo", "Bar", "Baz"));
+  }
+
+  @Test
+  public void classExtendingSuperclassAndImplementingMultipleInterfaces() {
+    parse("public static abstract class FooBar extends Foo implements Bar, Baz {");
+    verify(eventHandler).onTypeBlockStart("class", "FooBar", ImmutableSet.of("Foo", "Bar", "Baz"));
+  }
+
+  @Test
+  public void parameterWithInterfaceKeywordIn() {
+    // This triggered a bug due to accidentally marking the space after "interface" as optional.
+    parse("public Builder setInterfaceType(boolean interfaceType) {");
+    verify(eventHandler).onOtherBlockStart();
+  }
+
+  @After
+  public void teardown() {
+    verifyNoMoreInteractions(eventHandler);
+  }
+
+  private void parse(CharSequence chars) {
+    chars.chars().forEach(c -> parser.parse((char) c));
+  }
+}


### PR DESCRIPTION
Managed to trigger this when dogfooding, as Property defines a variable called 'interfaceType', which SourceParser was erroneously considering a definition of an interface called Type, which then fortuitously collided with the actual class 'Type' being used elsewhere.

Also add better error checking and a test suite.