### PR TITLE
Simplify identifier scope management

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilder.java
@@ -83,7 +83,7 @@ public class CompilationUnitBuilder
   public void onMethodBlockStart(String methodName, Set<String> paramNames) {
     Scope methodScope = new Scope.MethodScope(getLast(scopes));
     for (String paramName : paramNames) {
-      methodScope.add(new VariableName(paramName));
+      methodScope.putIfAbsent(new IdKey(paramName), methodScope);
     }
     typeShorteners.add(getLast(typeShorteners));
     scopes.add(methodScope);

--- a/src/main/java/org/inferred/freebuilder/processor/util/FieldAccess.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/FieldAccess.java
@@ -15,9 +15,7 @@
  */
 package org.inferred.freebuilder.processor.util;
 
-import org.inferred.freebuilder.processor.util.Scope.Level;
-
-public class FieldAccess extends ValueType implements Excerpt, Scope.Element<FieldAccess> {
+public class FieldAccess extends ValueType implements Excerpt {
 
   private final String fieldName;
 
@@ -26,17 +24,10 @@ public class FieldAccess extends ValueType implements Excerpt, Scope.Element<Fie
   }
 
   @Override
-  public Level level() {
-    return Level.METHOD;
-  }
-
-  @Override
   public void addTo(SourceBuilder source) {
-    if (source.scope().contains(new VariableName(fieldName))) {
+    Object idOwner = source.scope().putIfAbsent(new IdKey(fieldName), this);
+    if (idOwner != null && !idOwner.equals(this)) {
       source.add("this.");
-    } else {
-      // Prevent a new variable being declared and obscuring this field access
-      source.scope().add(this);
     }
     source.add(fieldName);
   }

--- a/src/main/java/org/inferred/freebuilder/processor/util/IdKey.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/IdKey.java
@@ -17,11 +17,14 @@ package org.inferred.freebuilder.processor.util;
 
 import org.inferred.freebuilder.processor.util.Scope.Level;
 
-class VariableName extends ValueType implements Scope.Element<VariableName> {
+/**
+ * Maps Java identifiers to their usage (e.g. a parameter, a variable) in the current method scope.
+ */
+class IdKey extends ValueType implements Scope.Element<Object> {
 
   private final String name;
 
-  VariableName(String name) {
+  IdKey(String name) {
     this.name = name;
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/Scope.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Scope.java
@@ -86,10 +86,6 @@ public abstract class Scope {
     return keys.build();
   }
 
-  public <T extends Element<T>> void add(T element) {
-    putIfAbsent(element, element);
-  }
-
   public <T> T putIfAbsent(Element<T> element, T value) {
     requireNonNull(element);
     requireNonNull(value);


### PR DESCRIPTION
Instead of having FieldAccess and Variable be mutually aware of each other, make a single IdKey type responsible for reserving usage of identifiers in method scope. The value stored with the key is the owner of the identifier (the Variable, the FieldAccess, or the MethodScope itself for parameters).