### PR TITLE
Stop using PackageElement.getEnclosedElements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
   testCompile javassist
   testCompile junit
   testCompile mockito
-  testCompile reflections
   testCompile truth
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,4 @@ javassist=org.javassist:javassist:3.19.0-GA
 jsr305=com.google.code.findbugs:jsr305:3.0.0
 junit=junit:junit:4.12
 mockito=org.mockito:mockito-core:1.10.8
-reflections=org.reflections:reflections:0.9.11
 truth=com.google.truth:truth:0.24

--- a/src/test/java/org/inferred/freebuilder/processor/GeneratedTypeSubject.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GeneratedTypeSubject.java
@@ -5,11 +5,9 @@ import static com.google.common.truth.Truth.THROW_ASSERTION_ERROR;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newNestedClass;
 import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 import com.google.common.truth.FailureStrategy;
 import com.google.common.truth.Subject;
@@ -23,26 +21,15 @@ import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
 import org.junit.ComparisonFailure;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
 
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 
 class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> {
-
-  private static volatile Reflections runtimeLib;
 
   public static GeneratedTypeSubject assertThat(GeneratedType subject) {
     return new GeneratedTypeSubject(THROW_ASSERTION_ERROR, subject);
@@ -91,10 +78,6 @@ class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> 
       CharSequence name = invocation.getArgumentAt(0, CharSequence.class);
       return mockTypeElement(name, generatedType, visibleTypes);
     });
-    when(env.getElementUtils().getPackageElement(any())).thenAnswer(invocation -> {
-      CharSequence pkg = invocation.getArgumentAt(0, CharSequence.class);
-      return mockPackageElement(pkg, generatedType, visibleTypes);
-    });
     return env;
   }
 
@@ -102,16 +85,21 @@ class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> 
       CharSequence name,
       QualifiedName generatedType,
       Set<QualifiedName> visibleTypes) {
-    for (QualifiedName visibleType : visibleTypes) {
-      if (visibleType.toString().contentEquals(name)) {
-        if (visibleType.equals(generatedType) || visibleType.isNestedIn(generatedType)) {
-          return null;
-        } else {
-          return classType(visibleType);
+    try {
+      Class<?> cls = ClassLoader.getSystemClassLoader().loadClass(name.toString());
+      return classType(QualifiedName.of(cls));
+    } catch (ClassNotFoundException e) {
+      for (QualifiedName visibleType : visibleTypes) {
+        if (visibleType.toString().contentEquals(name)) {
+          if (visibleType.equals(generatedType) || visibleType.isNestedIn(generatedType)) {
+            return null;
+          } else {
+            return classType(visibleType);
+          }
         }
       }
+      return null;
     }
-    return null;
   }
 
   private static TypeElement classType(QualifiedName visibleType) {
@@ -121,47 +109,5 @@ class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> 
       TypeElement parent = classType(visibleType.enclosingType());
       return newNestedClass(parent, visibleType.getSimpleName()).asElement();
     }
-  }
-
-  private static PackageElement mockPackageElement(
-      CharSequence name,
-      QualifiedName generatedType,
-      Set<QualifiedName> visibleTypes) {
-    List<TypeElement> topLevelTypes = new ArrayList<>();
-    topLevelTypes.addAll(runtimeLibTypeElements(name.toString()));
-    topLevelTypes.addAll(generatedTypeElements(name, generatedType, visibleTypes));
-
-    PackageElement pkgElement = Mockito.mock(PackageElement.class, new ReturnsDeepStubs());
-    doReturn(topLevelTypes).when(pkgElement).getEnclosedElements();
-    return pkgElement;
-  }
-
-  private static List<TypeElement> runtimeLibTypeElements(String pkg) {
-    try {
-      if (runtimeLib == null) {
-        URL url = new File(System.getProperty("java.home"), "lib/rt.jar").toURI().toURL();
-        runtimeLib = new Reflections(url, new SubTypesScanner(false));
-      }
-      return runtimeLib.getAllTypes()
-          .stream()
-          .filter(t -> t.startsWith(pkg) && !t.substring(pkg.length() + 1).contains("."))
-          .map(type -> newTopLevelClass(type.toString()).asElement())
-          .collect(toList());
-    } catch (MalformedURLException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static List<TypeElement> generatedTypeElements(
-      CharSequence name,
-      QualifiedName generatedType,
-      Set<QualifiedName> visibleTypes) {
-    List<TypeElement> topLevelTypes = visibleTypes.stream()
-        .filter(type -> type.getPackage().contentEquals(name))
-        .filter(QualifiedName::isTopLevel)
-        .filter(Predicate.isEqual(generatedType).negate())
-        .map(type -> newTopLevelClass(type.toString()).asElement())
-        .collect(toList());
-    return topLevelTypes;
   }
 }


### PR DESCRIPTION
Turns out this doesn't work reliably in Eclipse's incremental compilation. Use `Elements.getTypeElement` on a name-by-name basis instead.