### PR TITLE
Remove last use of SourceBuilder.subBuilder

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/AbstractSourceBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/AbstractSourceBuilder.java
@@ -62,11 +62,6 @@ public abstract class AbstractSourceBuilder<B extends AbstractSourceBuilder<B>>
   }
 
   @Override
-  public SourceStringBuilder subBuilder() {
-    return new SourceStringBuilder(getShortener(), features, scope());
-  }
-
-  @Override
   public <T extends Feature<T>> T feature(FeatureType<T> feature) {
     return features.get(feature);
   }

--- a/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/SourceBuilder.java
@@ -68,13 +68,6 @@ public interface SourceBuilder {
   SourceBuilder addLine(String fmt, Object... args);
 
   /**
-   * Returns a {@code SourceStringBuilder} with the same configuration as this builder. In
-   * particular, the {@code TypeShortener} will be shared, so any types added to the sub-builder
-   * will be included in the imports for this builder (and its parents).
-   */
-  SourceStringBuilder subBuilder();
-
-  /**
    * Returns the instance of {@code featureType} appropriate for the source being written. For
    * instance, <code>code.feature({@link GuavaLibrary#GUAVA
    * GUAVA}).{@link GuavaLibrary#isAvailable() isAvailable()}</code> returns true if the Guava

--- a/src/test/java/org/inferred/freebuilder/processor/util/LazyNameTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/LazyNameTest.java
@@ -84,6 +84,6 @@ public class LazyNameTest {
     code.addLine("%s", name2);
     LazyName.addLazyDefinitions(code);
 
-    assertThat(code.toString()).isEqualTo("hoolah\nexcerpt\nfoobar\n");
+    assertThat(code.toString()).isEqualTo("hoolah\nfoobar\nexcerpt\n");
   }
 }


### PR DESCRIPTION
Refactor LazyName to stop using subBuilder, at the cost of no longer guaranteeing alphabetical ordering of lazy definitions.