### PR TITLE
Require visible nested types in Datatype

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -187,6 +187,7 @@ public abstract class Datatype {
       checkState(datatype.getPropertyEnum().getQualifiedName().getEnclosingType()
               .equals(generatedBuilder),
           "%s not a nested class of %s", datatype.getPropertyEnum(), generatedBuilder);
+      checkState(!datatype.getVisibleNestedTypes().isEmpty(), "No nested types provided");
       return datatype;
     }
   }

--- a/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/DefaultedPropertiesSourceTest.java
@@ -1339,6 +1339,11 @@ public class DefaultedPropertiesSourceTest {
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .addVisibleNestedTypes(
+            generatedBuilder,
+            generatedBuilder.nestedType("Partial"),
+            generatedBuilder.nestedType("Property"),
+            generatedBuilder.nestedType("Value"))
         .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")

--- a/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GenericTypeSourceTest.java
@@ -885,6 +885,11 @@ public class GenericTypeSourceTest {
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters(paramA, paramB))
         .setValueType(generatedBuilder.nestedType("Value").withParameters(paramA, paramB))
+        .addVisibleNestedTypes(
+            generatedBuilder,
+            generatedBuilder.nestedType("Partial"),
+            generatedBuilder.nestedType("Property"),
+            generatedBuilder.nestedType("Value"))
         .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")

--- a/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GuavaOptionalSourceTest.java
@@ -1342,6 +1342,11 @@ public class GuavaOptionalSourceTest {
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .addVisibleNestedTypes(
+            generatedBuilder,
+            generatedBuilder.nestedType("Partial"),
+            generatedBuilder.nestedType("Property"),
+            generatedBuilder.nestedType("Value"))
         .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")

--- a/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/JavaUtilOptionalSourceTest.java
@@ -1026,6 +1026,11 @@ public class JavaUtilOptionalSourceTest {
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .addVisibleNestedTypes(
+            generatedBuilder,
+            generatedBuilder.nestedType("Partial"),
+            generatedBuilder.nestedType("Property"),
+            generatedBuilder.nestedType("Value"))
         .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")

--- a/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ListSourceTest.java
@@ -2025,6 +2025,11 @@ public class ListSourceTest {
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .addVisibleNestedTypes(
+            generatedBuilder,
+            generatedBuilder.nestedType("Partial"),
+            generatedBuilder.nestedType("Property"),
+            generatedBuilder.nestedType("Value"))
         .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")

--- a/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/MapSourceTest.java
@@ -1105,6 +1105,11 @@ public class MapSourceTest {
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .addVisibleNestedTypes(
+            generatedBuilder,
+            generatedBuilder.nestedType("Partial"),
+            generatedBuilder.nestedType("Property"),
+            generatedBuilder.nestedType("Value"))
         .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")

--- a/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NullableSourceTest.java
@@ -994,6 +994,11 @@ public class NullableSourceTest {
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .addVisibleNestedTypes(
+            generatedBuilder,
+            generatedBuilder.nestedType("Partial"),
+            generatedBuilder.nestedType("Property"),
+            generatedBuilder.nestedType("Value"))
         .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")

--- a/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/RequiredPropertiesSourceTest.java
@@ -1701,6 +1701,11 @@ public class RequiredPropertiesSourceTest {
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .addVisibleNestedTypes(
+            generatedBuilder,
+            generatedBuilder.nestedType("Partial"),
+            generatedBuilder.nestedType("Property"),
+            generatedBuilder.nestedType("Value"))
         .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")

--- a/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/SetSourceTest.java
@@ -1502,6 +1502,11 @@ public class SetSourceTest {
         .setPropertyEnum(generatedBuilder.nestedType("Property").withParameters())
         .setType(person.withParameters())
         .setValueType(generatedBuilder.nestedType("Value").withParameters())
+        .addVisibleNestedTypes(
+            generatedBuilder,
+            generatedBuilder.nestedType("Partial"),
+            generatedBuilder.nestedType("Property"),
+            generatedBuilder.nestedType("Value"))
         .build();
     Property name = new Property.Builder()
         .setAllCapsName("NAME")


### PR DESCRIPTION
Our source tests were incorrectly missing visible nested type information. Datatype will now throw an IllegalStateException if this property is empty, so we won't make this mistake again.