### PR TITLE
Merge duplicate methods in QualifiedName

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/BuilderFactory.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuilderFactory.java
@@ -50,10 +50,10 @@ public enum BuilderFactory {
   BUILDER_METHOD {
     @Override public Excerpt newBuilder(Type builderType, TypeInference typeInference) {
       if (typeInference == TypeInference.INFERRED_TYPES) {
-        return Excerpts.add("%s.builder()", builderType.getQualifiedName().getEnclosingType());
+        return Excerpts.add("%s.builder()", builderType.getQualifiedName().enclosingType());
       } else {
         return Excerpts.add("%s.%sbuilder()",
-            builderType.getQualifiedName().getEnclosingType(), builderType.typeParameters());
+            builderType.getQualifiedName().enclosingType(), builderType.typeParameters());
       }
     }
   },
@@ -62,10 +62,10 @@ public enum BuilderFactory {
   NEW_BUILDER_METHOD {
     @Override public Excerpt newBuilder(Type builderType, TypeInference typeInference) {
       if (typeInference == TypeInference.INFERRED_TYPES) {
-        return Excerpts.add("%s.newBuilder()", builderType.getQualifiedName().getEnclosingType());
+        return Excerpts.add("%s.newBuilder()", builderType.getQualifiedName().enclosingType());
       } else {
         return Excerpts.add("%s.%snewBuilder()",
-            builderType.getQualifiedName().getEnclosingType(), builderType.typeParameters());
+            builderType.getQualifiedName().enclosingType(), builderType.typeParameters());
       }
     }
   };

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -167,13 +167,13 @@ public abstract class Datatype {
     public Datatype build() {
       Datatype datatype = super.build();
       QualifiedName generatedBuilder = datatype.getGeneratedBuilder().getQualifiedName();
-      checkState(datatype.getValueType().getQualifiedName().getEnclosingType()
+      checkState(datatype.getValueType().getQualifiedName().enclosingType()
               .equals(generatedBuilder),
           "%s not a nested class of %s", datatype.getValueType(), generatedBuilder);
-      checkState(datatype.getPartialType().getQualifiedName().getEnclosingType()
+      checkState(datatype.getPartialType().getQualifiedName().enclosingType()
               .equals(generatedBuilder),
           "%s not a nested class of %s", datatype.getPartialType(), generatedBuilder);
-      checkState(datatype.getPropertyEnum().getQualifiedName().getEnclosingType()
+      checkState(datatype.getPropertyEnum().getQualifiedName().enclosingType()
               .equals(generatedBuilder),
           "%s not a nested class of %s", datatype.getPropertyEnum(), generatedBuilder);
       return datatype;

--- a/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/QualifiedName.java
@@ -122,6 +122,11 @@ public class QualifiedName extends ValueType implements Comparable<QualifiedName
     return packageName;
   }
 
+  /**
+   * Returns the {@link QualifiedName} of the type enclosing this one.
+   *
+   * @throws IllegalStateException if {@link #isTopLevel()} returns true
+   */
   public QualifiedName enclosingType() {
     checkState(!isTopLevel(), "Cannot return enclosing type of top-level type");
     return new QualifiedName(packageName, simpleNames.subList(0, simpleNames.size() - 1));
@@ -164,16 +169,6 @@ public class QualifiedName extends ValueType implements Comparable<QualifiedName
 
   public TypeClass withParameters(Iterable<? extends TypeParameterElement> typeParameters) {
     return new TypeClass(this, ImmutableList.copyOf(typeParameters));
-  }
-
-  /**
-   * Returns the {@link QualifiedName} of the type enclosing this one.
-   *
-   * @throws IllegalStateException if {@link #isTopLevel()} returns true
-   */
-  public QualifiedName getEnclosingType() {
-    checkState(!isTopLevel(), "%s has no enclosing type", this);
-    return new QualifiedName(packageName, simpleNames.subList(0, simpleNames.size() - 1));
   }
 
   @Override

--- a/src/main/java/org/inferred/freebuilder/processor/util/ScopeHandler.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ScopeHandler.java
@@ -106,7 +106,7 @@ class ScopeHandler {
         if (scope.isTopLevel()) {
           return typeInScope(scope.getPackage(), simpleName);
         } else {
-          return typeInScope(scope.getEnclosingType(), simpleName);
+          return typeInScope(scope.enclosingType(), simpleName);
         }
 
       case 1:

--- a/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/GenericElement.java
@@ -217,7 +217,7 @@ public abstract class GenericElement implements TypeElement {
   @Override
   public Element getEnclosingElement() {
     if (!qualifiedName.isTopLevel()) {
-      return newTopLevelClass(qualifiedName.getEnclosingType().toString()).asElement();
+      return newTopLevelClass(qualifiedName.enclosingType().toString()).asElement();
     } else {
       return PackageElementImpl.create(qualifiedName.getPackage());
     }


### PR DESCRIPTION
Somehow we managed to end up with both getEnclosingType() *and* enclosingType(). There can be only one.