### PR TITLE
Fix a smattering of warnings

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/Scope.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Scope.java
@@ -31,6 +31,7 @@ public abstract class Scope {
     FILE, METHOD;
   }
 
+  @SuppressWarnings("unused")
   public interface Element<T> {
     Level level();
   }

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/SingleBehaviorTester.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/SingleBehaviorTester.java
@@ -17,13 +17,16 @@ package org.inferred.freebuilder.processor.util.testing;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.not;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.util.concurrent.Uninterruptibles.joinUninterruptibly;
-import static java.util.stream.Collectors.toSet;
-import static javax.tools.JavaFileObject.Kind.CLASS;
+
 import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
 import static org.inferred.freebuilder.processor.util.feature.SourceLevel.SOURCE_LEVEL;
 
-import com.google.common.base.Throwables;
+import static java.util.stream.Collectors.toSet;
+
+import static javax.tools.JavaFileObject.Kind.CLASS;
+
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -306,7 +309,7 @@ class SingleBehaviorTester implements BehaviorTester {
       if (exceptions.size() == 1) {
         // If there was a single error on the same thread, propagate it directly.
         // This makes testing for expected errors easier.
-        Throwables.propagateIfPossible(exceptions.get(0));
+        throwIfUnchecked(exceptions.get(0));
       }
     }
     if (!exceptions.isEmpty()) {

--- a/src/test/java/org/inferred/freebuilder/processor/util/testing/SourceBuilder.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/testing/SourceBuilder.java
@@ -18,8 +18,6 @@ package org.inferred.freebuilder.processor.util.testing;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Throwables;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
@@ -94,7 +92,7 @@ public class SourceBuilder {
     try {
       return new URI("mem:///" + typeName.replaceAll("\\.", "/") + ".java");
     } catch (URISyntaxException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
Suppress an unused warning on Scope.Element's T param, and stop using two deprecated methods.