### PR TITLE
Unshade packages in QualifiedName rather than ImportManager

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
@@ -17,8 +17,6 @@ package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 
-import static org.inferred.freebuilder.processor.util.Shading.unshadedName;
-
 import com.google.common.base.Optional;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -70,7 +68,6 @@ class ImportManager {
 
   private void appendPackageForTopLevelClass(Appendable a, String pkg, CharSequence name)
       throws IOException {
-    pkg = unshadedName(pkg);
     String qualifiedName = pkg + "." + name;
     if (implicitImports.contains(qualifiedName) || explicitImports.contains(qualifiedName)) {
       // Append nothing

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -18,6 +18,8 @@ package org.inferred.freebuilder.processor.util;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getLast;
 
+import static org.inferred.freebuilder.processor.util.Shading.unshadedName;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -50,11 +52,12 @@ public class QualifiedName extends ValueType {
     Preconditions.checkNotNull(!packageName.isEmpty());
     Preconditions.checkArgument(!topLevelType.isEmpty());
     return new QualifiedName(
-        packageName, ImmutableList.<String>builder().add(topLevelType).add(nestedTypes).build());
+        unshadedName(packageName),  // shadowJar modifies string literals; unshade them here
+        ImmutableList.<String>builder().add(topLevelType).add(nestedTypes).build());
   }
 
   /**
-   * Returns a {@link QualifiedName} for {@code cls}.
+   * Returns a {@link QualifiedName} for {@code cls}, unshading if necessary.
    */
   public static QualifiedName of(Class<?> cls) {
     if (cls.getEnclosingClass() != null) {


### PR DESCRIPTION
I can't think of any good reason why we would want shading to persist in QualifiedName instances!