### PR TITLE
Reduce size of TypeShortener API

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/AbstractSourceBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/AbstractSourceBuilder.java
@@ -29,10 +29,12 @@ public abstract class AbstractSourceBuilder<B extends AbstractSourceBuilder<B>>
 
   protected final FeatureSet features;
   protected final Scope scope;
+  protected final TypeMirrorShortener typeMirrorShortener;
 
   protected AbstractSourceBuilder(FeatureSet features, Scope scope) {
     this.features = features;
     this.scope = scope;
+    typeMirrorShortener = new TypeMirrorShortener(this);
   }
 
   protected abstract TypeShortener getShortener();
@@ -135,7 +137,7 @@ public abstract class AbstractSourceBuilder<B extends AbstractSourceBuilder<B>>
       } else if (arg instanceof TypeMirror) {
         TypeMirror mirror = (TypeMirror) arg;
         checkArgument(isLegalType(mirror), "Cannot write unknown type %s", mirror);
-        getShortener().appendShortened(this, mirror);
+        typeMirrorShortener.appendShortened(getShortener(), mirror);
       } else if (arg instanceof QualifiedName) {
         getShortener().appendShortened(this, (QualifiedName) arg);
       } else if (arg instanceof AnnotationMirror) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
@@ -26,17 +26,11 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 
-import org.inferred.freebuilder.processor.util.TypeShortener.AbstractTypeShortener;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.TreeSet;
-
-import javax.lang.model.element.Name;
-import javax.lang.model.element.PackageElement;
-import javax.lang.model.element.TypeElement;
 
 /**
  * Manages the imports for a source file, and produces short type references by adding extra
@@ -45,7 +39,7 @@ import javax.lang.model.element.TypeElement;
  * <p>To ensure we never import common names like 'Builder', nested classes are never directly
  * imported. This is necessarily less readable when types are used as namespaces, e.g. in proto2.
  */
-class ImportManager extends AbstractTypeShortener {
+class ImportManager implements TypeShortener {
 
   private static final String JAVA_LANG_PACKAGE = "java.lang";
   private static final String PACKAGE_PREFIX = "package ";
@@ -108,20 +102,6 @@ class ImportManager extends AbstractTypeShortener {
     }
   }
 
-  @Override
-  public void appendShortened(Appendable a, TypeElement type) throws IOException {
-    if (type.getNestingKind().isNested()) {
-      appendShortened(a, (TypeElement) type.getEnclosingElement());
-      a.append('.');
-    } else {
-      PackageElement pkg = (PackageElement) type.getEnclosingElement();
-      Name name = type.getSimpleName();
-      appendPackageForTopLevelClass(a, pkg.getQualifiedName().toString(), name);
-    }
-    a.append(type.getSimpleName());
-  }
-
-  @Override
   public Optional<QualifiedName> lookup(String shortenedType) {
     String[] simpleNames = shortenedType.split("\\.");
     Set<QualifiedName> possibilities = visibleSimpleNames.get(simpleNames[0]);

--- a/src/main/java/org/inferred/freebuilder/processor/util/ScopeAwareTypeShortener.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ScopeAwareTypeShortener.java
@@ -6,28 +6,25 @@ import com.google.common.base.Optional;
 
 import org.inferred.freebuilder.processor.util.ScopeHandler.ScopeState;
 import org.inferred.freebuilder.processor.util.ScopeHandler.Visibility;
-import org.inferred.freebuilder.processor.util.TypeShortener.AbstractTypeShortener;
 
 import java.io.IOException;
 import java.util.Set;
 
-import javax.lang.model.element.TypeElement;
+class ScopeAwareTypeShortener implements TypeShortener {
 
-class ScopeAwareTypeShortener extends AbstractTypeShortener {
-
-  private final TypeShortener delegate;
+  private final ImportManager delegate;
   private final String pkg;
   private final QualifiedName scope;
   private final ScopeHandler handler;
 
-  ScopeAwareTypeShortener(TypeShortener delegate, ScopeHandler handler, String pkg) {
+  ScopeAwareTypeShortener(ImportManager delegate, ScopeHandler handler, String pkg) {
     this.delegate = delegate;
     this.pkg = pkg;
     this.scope = null;
     this.handler = handler;
   }
 
-  ScopeAwareTypeShortener(TypeShortener delegate, QualifiedName scope, ScopeHandler handler) {
+  ScopeAwareTypeShortener(ImportManager delegate, QualifiedName scope, ScopeHandler handler) {
     this.delegate = delegate;
     this.pkg = scope.getPackage();
     this.scope = scope;
@@ -55,7 +52,6 @@ class ScopeAwareTypeShortener extends AbstractTypeShortener {
     }
   }
 
-  @Override
   public Optional<QualifiedName> lookup(String shortenedType) {
     if (scope == null) {
       return delegate.lookup(shortenedType);
@@ -78,11 +74,6 @@ class ScopeAwareTypeShortener extends AbstractTypeShortener {
       return Optional.of(result);
     }
     return handler.lookup(shortenedType);
-  }
-
-  @Override
-  public void appendShortened(Appendable a, TypeElement type) throws IOException {
-    appendShortened(a, QualifiedName.of(type));
   }
 
   public ScopeAwareTypeShortener inScope(String simpleName, Set<String> supertypes) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/TypeMirrorShortener.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/TypeMirrorShortener.java
@@ -1,0 +1,91 @@
+package org.inferred.freebuilder.processor.util;
+
+import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
+
+import java.io.IOException;
+
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
+import javax.lang.model.util.SimpleTypeVisitor6;
+
+class TypeMirrorShortener extends SimpleTypeVisitor6<Void, TypeShortener> {
+
+  private static class IOExceptionWrapper extends RuntimeException {
+    IOExceptionWrapper(IOException cause) {
+      super(cause);
+    }
+
+    @Override
+    public synchronized IOException getCause() {
+      return (IOException) super.getCause();
+    }
+  }
+
+  private final Appendable a;
+
+  TypeMirrorShortener(Appendable a) {
+    this.a = a;
+  }
+
+  public void appendShortened(TypeShortener s, TypeMirror mirror) throws IOException {
+    try {
+      mirror.accept(this, s);
+    } catch (IOExceptionWrapper e) {
+      throw e.getCause();
+    }
+  }
+
+  @Override
+  public Void visitDeclared(DeclaredType mirror, TypeShortener s) {
+    try {
+      if (mirror.getEnclosingType().getKind() == TypeKind.NONE) {
+        s.appendShortened(a, QualifiedName.of(asElement(mirror)));
+      } else {
+        mirror.getEnclosingType().accept(this, s);
+        a.append('.').append(mirror.asElement().getSimpleName());
+      }
+      if (!mirror.getTypeArguments().isEmpty()) {
+        String prefix = "<";
+        for (TypeMirror typeArgument : mirror.getTypeArguments()) {
+          a.append(prefix);
+          typeArgument.accept(this, s);
+          prefix = ", ";
+        }
+        a.append(">");
+      }
+      return null;
+    } catch (IOException e) {
+      throw new IOExceptionWrapper(e);
+    }
+  }
+
+  @Override
+  public Void visitWildcard(WildcardType t, TypeShortener s) {
+    try {
+      a.append("?");
+      if (t.getSuperBound() != null) {
+        a.append(" super ");
+        t.getSuperBound().accept(this, s);
+      }
+      if (t.getExtendsBound() != null) {
+        a.append(" extends ");
+        t.getExtendsBound().accept(this, s);
+      }
+      return null;
+    } catch (IOException e) {
+      throw new IOExceptionWrapper(e);
+    }
+  }
+
+  @Override
+  protected Void defaultAction(TypeMirror mirror, TypeShortener s) {
+    try {
+      a.append(mirror.toString());
+      return null;
+    } catch (IOException e) {
+      throw new IOExceptionWrapper(e);
+    }
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/TypeShortener.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/TypeShortener.java
@@ -15,110 +15,17 @@
  */
 package org.inferred.freebuilder.processor.util;
 
-import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
-
-import com.google.common.base.Optional;
-
 import java.io.IOException;
-
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.type.WildcardType;
-import javax.lang.model.util.SimpleTypeVisitor6;
 
 /**
  * Produces type references for use in source code.
  */
 interface TypeShortener {
 
-  void appendShortened(Appendable a, TypeElement type) throws IOException;
-  void appendShortened(Appendable a, TypeMirror mirror) throws IOException;
   void appendShortened(Appendable a, QualifiedName type) throws IOException;
 
-  Optional<QualifiedName> lookup(String shortenedType);
-
-  abstract class AbstractTypeShortener
-      extends SimpleTypeVisitor6<Void, Appendable>
-      implements TypeShortener {
-
-    private static class IOExceptionWrapper extends RuntimeException {
-      IOExceptionWrapper(IOException cause) {
-        super(cause);
-      }
-
-      @Override
-      public synchronized IOException getCause() {
-        return (IOException) super.getCause();
-      }
-    }
-
-    @Override
-    public void appendShortened(Appendable a, TypeMirror mirror) throws IOException {
-      try {
-        mirror.accept(this, a);
-      } catch (IOExceptionWrapper e) {
-        throw e.getCause();
-      }
-    }
-
-    @Override
-    public Void visitDeclared(DeclaredType mirror, Appendable a) {
-      try {
-        if (mirror.getEnclosingType().getKind() == TypeKind.NONE) {
-          appendShortened(a, asElement(mirror));
-        } else {
-          mirror.getEnclosingType().accept(this, a);
-          a.append('.').append(mirror.asElement().getSimpleName());
-        }
-        if (!mirror.getTypeArguments().isEmpty()) {
-          String prefix = "<";
-          for (TypeMirror typeArgument : mirror.getTypeArguments()) {
-            a.append(prefix);
-            typeArgument.accept(this, a);
-            prefix = ", ";
-          }
-          a.append(">");
-        }
-        return null;
-      } catch (IOException e) {
-        throw new IOExceptionWrapper(e);
-      }
-    }
-
-    @Override
-    public Void visitWildcard(WildcardType t, Appendable a) {
-      try {
-        a.append("?");
-        if (t.getSuperBound() != null) {
-          a.append(" super ");
-          t.getSuperBound().accept(this, a);
-        }
-        if (t.getExtendsBound() != null) {
-          a.append(" extends ");
-          t.getExtendsBound().accept(this, a);
-        }
-        return null;
-      } catch (IOException e) {
-        throw new IOExceptionWrapper(e);
-      }
-    }
-
-    @Override
-    protected Void defaultAction(TypeMirror mirror, Appendable a) {
-      try {
-        a.append(mirror.toString());
-        return null;
-      } catch (IOException e) {
-        throw new IOExceptionWrapper(e);
-      }
-    }
-  }
-
   /** A {@link TypeShortener} that never shortens types. */
-  class NeverShorten extends AbstractTypeShortener {
-
+  class NeverShorten implements TypeShortener {
     @Override
     public void appendShortened(Appendable a, QualifiedName type) throws IOException {
       a.append(type.getPackage());
@@ -128,21 +35,10 @@ interface TypeShortener {
         separator = ".";
       }
     }
-
-    @Override
-    public void appendShortened(Appendable a, TypeElement type) throws IOException {
-      a.append(type.toString());
-    }
-
-    @Override
-    public Optional<QualifiedName> lookup(String shortenedType) {
-      throw new UnsupportedOperationException();
-    }
   }
 
   /** A {@link TypeShortener} that always shortens types, even if that causes conflicts. */
-  class AlwaysShorten extends AbstractTypeShortener {
-
+  class AlwaysShorten implements TypeShortener {
     @Override
     public void appendShortened(Appendable a, QualifiedName type) throws IOException {
       String separator = "";
@@ -150,20 +46,6 @@ interface TypeShortener {
         a.append(separator).append(simpleName);
         separator = ".";
       }
-    }
-
-    @Override
-    public void appendShortened(Appendable a, TypeElement type) throws IOException {
-      if (type.getNestingKind().isNested()) {
-        appendShortened(a, (TypeElement) type.getEnclosingElement());
-        a.append('.');
-      }
-      a.append(type.getSimpleName());
-    }
-
-    @Override
-    public Optional<QualifiedName> lookup(String shortenedType) {
-      throw new UnsupportedOperationException();
     }
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
@@ -17,127 +17,22 @@ package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import static org.inferred.freebuilder.processor.util.ClassTypeImpl.STRING;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newNestedClass;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.junit.Assert.assertEquals;
 
-import com.google.common.reflect.TypeToken;
-
 import org.inferred.freebuilder.processor.util.ClassTypeImpl.ClassElementImpl;
-import org.inferred.freebuilder.processor.util.testing.Model;
-import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-
-import javax.lang.model.element.Name;
-import javax.lang.model.type.TypeMirror;
 
 @RunWith(JUnit4.class)
 public class ImportManagerTest {
 
-  // Models are expensive to create, so tests share a lazy singleton
-  private static Model model;
-
-  private static void createModel() {
-    if (model == null) {
-      model = Model.create();
-    }
-  }
-
-  @AfterClass
-  public static void destroySharedModel() {
-    if (model != null) {
-      model.destroy();
-      model = null;
-    }
-  }
-
   @Test
-  public void testTypeMirrorShortening() {
-    ImportManager manager = new ImportManager.Builder().build();
-    assertEquals("String", shorten(manager, STRING));
-    assertEquals("List", shorten(manager, newTopLevelClass("java.util.List")));
-    assertEquals("java.awt.List", shorten(manager, newTopLevelClass("java.awt.List")));
-    ClassTypeImpl mapType = newTopLevelClass("java.util.Map");
-    assertEquals("Map", shorten(manager, mapType));
-    assertEquals("Map.Entry", shorten(manager, newNestedClass(mapType.asElement(), "Entry")));
-    assertThat(manager.getClassImports())
-        .containsExactly("java.util.List", "java.util.Map").inOrder();
-  }
-
-  @Test
-  public void testTypeMirrorShortening_withConflicts() {
-    ClassElementImpl listType = newTopLevelClass("org.example.List").asElement();
-    ClassElementImpl stringType = newNestedClass(listType, "String").asElement();
-    ImportManager manager = new ImportManager.Builder()
-        .addImplicitImport(QualifiedName.of(listType))
-        .addImplicitImport(QualifiedName.of(stringType))
-        .build();
-    assertEquals("java.lang.String",
-        shorten(manager, ClassTypeImpl.STRING));
-    assertEquals("java.util.List", shorten(manager, newTopLevelClass("java.util.List")));
-    ClassTypeImpl awtListType = newTopLevelClass("java.awt.List");
-    assertEquals("java.awt.List", shorten(manager, awtListType));
-    assertEquals("java.awt.List.Sucks",
-        shorten(manager, newNestedClass(awtListType.asElement(), "Sucks")));
-    assertEquals("Map", shorten(manager, newTopLevelClass("java.util.Map")));
-    assertEquals("List", shorten(manager, listType.asType()));
-    assertEquals("List.String", shorten(manager, stringType.asType()));
-    assertThat(manager.getClassImports()).containsExactly("java.util.Map");
-  }
-
-  @Test
-  public void testTypeMirrorShortening_nestedGenericClass() {
-    createModel();
-    ImportManager manager = new ImportManager.Builder().build();
-    assertEquals("Map.Entry<String, List<Double>>",
-        shorten(manager, model.typeMirror(new TypeToken<Map.Entry<String, List<Double>>>() {})));
-    assertThat(manager.getClassImports())
-        .containsExactly("java.util.List", "java.util.Map").inOrder();
-  }
-
-  @Test
-  public void testTypeMirrorShortening_innerClassOnGenericType() {
-    createModel();
-    ImportManager manager = new ImportManager.Builder().build();
-    assertEquals("ImportManagerTest.OuterClass<List<String>>.InnerClass",
-        shorten(manager, model.typeMirror(
-            new TypeToken<ImportManagerTest.OuterClass<List<String>>.InnerClass>() {})));
-    assertThat(manager.getClassImports())
-        .containsExactly("java.util.List", this.getClass().getCanonicalName()).inOrder();
-  }
-
-  @Test
-  public void testTypeMirrorShortening_typeVariables() {
-    createModel();
-    ImportManager manager = new ImportManager.Builder().build();
-
-    // Type variables should be printed as name only, not e.g. "E extends Enum<E>"
-    assertEquals("Enum<E>", shorten(manager, model.typeElement(Enum.class).asType()));
-  }
-
-  @Test
-  public void testTypeMirrorShortening_wildcards() {
-    createModel();
-    ImportManager manager = new ImportManager.Builder().build();
-
-    assertEquals("Map<Name, ? extends Logger>",
-        shorten(manager, model.typeMirror(new TypeToken<Map<Name, ? extends Logger>>() {})));
-    assertThat(manager.getClassImports())
-        .containsExactly(
-            "java.util.Map", "java.util.logging.Logger", "javax.lang.model.element.Name")
-        .inOrder();
-  }
-
-  @Test
-  public void testTypeReferenceShortening() {
+  public void testNoConflicts() {
     ImportManager manager = new ImportManager.Builder().build();
     assertEquals("String", shorten(manager, QualifiedName.of("java.lang", "String")));
     assertEquals("List", shorten(manager, QualifiedName.of("java.util", "List")));
@@ -149,7 +44,7 @@ public class ImportManagerTest {
   }
 
   @Test
-  public void testTypeReferenceShortening_withConflicts() {
+  public void testConflicts() {
     ClassElementImpl listType = newTopLevelClass("org.example.List").asElement();
     ClassElementImpl stringType = newNestedClass(listType, "String").asElement();
     ImportManager manager = new ImportManager.Builder()
@@ -171,19 +66,5 @@ public class ImportManagerTest {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  private static String shorten(TypeShortener shortener, TypeMirror type) {
-    try {
-      StringBuilder result = new StringBuilder();
-      shortener.appendShortened(result, type);
-      return result.toString();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static class OuterClass<T> {
-    private class InnerClass { }
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/TypeMirrorShortenerTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/TypeMirrorShortenerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.inferred.freebuilder.processor.util;
+
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newNestedClass;
+import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
+import static org.junit.Assert.assertEquals;
+
+import static java.util.stream.Collectors.joining;
+
+import com.google.common.reflect.TypeToken;
+
+import org.inferred.freebuilder.processor.util.testing.Model;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import javax.lang.model.element.Name;
+import javax.lang.model.type.TypeMirror;
+
+@RunWith(JUnit4.class)
+public class TypeMirrorShortenerTest {
+
+  private static class FakeShortener implements TypeShortener {
+    @Override
+    public void appendShortened(Appendable a, QualifiedName type) throws IOException {
+      a.append("{{").append(type.getSimpleNames().stream().collect(joining("."))).append("}}");
+    }
+  }
+
+  // Models are expensive to create, so tests share a lazy singleton
+  private static Model model;
+
+  private static void createModel() {
+    if (model == null) {
+      model = Model.create();
+    }
+  }
+
+  @AfterClass
+  public static void destroySharedModel() {
+    if (model != null) {
+      model.destroy();
+      model = null;
+    }
+  }
+
+  @Test
+  public void testTopLevelType() {
+    assertEquals("{{List}}", shorten(newTopLevelClass("java.util.List")));
+  }
+
+  @Test
+  public void testNestedType() {
+    ClassTypeImpl mapType = newTopLevelClass("java.util.Map");
+    assertEquals("{{Map.Entry}}", shorten(newNestedClass(mapType.asElement(), "Entry")));
+  }
+
+  @Test
+  public void testNestedGenericClass() {
+    createModel();
+    assertEquals(
+        "{{Map.Entry}}<{{String}}, {{List}}<{{Double}}>>",
+        shorten(model.typeMirror(new TypeToken<Map.Entry<String, List<Double>>>() {})));
+  }
+
+  @Test
+  public void testInnerClassOnGenericType() {
+    createModel();
+    assertEquals("{{TypeMirrorShortenerTest.OuterClass}}<{{List}}<{{String}}>>.InnerClass",
+        shorten(model.typeMirror(
+            new TypeToken<TypeMirrorShortenerTest.OuterClass<List<String>>.InnerClass>() {})));
+  }
+
+  @Test
+  public void testTypeVariables() {
+    createModel();
+
+    // Type variables should be printed as name only, not e.g. "E extends Enum<E>"
+    assertEquals("{{Enum}}<E>", shorten(model.typeElement(Enum.class).asType()));
+  }
+
+  @Test
+  public void testWildcards() {
+    createModel();
+
+    assertEquals("{{Map}}<{{Name}}, ? extends {{Logger}}>",
+        shorten(model.typeMirror(new TypeToken<Map<Name, ? extends Logger>>() {})));
+  }
+
+  private static String shorten(TypeMirror type) {
+    try {
+      StringBuilder result = new StringBuilder();
+      new TypeMirrorShortener(result).appendShortened(new FakeShortener(), type);
+      return result.toString();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static class OuterClass<T> {
+    private class InnerClass { }
+
+    @SuppressWarnings("unused")
+    T field;
+  }
+}


### PR DESCRIPTION
Remove all but one method from TypeShortener using the following observations:

 - The TypeElement-accepting method was only used in one place, which can use the QualifiedName-accepting method instead
 - The lookup method can be confined to specific subclasses
 - The TypeMirror-accepting method has only one implementation (in AbstractTypeShortener) and only one caller

Replacing inheritance with composition, we can put the TypeMirror-accepting method into its own class, TypeMirrorShortener, leaving TypeShortener with a single method, each of which is implemented differently on all subclasses.