### PR TITLE
Don't import primitive types

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/ScopeAwareTypeShortener.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ScopeAwareTypeShortener.java
@@ -93,7 +93,9 @@ class ScopeAwareTypeShortener implements TypeShortener {
   }
 
   private ScopeState visibilityInScope(QualifiedName type) {
-    if (scope != null) {
+    if (type.getPackage().isEmpty()) {
+      return ScopeState.IN_SCOPE;
+    } else if (scope != null) {
       return handler.visibilityIn(scope, type);
     } else {
       return handler.visibilityIn(pkg, type);


### PR DESCRIPTION
We only actually do this in a test, but it's still not a good idea