### PR TITLE
Refactor ImportManager

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ImportManager.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.Maps.newLinkedHashMap;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSortedSet;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,18 +44,6 @@ class ImportManager {
       result.add(type.toString());
     }
     return result.build();
-  }
-
-  public void appendShortened(Appendable a, QualifiedName type) throws IOException {
-    String pkg = type.getPackage();
-    if (!add(QualifiedName.of(pkg, type.getSimpleNames().get(0)))) {
-      a.append(pkg).append(".");
-    }
-    String prefix = "";
-    for (String simpleName : type.getSimpleNames()) {
-      a.append(prefix).append(simpleName);
-      prefix = ".";
-    }
   }
 
   /**

--- a/src/main/java/org/inferred/freebuilder/processor/util/ScopeAwareTypeShortener.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ScopeAwareTypeShortener.java
@@ -38,12 +38,12 @@ class ScopeAwareTypeShortener implements TypeShortener {
         break;
 
       case IMPORTABLE:
-        if (type.isTopLevel()) {
-          importManager.appendShortened(a, type);
-          return;
+        if (!type.isTopLevel()) {
+          appendShortened(a, type.getEnclosingType());
+          a.append('.');
+        } else if (!importManager.add(type)) {
+          a.append(type.getPackage()).append(".");
         }
-        appendShortened(a, type.getEnclosingType());
-        a.append('.');
         break;
 
       case HIDDEN:

--- a/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
@@ -35,8 +35,17 @@ public class ImportManagerTest {
     assertEquals("java.awt.List", shorten(manager, QualifiedName.of("java.awt", "List")));
     assertEquals("Map", shorten(manager, QualifiedName.of("java.util", "Map")));
     assertEquals("Map.Entry", shorten(manager, QualifiedName.of("java.util", "Map", "Entry")));
+    assertThat(manager.getClassImports()).containsExactly("java.util.List", "java.util.Map");
+  }
+
+  @Test
+  public void testImportsAreSorted() {
+    ImportManager manager = new ImportManager();
+    shorten(manager, QualifiedName.of("java.util", "Map"));
+    shorten(manager, QualifiedName.of("java.util", "List"));
+    shorten(manager, QualifiedName.of("java.util", "Collection"));
     assertThat(manager.getClassImports())
-        .containsExactly("java.util.List", "java.util.Map").inOrder();
+        .containsExactly("java.util.Collection", "java.util.List", "java.util.Map").inOrder();
   }
 
   private static String shorten(ImportManager shortener, QualifiedName type) {

--- a/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
@@ -17,7 +17,6 @@ package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -25,30 +24,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.io.IOException;
-
 @RunWith(JUnit4.class)
 public class ImportManagerTest {
-
-  @Test
-  public void testImports() {
-    ImportManager manager = new ImportManager();
-    assertEquals("List", shorten(manager, QualifiedName.of("java.util", "List")));
-    assertEquals("java.awt.List", shorten(manager, QualifiedName.of("java.awt", "List")));
-    assertEquals("Map", shorten(manager, QualifiedName.of("java.util", "Map")));
-    assertEquals("Map.Entry", shorten(manager, QualifiedName.of("java.util", "Map", "Entry")));
-    assertThat(manager.getClassImports()).containsExactly("java.util.List", "java.util.Map");
-  }
-
-  @Test
-  public void testImportsAreSorted() {
-    ImportManager manager = new ImportManager();
-    shorten(manager, QualifiedName.of("java.util", "Map"));
-    shorten(manager, QualifiedName.of("java.util", "List"));
-    shorten(manager, QualifiedName.of("java.util", "Collection"));
-    assertThat(manager.getClassImports())
-        .containsExactly("java.util.Collection", "java.util.List", "java.util.Map").inOrder();
-  }
 
   @Test
   public void testAdd() {
@@ -73,15 +50,5 @@ public class ImportManagerTest {
     assertThat(manager.lookup("List")).hasValue(list1);
     manager.add(list2);
     assertThat(manager.lookup("List")).hasValue(list1);
-  }
-
-  private static String shorten(ImportManager shortener, QualifiedName type) {
-    try {
-      StringBuilder result = new StringBuilder();
-      shortener.appendShortened(result, type);
-      return result.toString();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ImportManagerTest.java
@@ -18,6 +18,8 @@ package org.inferred.freebuilder.processor.util;
 import static com.google.common.truth.Truth.assertThat;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,6 +48,31 @@ public class ImportManagerTest {
     shorten(manager, QualifiedName.of("java.util", "Collection"));
     assertThat(manager.getClassImports())
         .containsExactly("java.util.Collection", "java.util.List", "java.util.Map").inOrder();
+  }
+
+  @Test
+  public void testAdd() {
+    ImportManager manager = new ImportManager();
+    assertTrue(manager.add(QualifiedName.of("java.util", "List")));
+    assertFalse(manager.add(QualifiedName.of("java.awt", "List")));
+    assertTrue(manager.add(QualifiedName.of("java.util", "Map")));
+    assertTrue(manager.add(QualifiedName.of("java.util", "Map", "Entry")));
+    assertTrue(manager.add(QualifiedName.of("java.util", "List")));
+    assertThat(manager.getClassImports()).containsExactly(
+        "java.util.List", "java.util.Map", "java.util.Map.Entry");
+  }
+
+  @Test
+  public void testLookup() {
+    QualifiedName list1 = QualifiedName.of("java.util", "List");
+    QualifiedName list2 = QualifiedName.of("java.awt", "List");
+
+    ImportManager manager = new ImportManager();
+    assertThat(manager.lookup("List")).isAbsent();
+    manager.add(list1);
+    assertThat(manager.lookup("List")).hasValue(list1);
+    manager.add(list2);
+    assertThat(manager.lookup("List")).hasValue(list1);
   }
 
   private static String shorten(ImportManager shortener, QualifiedName type) {


### PR DESCRIPTION
Based on the following observations:

 * visibleSimpleNames no longer needs to be a multimap.
 * implicitImports is totally unused (missed in previous refactoring).
 * explicitImports can be constructed on-demand for the same overall cost.
 * appendShortened is doing two jobs: managing the import set and appending to an Appendable.
 * ScopeAwareTypeShortener is having to special-case appendShortened with an early return statement.

Perform the following changes:

 * Store a single field, a Map called imports
 * Generate the sorted set of class imports on demand
 * Pull the non-Appendable code of appendShortened out into a new `add` method
 * Inline the remaining appendShortened code in ScopeAwareTypeShortener
