### PR TITLE
Move special-casing of java.lang from ImportManager to ScopeHandler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
   testCompile javassist
   testCompile junit
   testCompile mockito
+  testCompile reflections
   testCompile truth
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,5 @@ javassist=org.javassist:javassist:3.19.0-GA
 jsr305=com.google.code.findbugs:jsr305:3.0.0
 junit=junit:junit:4.12
 mockito=org.mockito:mockito-core:1.10.8
+reflections=org.reflections:reflections:0.9.11
 truth=com.google.truth:truth:0.24

--- a/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
@@ -38,9 +38,6 @@ import java.util.TreeSet;
  */
 class ImportManager {
 
-  private static final String JAVA_LANG_PACKAGE = "java.lang";
-  private static final String PACKAGE_PREFIX = "package ";
-
   private final SetMultimap<String, QualifiedName> visibleSimpleNames = HashMultimap.create();
   private final ImmutableSet<String> implicitImports = ImmutableSet.of();
   private final Set<String> explicitImports = new TreeSet<String>();
@@ -73,17 +70,12 @@ class ImportManager {
 
   private void appendPackageForTopLevelClass(Appendable a, String pkg, CharSequence name)
       throws IOException {
-    if (pkg.startsWith(PACKAGE_PREFIX)) {
-      pkg = pkg.substring(PACKAGE_PREFIX.length());
-    }
     pkg = unshadedName(pkg);
     String qualifiedName = pkg + "." + name;
     if (implicitImports.contains(qualifiedName) || explicitImports.contains(qualifiedName)) {
       // Append nothing
     } else if (visibleSimpleNames.containsKey(name.toString())) {
       a.append(pkg).append(".");
-    } else if (pkg.equals(JAVA_LANG_PACKAGE)) {
-      // Append nothing
     } else {
       visibleSimpleNames.put(name.toString(), QualifiedName.of(pkg, name.toString()));
       explicitImports.add(qualifiedName);

--- a/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
@@ -1317,6 +1317,29 @@ public class ProcessorTest {
         .withNoWarnings();
   }
 
+  @Test
+  public void testNameConflictWithJavaLangType() {
+    // The implicit import of java.lang in every scope can be hidden by an explicit import of
+    // a type with the same name. This sounds crazy but even com.sun is occasionally guilty of
+    // reusing a tempting name like "Override" — and accidentally importing such a type is just
+    // as chaotic as you might expect.
+    behaviorTester.with(new Processor(features))
+        .with(new SourceBuilder()
+            .addLine("package com.example.p;")
+            .addLine("public interface Override { }")
+            .build())
+        .with(new SourceBuilder()
+            .addLine("package com.example.r;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface A {")
+            .addLine("  com.example.p.Override override();")
+            .addLine("  class Builder extends A_Builder {}")
+            .addLine("}")
+            .build())
+        .compiles()
+        .withNoWarnings();
+  }
+
   private static TestBuilder testBuilder() {
     return new TestBuilder()
         .addImport("com.example.DataType");

--- a/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
@@ -31,7 +31,6 @@ public class ImportManagerTest {
   @Test
   public void testImports() {
     ImportManager manager = new ImportManager();
-    assertEquals("String", shorten(manager, QualifiedName.of("java.lang", "String")));
     assertEquals("List", shorten(manager, QualifiedName.of("java.util", "List")));
     assertEquals("java.awt.List", shorten(manager, QualifiedName.of("java.awt", "List")));
     assertEquals("Map", shorten(manager, QualifiedName.of("java.util", "Map")));

--- a/src/test/java/org/inferred/freebuilder/processor/util/ScopeHandlerTests.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ScopeHandlerTests.java
@@ -40,6 +40,12 @@ public class ScopeHandlerTests {
   }
 
   @Test
+  public void typeInJavaLangPackageIsInScope() {
+    ScopeState result = handler.visibilityIn("java.util", QualifiedName.of(Integer.class));
+    assertThat(result).isEqualTo(ScopeState.IN_SCOPE);
+  }
+
+  @Test
   public void generatedTypeInThisPackageIsInScope() {
     QualifiedName myType = QualifiedName.of("com.example", "MyType");
     handler.declareGeneratedType(Visibility.PACKAGE, myType, ImmutableSet.of());


### PR DESCRIPTION
java.lang is treated as a superscope of all other packages, and hence never needs to be imported, but importing a type of the same name will hide the java.lang equivalent. ScopeHandler is best placed to ensure we never accidentally do this, since it already contains all the reflective code we need to enumerate the top-level types in java.lang.