### PR TITLE
Clean the Scope API

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/Declarations.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Declarations.java
@@ -13,7 +13,7 @@ class Declarations {
   private static final String UPCAST_COMMENT =
       "// Upcast to access private fields; otherwise, oddly, we get an access violation.";
 
-  private enum Declaration implements Scope.Element<Variable> {
+  private enum Declaration implements Scope.Key<Variable> {
     UPCAST, FRESH_BUILDER;
 
     @Override

--- a/src/main/java/org/inferred/freebuilder/processor/util/IdKey.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/IdKey.java
@@ -20,7 +20,7 @@ import org.inferred.freebuilder.processor.util.Scope.Level;
 /**
  * Maps Java identifiers to their usage (e.g. a parameter, a variable) in the current method scope.
  */
-class IdKey extends ValueType implements Scope.Element<Object> {
+class IdKey extends ValueType implements Scope.Key<Object> {
 
   private final String name;
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/LazyName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/LazyName.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-public class LazyName extends ValueType implements Excerpt, Scope.Element<LazyName.Declaration> {
+public class LazyName extends ValueType implements Excerpt, Scope.Key<LazyName.Declaration> {
 
   /**
    * Finds all lazily-declared classes and methods and adds their definitions to the source.
@@ -85,7 +85,7 @@ public class LazyName extends ValueType implements Excerpt, Scope.Element<LazyNa
    * A Declaration maps a unique static class name to its static excerpt in a scope.
    */
   static class Declaration extends ValueType
-      implements Comparable<Declaration>, Scope.Element<LazyName> {
+      implements Comparable<Declaration>, Scope.Key<LazyName> {
 
     private final String name;
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/Scope.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Scope.java
@@ -36,7 +36,7 @@ public abstract class Scope {
     Level level();
   }
 
-  private final Map<Key<?>, Object> elements = new LinkedHashMap<>();
+  private final Map<Key<?>, Object> entries = new LinkedHashMap<>();
   private final Scope parent;
   private final Level level;
 
@@ -51,7 +51,7 @@ public abstract class Scope {
 
   public <V> V get(Key<V> key) {
     @SuppressWarnings("unchecked")
-    V value = (V) elements.get(key);
+    V value = (V) entries.get(key);
     if (value != null) {
       return value;
     } else if (parent != null) {
@@ -67,7 +67,7 @@ public abstract class Scope {
       return value;
     } else if (level == key.level()) {
       value = supplier.get();
-      elements.put(key, value);
+      entries.put(key, value);
       return value;
     } else if (parent != null) {
       return parent.computeIfAbsent(key, supplier);
@@ -82,7 +82,7 @@ public abstract class Scope {
     if (parent != null) {
       keys.addAll(parent.keysOfType(keyType));
     }
-    keys.addAll(FluentIterable.from(elements.keySet()).filter(keyType).toSet());
+    keys.addAll(FluentIterable.from(entries.keySet()).filter(keyType).toSet());
     return keys.build();
   }
 
@@ -91,9 +91,9 @@ public abstract class Scope {
     requireNonNull(value);
     if (level == key.level()) {
       @SuppressWarnings("unchecked")
-      V existingValue = (V) elements.get(key);
+      V existingValue = (V) entries.get(key);
       if (existingValue == null) {
-        elements.put(key, value);
+        entries.put(key, value);
       }
       return existingValue;
     } else if (parent != null) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/Variable.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Variable.java
@@ -17,7 +17,7 @@ package org.inferred.freebuilder.processor.util;
 
 import org.inferred.freebuilder.processor.util.Scope.Level;
 
-public class Variable extends ValueType implements Excerpt, Scope.Element<IdKey> {
+public class Variable extends ValueType implements Excerpt, Scope.Key<IdKey> {
 
   private final String preferredName;
 

--- a/src/test/java/org/inferred/freebuilder/processor/util/ScopeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ScopeTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 public class ScopeTest {
 
-  private static class FileElement extends ValueType implements Scope.Element<String> {
+  private static class FileElement extends ValueType implements Scope.Key<String> {
 
     private final String name;
 
@@ -45,7 +45,7 @@ public class ScopeTest {
     }
   }
 
-  private static class MethodElement extends ValueType implements Scope.Element<Integer> {
+  private static class MethodElement extends ValueType implements Scope.Key<Integer> {
 
     private final String name;
 


### PR DESCRIPTION
While it started out as a set, Scope is now a hierarchical map. Clarify this with better naming (e.g. `Scope.Element<E>` is now `Scope.Key<V>`) and with JavaDoc. Also, defend against illegal recursion in computeIfAbsent.