### PR TITLE
Parameterize first argument of PreconditionExcerpts methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ compileTestJava {
 }
 
 dependencies {
-  compile commonsLang3
   compile googleJavaFormat
   compile guava
   compileOnly autoService
@@ -132,11 +131,6 @@ shadowJar {
   include 'com/google/googlejavaformat/**'
   include 'org/openjdk/**'
   exclude 'org/openjdk/tools/javadoc/**'
-
-  // Include StringEscapeUtils from Apache Commons' lang3
-  // (Used to correctly quote Java string literals)
-  include 'org/apache/commons/lang3/StringEscapeUtils.class'
-  include 'org/apache/commons/lang3/text/translate/CharSequenceTranslator.class'
 }
 tasks.shadowJar.shouldRunAfter tasks.test
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 autoService=com.google.auto.service:auto-service:1.0-rc2
-commonsLang3=org.apache.commons:commons-lang3:3.4
 googleJavaFormat=com.google.googlejavaformat:google-java-format:1.2
 guava=com.google.guava:guava:16.0
 guavaTestlib=com.google.guava:guava-testlib:17.0

--- a/src/main/java/org/inferred/freebuilder/processor/DefaultProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/DefaultProperty.java
@@ -161,9 +161,12 @@ class DefaultProperty extends PropertyCodeGenerator {
     code.addLine(" */")
         .addLine("public %s %s() {", property.getType(), getter(property));
     if (!hasDefault) {
-      Excerpt propertyIsSet = Excerpts.add("!%s.contains(%s.%s)",
-              UNSET_PROPERTIES, datatype.getPropertyEnum(), property.getAllCapsName());
-      code.add(PreconditionExcerpts.checkState(propertyIsSet, property.getName() + " not set"));
+      code.add(PreconditionExcerpts.checkState(
+          "!%s.contains(%s.%s)",
+          property.getName() + " not set",
+          UNSET_PROPERTIES,
+          datatype.getPropertyEnum(),
+          property.getAllCapsName()));
     }
     code.addLine("  return %s;", property.getField())
         .addLine("}");

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
@@ -171,7 +171,7 @@ class GeneratedBuilder extends GeneratedType {
         .addLine("public %s build() {", datatype.getType());
     if (hasRequiredProperties) {
       code.add(PreconditionExcerpts.checkState(
-          Excerpts.add("%s.isEmpty()", UNSET_PROPERTIES), "Not set: %s", UNSET_PROPERTIES));
+          "%1$s.isEmpty()", "Not set: %1$s", UNSET_PROPERTIES));
     }
     code.addLine("  return %s(this);", datatype.getValueType().constructor())
         .addLine("}");

--- a/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
+++ b/src/main/java/org/inferred/freebuilder/processor/SortedSetProperty.java
@@ -36,7 +36,6 @@ import com.google.common.collect.ImmutableSortedSet;
 
 import org.inferred.freebuilder.processor.excerpt.CheckedNavigableSet;
 import org.inferred.freebuilder.processor.util.Excerpt;
-import org.inferred.freebuilder.processor.util.Excerpts;
 import org.inferred.freebuilder.processor.util.FunctionalType;
 import org.inferred.freebuilder.processor.util.PreconditionExcerpts;
 import org.inferred.freebuilder.processor.util.SourceBuilder;
@@ -192,9 +191,7 @@ class SortedSetProperty extends PropertyCodeGenerator {
             Comparator.class,
             elementType)
         .add(PreconditionExcerpts.checkState(
-            Excerpts.add("%s == null", property.getField()),
-            "Comparator already set for %s",
-            property.getField()));
+            "%1$s == null", "Comparator already set for %1$s", property.getField()));
     if (code.feature(GUAVA).isAvailable()) {
       code.addLine("  if (comparator == null) {")
           .addLine("    %s = %s.of();", property.getField(), ImmutableSortedSet.class)

--- a/src/main/java/org/inferred/freebuilder/processor/util/AbstractSourceBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/AbstractSourceBuilder.java
@@ -9,9 +9,6 @@ import org.inferred.freebuilder.processor.util.feature.FeatureSet;
 import org.inferred.freebuilder.processor.util.feature.FeatureType;
 
 import java.io.IOException;
-import java.util.MissingFormatArgumentException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -25,7 +22,6 @@ public abstract class AbstractSourceBuilder<B extends AbstractSourceBuilder<B>>
     implements SourceBuilder, Appendable {
 
   private static final String LINE_SEPARATOR = System.getProperty("line.separator");
-  private static final Pattern TEMPLATE_PARAM = Pattern.compile("%([%ns]|([1-9]\\d*)\\$s)");
 
   protected final FeatureSet features;
   protected final TypeMirrorShortener typeMirrorShortener;
@@ -54,31 +50,7 @@ public abstract class AbstractSourceBuilder<B extends AbstractSourceBuilder<B>>
 
   @Override
   public B add(String template, Object... params) {
-    int offset = 0;
-    int nextParam = 0;
-    Matcher matcher = TEMPLATE_PARAM.matcher(template);
-    while (matcher.find()) {
-      append(template.subSequence(offset, matcher.start()));
-      if (matcher.group(1).contentEquals("%")) {
-        append("%");
-      } else if (matcher.group(1).contentEquals("n")) {
-        append(LINE_SEPARATOR);
-      } else if (matcher.group(1).contentEquals("s")) {
-        if (nextParam >= params.length) {
-          throw new MissingFormatArgumentException(matcher.group(0));
-        }
-        add(params[nextParam++]);
-      } else {
-        int index = Integer.parseInt(matcher.group(2)) - 1;
-        if (index >= params.length) {
-          throw new MissingFormatArgumentException(matcher.group(0));
-        }
-        add(params[index]);
-      }
-      offset = matcher.end();
-    }
-    append(template.subSequence(offset, template.length()));
-
+    TemplateApplier.withParams(params).onText(this::append).onParam(this::add).parse(template);
     return getThis();
   }
 
@@ -101,13 +73,15 @@ public abstract class AbstractSourceBuilder<B extends AbstractSourceBuilder<B>>
 
   @Override
   public Appendable append(CharSequence csq) {
-    csq.chars().forEach(c -> append((char) c));
-    return getThis();
+    return append(csq, 0, csq.length());
   }
 
   @Override
   public Appendable append(CharSequence csq, int start, int end) {
-    return append(csq.subSequence(start, end));
+    for (int i = start; i < end; i++) {
+      append(csq.charAt(i));
+    }
+    return getThis();
   }
 
   private void add(Object arg) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/AnnotationSource.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/AnnotationSource.java
@@ -16,8 +16,9 @@
 package org.inferred.freebuilder.processor.util;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static org.apache.commons.lang3.StringEscapeUtils.escapeJava;
+
 import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
+import static org.inferred.freebuilder.processor.util.Quotes.escapeJava;
 
 import java.util.List;
 import java.util.Map.Entry;

--- a/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/PreconditionExcerpts.java
@@ -1,13 +1,13 @@
 package org.inferred.freebuilder.processor.util;
 
+import static org.inferred.freebuilder.processor.util.Quotes.escapeJava;
 import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
 
 import com.google.common.base.Preconditions;
-import com.google.common.escape.Escaper;
-import com.google.common.escape.Escapers;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 /**
@@ -15,14 +15,93 @@ import java.util.regex.Pattern;
  */
 public class PreconditionExcerpts {
 
+  /**
+   * Matches all operators with a lower precedence than unary negation (!).
+   *
+   * <p>False positives are acceptable, as the only downside is putting unnecessary brackets around
+   * the condition when Guava is not available, so a simple check for offending characters is fine,
+   * even though they might actually be in a string.
+   */
+  private static final Pattern ANY_OPERATOR = Pattern.compile("[+=<>!&^|?:]|\\binstanceof\\b");
+  private static final Pattern BOOLEAN_BINARY_OPERATOR = Pattern.compile("&&|\\|\\|");
+
+  /**
+   * Returns an excerpt equivalent to Guava's
+   * {@link Preconditions#checkArgument(boolean, String, Object...)}.
+   * <ul>
+   * <li>If Guava is available, Preconditions.checkArgument will be used.
+   * <li>Otherwise, the check will be done with an if block.
+   * </ul>
+   *
+   * <pre>code.add(checkArgument("%1$s &gt;= 0", "age must be &gt;= 0 (got %1$s)", "age"));</pre>
+   *
+   * @param condition a code template to pass to the checkArgument method
+   * @param message the error message template to pass to the checkArgument method
+   * @param args excerpts containing the error message arguments to pass to the checkArgument method
+   */
+  public static Excerpt checkArgument(
+      String conditionTemplate,
+      String messageTemplate,
+      Object... args) {
+    return new GuavaCheckExcerpt(
+        "checkArgument", conditionTemplate, messageTemplate, args, IllegalArgumentException.class);
+  }
+
+  /**
+   * Returns an excerpt equivalent to Guava's
+   * {@link Preconditions#checkState(boolean, String, Object...)}.
+   * <ul>
+   * <li>If Guava is available, Preconditions.checkState will be used.
+   * <li>Otherwise, the check will be done with an if block.
+   * </ul>
+   *
+   * <pre>code.add(checkState("%1$s &lt; %2$s",
+   *         "start must be before end (got %1$s and %2$s)", "start", "end"));</pre>
+   *
+   * @param condition an excerpt containing the expression to pass to the checkState method
+   * @param message the error message template to pass to the checkState method
+   * @param args excerpts containing the error message arguments to pass to the checkState method
+   */
+  public static Excerpt checkState(
+      String conditionTemplate,
+      String messageTemplate,
+      Object... args) {
+    return new GuavaCheckExcerpt(
+        "checkState", conditionTemplate, messageTemplate, args, IllegalStateException.class);
+  }
+
+  /**
+   * Negates {@code conditionTemplate}, removing unnecessary brackets and double-negatives if
+   * possible.
+   */
+  private static String negate(String conditionTemplate) {
+    if (conditionTemplate.startsWith("!")
+        && !BOOLEAN_BINARY_OPERATOR.matcher(conditionTemplate).find()) {
+      return conditionTemplate.substring(1);
+    } else if (ANY_OPERATOR.matcher(conditionTemplate).find()) {
+      // The condition might already enclosed in a bracket, but we can't simply check for opening
+      // and closing brackets at the start and end of the string, as that misses cases like
+      // (a || b) && (c || d). Attempting to determine if the initial and closing bracket are paired
+      // requires understanding character constants and strings constants, so for simplicity we
+      // just add unnecessary brackets.
+      return "!(" + conditionTemplate + ")";
+    } else {
+      return "!" + conditionTemplate;
+    }
+  }
+
   private static final class GuavaCheckExcerpt implements Excerpt {
-    private final Object[] args;
-    private final Object condition;
-    private final String message;
     private final String methodName;
+    private final String condition;
+    private final String message;
+    private final Object[] args;
     private final Class<? extends RuntimeException> exceptionType;
 
-    private GuavaCheckExcerpt(Object[] args, Object condition, String message, String methodName,
+    private GuavaCheckExcerpt(
+        String methodName,
+        String condition,
+        String message,
+        Object[] args,
         Class<? extends RuntimeException> exceptionType) {
       this.args = args;
       this.condition = condition;
@@ -34,109 +113,72 @@ public class PreconditionExcerpts {
     @Override
     public void addTo(SourceBuilder code) {
       if (code.feature(GUAVA).isAvailable()) {
-        code.add("%s.%s(%s, \"%s\"",
-            Preconditions.class,
-            methodName,
-            condition,
-            JAVA_STRING_ESCAPER.escape(message));
-        for (Object arg : args) {
-          code.add(", %s", arg);
-        }
-        code.add(");\n");
+        addGuavaTo(code);
       } else {
-        List<Excerpt> escapedArgs = new ArrayList<>();
-        for (Object arg : args) {
-          escapedArgs.add(Excerpts.add("\" + %s + \"", arg));
-        }
-        String messageConcatenated = code.subBuilder()
-            .add("\"" + JAVA_STRING_ESCAPER.escape(message) + "\"", escapedArgs.toArray())
-            .toString()
-            .replace("\"\" + ", "")
-            .replace(" + \"\"", "");
-        code.addLine("if (%s) {", negate(code, condition))
-            .addLine("  throw new %s(%s);", exceptionType, messageConcatenated)
-            .addLine("}");
+        addIfBlockTo(code);
       }
     }
-  }
 
-  private static final Escaper JAVA_STRING_ESCAPER = Escapers.builder()
-      .addEscape('"', "\"")
-      .addEscape('\\', "\\\\")
-      .addEscape('\n', "\\n")
-      .build();
-  /**
-   * Matches all operators with a lower precedence than unary negation (!).
-   *
-   * <p>False positives are acceptable, as the only downside is putting unnecessary brackets around
-   * the condition when Guava is not available, so a simple check for offending characters is fine,
-   * even though they might actually be in a string.
-   */
-  private static final Pattern ANY_OPERATOR = Pattern.compile("[+=<>!&^|?:]|\\binstanceof\\b");
+    private void addIfBlockTo(SourceBuilder code) {
+      TemplateApplier templateApplier = TemplateApplier.withParams(args);
+      code.add("if (");
+      templateApplier
+          .onText((csq, start, end) -> code.add("%s", csq.subSequence(start, end)))
+          .onParam(param -> code.add("%s", param))
+          .parse(negate(condition));
+      code.addLine(") {")
+          .add("  throw new %s(", exceptionType);
+      AtomicBoolean inString = new AtomicBoolean(false);
+      AtomicBoolean needsSeparator = new AtomicBoolean(false);
+      templateApplier
+          .onText((csq, start, end) -> {
+            if (!inString.getAndSet(true)) {
+              if (needsSeparator.getAndSet(true)) {
+                code.add(" + ");
+              }
+              code.add("\"");
+            }
+            code.add("%s", escapeJava(csq.subSequence(start, end).toString()));
+          })
+          .onParam(param -> {
+            if (inString.getAndSet(false)) {
+              code.add("\"");
+            }
+            if (needsSeparator.getAndSet(true)) {
+              code.add(" + ");
+            }
+            code.add("%s", param);
+          })
+          .parse(message);
+      if (inString.get()) {
+        code.add("\"");
+      }
+      code.addLine(");")
+          .addLine("}");
+    }
 
-  /**
-   * Returns an excerpt equivalent to Guava's
-   * {@link Preconditions#checkArgument(boolean, String, Object...)}.
-   * <ul>
-   * <li>If Guava is available, Preconditions.checkArgument will be used.
-   * <li>Otherwise, the check will be done with an if block.
-   * </ul>
-   *
-   * <pre>code.add(checkArgument("age &gt;= 0", "age must be non-negative (got %s)", "age"));</pre>
-   *
-   * @param condition an excerpt containing the expression to pass to the checkArgument method
-   * @param message the error message template to pass to the checkArgument method
-   * @param args excerpts containing the error message arguments to pass to the checkArgument method
-   */
-  public static Excerpt checkArgument(
-      final Object condition,
-      final String message,
-      final Object... args) {
-    return new GuavaCheckExcerpt(
-        args, condition, message, "checkArgument", IllegalArgumentException.class);
-  }
-
-  /**
-   * Returns an excerpt equivalent to Guava's
-   * {@link Preconditions#checkState(boolean, String, Object...)}.
-   * <ul>
-   * <li>If Guava is available, Preconditions.checkState will be used.
-   * <li>Otherwise, the check will be done with an if block.
-   * </ul>
-   *
-   * <pre>code.add(checkState("start &lt; end",
-   *         "start must be before end (got %s and %s)", "start", "end"));</pre>
-   *
-   * @param condition an excerpt containing the expression to pass to the checkState method
-   * @param message the error message template to pass to the checkState method
-   * @param args excerpts containing the error message arguments to pass to the checkState method
-   */
-  public static Excerpt checkState(
-      final Object condition,
-      final String message,
-      final Object... args) {
-    return new GuavaCheckExcerpt(
-        args, condition, message, "checkState", IllegalStateException.class);
-  }
-
-  /**
-   * Negates {@code condition}, removing unnecessary brackets and double-negatives if possible.
-   */
-  private static String negate(SourceBuilder code, Object condition) {
-    SourceStringBuilder subBuilder = code.subBuilder();
-    subBuilder.add("%s", condition);
-    String conditionText = subBuilder.toString();
-    if (conditionText.startsWith("!")) {
-      return conditionText.substring(1);
-    } else if (ANY_OPERATOR.matcher(conditionText).find()) {
-      // The condition might already enclosed in a bracket, but we can't simply check for opening
-      // and closing brackets at the start and end of the string, as that misses cases like
-      // (a || b) && (c || d). Attempting to determine if the initial and closing bracket are paired
-      // requires understanding character constants and strings constants, so for simplicity we
-      // just add unnecessary brackets.
-      return "!(" + conditionText + ")";
-    } else {
-      return "!" + conditionText;
+    private void addGuavaTo(SourceBuilder code) {
+      TemplateApplier templateApplier = TemplateApplier.withParams(args);
+      code.add("%s.%s(", Preconditions.class, methodName);
+      templateApplier
+          .onText((csq, start, end) -> code.add("%s", csq.subSequence(start, end)))
+          .onParam(param -> code.add("%s", param))
+          .parse(condition);
+      code.add(", \"");
+      List<Object> templateArgs = new ArrayList<>();
+      templateApplier
+          .onText((csq, start, end) -> code.add("%s",
+              escapeJava(csq.subSequence(start, end).toString().replaceAll("%", "%%"))))
+          .onParam(param -> {
+            templateArgs.add(param);
+            code.add("%%s");
+          })
+          .parse(message);
+      code.add("\"");
+      for (Object arg : templateArgs) {
+        code.add(", %s", arg);
+      }
+      code.add(");\n");
     }
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/Quotes.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/Quotes.java
@@ -1,0 +1,49 @@
+package org.inferred.freebuilder.processor.util;
+
+public class Quotes {
+
+  /** Escapes each character in a string that has an escape sequence. */
+  public static CharSequence escapeJava(CharSequence s) {
+    return quote(s, 0, s.length());
+  }
+
+  public static CharSequence quote(CharSequence s, int start, int end) {
+    StringBuilder buf = new StringBuilder();
+    for (int i = start; i < end; i++) {
+      appendQuoted(buf, s.charAt(i));
+    }
+    return buf;
+  }
+
+  private static void appendQuoted(StringBuilder buf, char ch) {
+    switch (ch) {
+      case '\b':
+        buf.append("\\b");
+        return;
+      case '\f':
+        buf.append("\\f");
+        return;
+      case '\n':
+        buf.append("\\n");
+        return;
+      case '\r':
+        buf.append("\\r");
+        return;
+      case '\t':
+        buf.append("\\t");
+        return;
+      case '\"':
+        buf.append("\\\"");
+        return;
+      case '\\':
+        buf.append("\\\\");
+        return;
+      default:
+        buf.append(ch);
+        return;
+    }
+  }
+
+  private Quotes() {
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/TemplateApplier.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/TemplateApplier.java
@@ -1,0 +1,75 @@
+package org.inferred.freebuilder.processor.util;
+
+import static java.lang.Integer.parseInt;
+
+import java.util.MissingFormatArgumentException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TemplateApplier {
+
+  public interface TextAppender {
+    void append(CharSequence chars, int start, int end);
+  }
+
+  public interface ParamAppender {
+    void append(Object param);
+  }
+
+  public static TemplateApplier withParams(Object[] params) {
+    return new TemplateApplier(params);
+  }
+
+  private static final Pattern PARAM = Pattern.compile("%([%ns]|([1-9]\\d*)\\$s)");
+  private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+  private final Object[] params;
+  private TextAppender textAppender;
+  private ParamAppender paramAppender;
+  private int nextParam = 0;
+
+  private TemplateApplier(Object[] params) {
+    this.params = params;
+  }
+
+  public TemplateApplier onText(TextAppender textAppender) {
+    this.textAppender = textAppender;
+    return this;
+  }
+
+  public TemplateApplier onParam(ParamAppender paramAppender) {
+    this.paramAppender = paramAppender;
+    return this;
+  }
+
+  public TemplateApplier parse(CharSequence template) {
+    int offset = 0;
+    Matcher matcher = PARAM.matcher(template);
+    while (matcher.find()) {
+      if (offset != matcher.start()) {
+        textAppender.append(template, offset, matcher.start());
+      }
+      if (matcher.group(1).contentEquals("%")) {
+        textAppender.append("%", 0, 1);
+      } else if (matcher.group(1).contentEquals("n")) {
+        textAppender.append(LINE_SEPARATOR, 0, LINE_SEPARATOR.length());
+      } else if (matcher.group(1).contentEquals("s")) {
+        if (nextParam >= params.length) {
+          throw new MissingFormatArgumentException(matcher.group());
+        }
+        paramAppender.append(params[nextParam++]);
+      } else {
+        int index = parseInt(matcher.group(2)) - 1;
+        if (index >= params.length) {
+          throw new MissingFormatArgumentException(matcher.group());
+        }
+        paramAppender.append(params[index]);
+      }
+      offset = matcher.end();
+    }
+    if (offset != template.length()) {
+      textAppender.append(template, offset, template.length());
+    }
+    return this;
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/BuildableListPropertyTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuildableListPropertyTest.java
@@ -1,6 +1,6 @@
 package org.inferred.freebuilder.processor;
 
-import static org.apache.commons.lang3.StringEscapeUtils.escapeJava;
+import static org.inferred.freebuilder.processor.util.Quotes.escapeJava;
 import static org.inferred.freebuilder.processor.util.feature.GuavaLibrary.GUAVA;
 import static org.junit.Assume.assumeTrue;
 

--- a/src/test/java/org/inferred/freebuilder/processor/util/PreconditionExcerptsTests.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/PreconditionExcerptsTests.java
@@ -69,7 +69,7 @@ public class PreconditionExcerptsTests {
             "foo.contains(\"\\\"\")", "foo must contain at least one double quote ('\"')"))
         .toString();
     assertEquals("Preconditions.checkArgument(foo.contains(\"\\\"\"), "
-        + "\"foo must contain at least one double quote ('\"')\");\n", source);
+        + "\"foo must contain at least one double quote ('\\\"')\");\n", source);
   }
 
   @Test
@@ -93,7 +93,7 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_simpleMessage() {
+  public void testCheckArgument_if_simpleMessage() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("condition", "message"))
         .toString();
@@ -102,7 +102,7 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_singleParameterAtEnd() {
+  public void testCheckArgument_if_singleParameterAtEnd() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("condition", "message about %s", "foo"))
         .toString();
@@ -112,7 +112,7 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_singleParameterInMiddle() {
+  public void testCheckArgument_if_singleParameterInMiddle() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("condition", "bar %s baz", "foo"))
         .toString();
@@ -122,7 +122,7 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_singleParameterAtStart() {
+  public void testCheckArgument_if_singleParameterAtStart() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("condition", "%s is wrong", "foo"))
         .toString();
@@ -132,7 +132,7 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_twoParametersInMiddle() {
+  public void testCheckArgument_if_twoParametersInMiddle() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("condition", "a %s c %s e", "b", "d"))
         .toString();
@@ -143,19 +143,19 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_doubleQuotes() {
+  public void testCheckArgument_if_doubleQuotes() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument(
             "foo.contains(\"\\\"\")", "foo must contain at least one double quote ('\"')"))
         .toString();
     assertEquals(
         "if (!foo.contains(\"\\\"\")) {\n  throw new IllegalArgumentException("
-                + "\"foo must contain at least one double quote ('\"')\");\n}\n",
+                + "\"foo must contain at least one double quote ('\\\"')\");\n}\n",
         source);
   }
 
   @Test
-  public void testCheckArgument_j6_backslashes() {
+  public void testCheckArgument_if_backslashes() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument(
             "foo.contains(\"\\\\\")", "foo must contain at least one backslash ('\\')"))
@@ -167,7 +167,7 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_newLines() {
+  public void testCheckArgument_if_newLines() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument(
             "foo.contains(\"\\n\")", "foo must contain at least one newline ('\n')"))
@@ -179,7 +179,7 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_doubleNegative() {
+  public void testCheckArgument_if_doubleNegative() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("!foo.isEmpty()", "foo must not be empty"))
         .toString();
@@ -190,7 +190,17 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_complexCondition() {
+  public void testCheckArgument_if_doubleNegativeBooleanLogic() {
+    String source = SourceStringBuilder.simple()
+        .add(PreconditionExcerpts.checkArgument("!a && !b", "message"))
+        .toString();
+    assertEquals(
+        "if (!(!a && !b)) {\n  throw new IllegalArgumentException(\"message\");\n}\n",
+        source);
+  }
+
+  @Test
+  public void testCheckArgument_if_complexCondition() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("a % 3 > 0", "message"))
         .toString();
@@ -199,7 +209,7 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_complexConditionWithMultipleBrackets() {
+  public void testCheckArgument_if_complexConditionWithMultipleBrackets() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("(a || b) && (c || d)", "message"))
         .toString();
@@ -209,7 +219,7 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckArgument_j6_instanceOf() {
+  public void testCheckArgument_if_instanceOf() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkArgument("a instanceof Integer", "message"))
         .toString();
@@ -227,13 +237,37 @@ public class PreconditionExcerptsTests {
   }
 
   @Test
-  public void testCheckState_j6_simpleMessage() {
+  public void testCheckState_if_simpleMessage() {
     String source = SourceStringBuilder.simple()
         .add(PreconditionExcerpts.checkState("foo != 0", "foo must not be zero"))
         .toString();
     assertEquals(
         "if (!(foo != 0)) {\n  throw new IllegalStateException("
                 + "\"foo must not be zero\");\n}\n",
+        source);
+  }
+
+  @Test
+  public void testCheckState_guava_parameterizedCondition() {
+    String source = SourceStringBuilder.simple(GuavaLibrary.AVAILABLE)
+        .add(PreconditionExcerpts.checkState(
+            "%1$s > 0", "foo must be positive (got %1$s)", new Variable("foo")))
+        .toString();
+    assertEquals(
+        "Preconditions.checkState(foo > 0, \"foo must be positive (got %s)\", foo);\n",
+        source);
+  }
+
+  @Test
+  public void testCheckState_if_parameterizedCondition() {
+    String source = SourceStringBuilder.simple()
+        .add(PreconditionExcerpts.checkState(
+            "%1$s > 0", "foo must be positive (got %1$s)", new Variable("foo")))
+        .toString();
+    assertEquals(
+        "if (!(foo > 0)) {\n"
+            + "  throw new IllegalStateException(\"foo must be positive (got \" + foo + \")\");\n"
+            + "}\n",
         source);
   }
 }


### PR DESCRIPTION
Rather than taking in and attempting to negate an Excerpt, which is blocking SourceBuilder cleanups, instead make the first argument a parameter using the same list of arguments as the second. This has the nice side-effect of making uses cleaner. For example,

```java

Excerpt propertyIsSet = Excerpts.add("!%s.contains(%s.%s)",
    UNSET_PROPERTIES, datatype.getPropertyEnum(), property.getAllCapsName());
code.add(PreconditionExcerpts.checkState(propertyIsSet, property.getName() + " not set"));
```

becomes:

```java

code.add(PreconditionExcerpts.checkState(
    "!%s.contains(%s.%s)",
    property.getName() + " not set",
    UNSET_PROPERTIES,
    datatype.getPropertyEnum(),
    property.getAllCapsName()));
```

The new TemplateApplier class encapsulates the code shared between this and AbstractSourceBuilder.