### PR TITLE
Add CompilationUnitBuilder.forTesting

### DIFF
--- a/src/main/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilder.java
@@ -61,7 +61,7 @@ public class CompilationUnitBuilder
     this.classToWrite = classToWrite;
     // Write the source code into an intermediate SourceStringBuilder, as the imports need to be
     // written first, but aren't known yet.
-    scopeHandler = new ScopeHandler(env.getElementUtils());
+    scopeHandler = new ScopeHandler(new CompilerReflection(env.getElementUtils()));
     parser = new SourceParser(this);
     scopes.add(new FileScope());
     types.add(null);

--- a/src/main/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilder.java
@@ -25,11 +25,16 @@ import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.FormatterException;
 
 import org.inferred.freebuilder.processor.util.Scope.FileScope;
+import org.inferred.freebuilder.processor.util.ScopeHandler.Reflection;
 import org.inferred.freebuilder.processor.util.ScopeHandler.Visibility;
+import org.inferred.freebuilder.processor.util.feature.EnvironmentFeatureSet;
+import org.inferred.freebuilder.processor.util.feature.Feature;
 import org.inferred.freebuilder.processor.util.feature.FeatureSet;
+import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -51,17 +56,40 @@ public class CompilationUnitBuilder
   /**
    * Returns a {@link CompilationUnitBuilder} for {@code classToWrite} using {@code features}. The
    * file preamble (package and imports) will be generated automatically, and {@code env} will be
-   * inspected for potential import collisions.
+   * inspected for potential import collisions. If {@code features} is null, it will be deduced
+   * from {@code env}.
    */
-  public CompilationUnitBuilder(
+  public static CompilationUnitBuilder forEnvironment(
       ProcessingEnvironment env,
+      QualifiedName classToWrite,
+      FeatureSet features) {
+    return new CompilationUnitBuilder(
+        new CompilerReflection(env.getElementUtils()),
+        classToWrite,
+        Optional.ofNullable(features).orElseGet(() -> new EnvironmentFeatureSet(env)));
+  }
+
+  /**
+   * Returns a {@link CompilationUnitBuilder} for {@code classToWrite} using {@code features}. The
+   * file preamble (package and imports) will be generated automatically.
+   */
+  @VisibleForTesting
+  public static CompilationUnitBuilder forTesting(
+      QualifiedName classToWrite,
+      Feature<?>... features) {
+    return new CompilationUnitBuilder(
+        new RuntimeReflection(ClassLoader.getSystemClassLoader()),
+        classToWrite,
+        new StaticFeatureSet(features));
+  }
+
+  private CompilationUnitBuilder(
+      Reflection reflect,
       QualifiedName classToWrite,
       FeatureSet features) {
     super(features);
     this.classToWrite = classToWrite;
-    // Write the source code into an intermediate SourceStringBuilder, as the imports need to be
-    // written first, but aren't known yet.
-    scopeHandler = new ScopeHandler(new CompilerReflection(env.getElementUtils()));
+    scopeHandler = new ScopeHandler(reflect);
     parser = new SourceParser(this);
     scopes.add(new FileScope());
     types.add(null);

--- a/src/main/java/org/inferred/freebuilder/processor/util/CompilerReflection.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/CompilerReflection.java
@@ -1,0 +1,88 @@
+package org.inferred.freebuilder.processor.util;
+
+import static org.inferred.freebuilder.processor.util.ModelUtils.maybeAsTypeElement;
+
+import org.inferred.freebuilder.processor.util.ScopeHandler.Reflection;
+import org.inferred.freebuilder.processor.util.ScopeHandler.TypeInfo;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
+
+/** Encapsulates the parts of {@link Elements} used by {@link ScopeHandler}. */
+class CompilerReflection implements Reflection {
+
+  private static class ElementsTypeInfo implements ScopeHandler.TypeInfo {
+    private final Elements elements;
+    private final TypeElement element;
+    private final QualifiedName name;
+
+    ElementsTypeInfo(Elements elements, TypeElement element) {
+      this.elements = elements;
+      this.element = element;
+      this.name = QualifiedName.of(element);
+    }
+
+    @Override
+    public QualifiedName name() {
+      return name;
+    }
+
+    @Override
+    public ScopeHandler.Visibility visibility() {
+      Set<Modifier> modifiers = element.getModifiers();
+      if (modifiers.contains(Modifier.PUBLIC)) {
+        return ScopeHandler.Visibility.PUBLIC;
+      } else if (modifiers.contains(Modifier.PROTECTED)) {
+        return ScopeHandler.Visibility.PROTECTED;
+      } else if (modifiers.contains(Modifier.PRIVATE)) {
+        return ScopeHandler.Visibility.PRIVATE;
+      } else  {
+        return ScopeHandler.Visibility.PACKAGE;
+      }
+    }
+
+    @Override
+    public Stream<ScopeHandler.TypeInfo> supertypes() {
+      return Stream.concat(
+          create(element.getSuperclass()),
+          element.getInterfaces().stream().flatMap(this::create));
+    }
+
+    @Override
+    public Stream<ScopeHandler.TypeInfo> nestedTypes() {
+      return ElementFilter.typesIn(element.getEnclosedElements())
+          .stream()
+          .map(element -> new ElementsTypeInfo(elements, element));
+    }
+
+    private Stream<ScopeHandler.TypeInfo> create(TypeMirror mirror) {
+      TypeElement element = maybeAsTypeElement(mirror).orElse(null);
+      if (element == null) {
+        return Stream.of();
+      }
+      return Stream.of(new ElementsTypeInfo(elements, element));
+    }
+  }
+
+  private final Elements elements;
+
+  CompilerReflection(Elements elements) {
+    this.elements = elements;
+  }
+
+  @Override
+  public Optional<TypeInfo> find(String name) {
+    TypeElement element = elements.getTypeElement(name);
+    if (element == null) {
+      return Optional.empty();
+    }
+    return Optional.of(new CompilerReflection.ElementsTypeInfo(elements, element));
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/RuntimeReflection.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/RuntimeReflection.java
@@ -1,0 +1,74 @@
+package org.inferred.freebuilder.processor.util;
+
+import org.inferred.freebuilder.processor.util.ScopeHandler.TypeInfo;
+import org.inferred.freebuilder.processor.util.ScopeHandler.Visibility;
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+class RuntimeReflection implements ScopeHandler.Reflection {
+
+  private class RuntimeTypeInfo implements ScopeHandler.TypeInfo {
+
+    private final Class<?> cls;
+    private final QualifiedName name;
+
+    RuntimeTypeInfo(Class<?> cls) {
+      this.cls = cls;
+      this.name = QualifiedName.of(cls);
+    }
+
+    @Override
+    public QualifiedName name() {
+      return name;
+    }
+
+    @Override
+    public Visibility visibility() {
+      int modifiers = cls.getModifiers();
+      if (Modifier.isPublic(modifiers)) {
+        return Visibility.PUBLIC;
+      } else if (Modifier.isProtected(modifiers)) {
+        return Visibility.PROTECTED;
+      } else if (Modifier.isPrivate(modifiers)) {
+        return Visibility.PRIVATE;
+      } else if (cls.getEnclosingClass() != null && cls.getEnclosingClass().isInterface()) {
+        return Visibility.PUBLIC;
+      } else {
+        return Visibility.PROTECTED;
+      }
+    }
+
+    @Override
+    public Stream<TypeInfo> supertypes() {
+      return Stream.concat(stream(cls.getSuperclass()), Arrays.stream(cls.getInterfaces()))
+          .map(RuntimeTypeInfo::new);
+    }
+
+    @Override
+    public Stream<TypeInfo> nestedTypes() {
+      return Arrays.stream(cls.getDeclaredClasses()).map(RuntimeTypeInfo::new);
+    }
+  }
+
+  private final ClassLoader classLoader;
+
+  RuntimeReflection(ClassLoader classLoader) {
+    this.classLoader = classLoader;
+  }
+
+  @Override
+  public Optional<TypeInfo> find(String typename) {
+    try {
+      return Optional.of(classLoader.loadClass(typename)).map(RuntimeTypeInfo::new);
+    } catch (ClassNotFoundException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static <T> Stream<T> stream(T value) {
+    return (value != null) ? Stream.of(value) : Stream.of();
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/util/ScopeHandler.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ScopeHandler.java
@@ -127,7 +127,7 @@ class ScopeHandler {
   }
 
   private SetMultimap<String, QualifiedName> typesInScope(QualifiedName scope) {
-    return visibleTypes.computeIfAbsent(scope, this::computeTypesInScope);
+    return Optional.ofNullable(visibleTypes.get(scope)).orElseGet(() -> computeTypesInScope(scope));
   }
 
   private SetMultimap<String, QualifiedName> computeTypesInScope(QualifiedName scope) {

--- a/src/main/java/org/inferred/freebuilder/processor/util/ScopeHandler.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ScopeHandler.java
@@ -1,7 +1,5 @@
 package org.inferred.freebuilder.processor.util;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
-
 import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
 
 import com.google.common.collect.HashMultimap;
@@ -11,7 +9,6 @@ import com.google.common.collect.SetMultimap;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -86,34 +83,6 @@ class ScopeHandler {
       return visibilityIn(scope.enclosingType(), type);
     } else {
       return visibilityIn(scope.getPackage(), type);
-    }
-  }
-
-  Optional<QualifiedName> typeInScope(String pkg, String simpleName) {
-    if (isTopLevelType(pkg, simpleName)) {
-      return Optional.of(QualifiedName.of(pkg, simpleName));
-    } else if (!pkg.equals(UNIVERSALLY_VISIBLE_PACKAGE)) {
-      return typeInScope(UNIVERSALLY_VISIBLE_PACKAGE, simpleName);
-    } else {
-      return Optional.empty();
-    }
-  }
-
-  Optional<QualifiedName> typeInScope(QualifiedName scope, String simpleName) {
-    Set<QualifiedName> possibleTypes = typesInScope(scope).get(simpleName);
-    switch (possibleTypes.size()) {
-      case 0:
-        if (scope.isTopLevel()) {
-          return typeInScope(scope.getPackage(), simpleName);
-        } else {
-          return typeInScope(scope.enclosingType(), simpleName);
-        }
-
-      case 1:
-        return Optional.of(getOnlyElement(possibleTypes));
-
-      default:
-        return Optional.empty();
     }
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/util/ScopeHandler.java
+++ b/src/main/java/org/inferred/freebuilder/processor/util/ScopeHandler.java
@@ -1,25 +1,14 @@
 package org.inferred.freebuilder.processor.util;
 
-import static org.inferred.freebuilder.processor.util.ModelUtils.asElement;
-
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.type.TypeVisitor;
-import javax.lang.model.util.ElementFilter;
-import javax.lang.model.util.Elements;
-import javax.lang.model.util.SimpleTypeVisitor6;
 
 /**
  * Handles the byzantine rules of Java scoping.
@@ -36,9 +25,19 @@ class ScopeHandler {
   }
   enum Visibility { PUBLIC, PROTECTED, PACKAGE, PRIVATE, UNKNOWN }
 
+  interface Reflection {
+    Optional<TypeInfo> find(String typename);
+  }
+  interface TypeInfo {
+    QualifiedName name();
+    Visibility visibility();
+    Stream<TypeInfo> supertypes();
+    Stream<TypeInfo> nestedTypes();
+  }
+
   private static final String UNIVERSALLY_VISIBLE_PACKAGE = "java.lang";
 
-  private final Elements elements;
+  private final Reflection reflect;
 
   /** Type ↦ visibility in parent scope */
   private final Map<QualifiedName, Visibility> typeVisibility = new HashMap<>();
@@ -48,8 +47,8 @@ class ScopeHandler {
   /** Qualified name as string ↦ qualified name */
   private final Map<String, QualifiedName> generatedTypes = new HashMap<>();
 
-  ScopeHandler(Elements elements) {
-    this.elements = elements;
+  ScopeHandler(Reflection reflect) {
+    this.reflect = reflect;
   }
 
   /**
@@ -99,7 +98,7 @@ class ScopeHandler {
     SetMultimap<String, QualifiedName> visibleInScope = get(visibleTypes, generatedType);
     supertypes.stream().flatMap(this::lookup).forEach(supertype -> {
       for (QualifiedName type : typesInScope(supertype).values()) {
-        if (maybeVisibleInScope(generatedType, type)) {
+        if (maybeVisibleInScope(generatedType, visibilityOf(type), type)) {
           visibleInScope.put(type.getSimpleName(), type);
         }
       }
@@ -110,16 +109,12 @@ class ScopeHandler {
     if (generatedTypes.containsKey(typename)) {
       return Stream.of(generatedTypes.get(typename));
     }
-    TypeElement scopeElement = elements.getTypeElement(typename);
-    if (scopeElement != null) {
-      return Stream.of(QualifiedName.of(scopeElement));
-    }
-    return Stream.empty();
+    return reflect.find(typename).map(TypeInfo::name).map(Stream::of).orElse(Stream.of());
   }
 
   private boolean isTopLevelType(String pkg, String simpleName) {
     String name = pkg + "." + simpleName;
-    return generatedTypes.containsKey(name) || elements.getTypeElement(name) != null;
+    return generatedTypes.containsKey(name) || reflect.find(name).isPresent();
   }
 
   private static <K1, K2, V> SetMultimap<K2, V> get(Map<K1, SetMultimap<K2, V>> map, K1 key) {
@@ -132,41 +127,32 @@ class ScopeHandler {
   }
 
   private SetMultimap<String, QualifiedName> typesInScope(QualifiedName scope) {
-    SetMultimap<String, QualifiedName> result = visibleTypes.get(scope);
-    if (result != null) {
-      return result;
-    }
-    TypeElement scopeElement = elements.getTypeElement(scope.toString());
-    return cacheTypesInScope(scope, scopeElement);
+    return visibleTypes.computeIfAbsent(scope, this::computeTypesInScope);
   }
 
-  private SetMultimap<String, QualifiedName> cacheTypesInScope(
-      QualifiedName scope,
-      TypeElement element) {
+  private SetMultimap<String, QualifiedName> computeTypesInScope(QualifiedName scope) {
     SetMultimap<String, QualifiedName> visibleInScope = HashMultimap.create();
-    if (element != null) {
-      for (QualifiedName type : TYPES_IN_SCOPE.visit(element.getSuperclass(), this)) {
-        if (maybeVisibleInScope(scope, type)) {
-          visibleInScope.put(type.getSimpleName(), type);
-        }
-      }
-      for (TypeMirror iface : element.getInterfaces()) {
-        for (QualifiedName type : TYPES_IN_SCOPE.visit(iface, this)) {
-          if (maybeVisibleInScope(scope, type)) {  // In case interfaces ever get private members
+    visibleTypes.put(scope, visibleInScope);
+    reflect.find(scope.toString()).ifPresent(element -> {
+      element.supertypes().forEach(supertype -> {
+        typesInScope(supertype.name()).values().forEach(type -> {
+          if (maybeVisibleInScope(scope, visibilityOf(type), type)) {
             visibleInScope.put(type.getSimpleName(), type);
           }
-        }
-      }
-      for (TypeElement nested : ElementFilter.typesIn(element.getEnclosedElements())) {
-        visibleInScope.put(nested.getSimpleName().toString(), QualifiedName.of(nested));
-      }
-    }
-    visibleTypes.put(scope, visibleInScope);
+        });
+      });
+      element.nestedTypes().forEach(nested -> {
+        visibleInScope.put(nested.name().getSimpleName().toString(), nested.name());
+      });
+    });
     return visibleInScope;
   }
 
-  private boolean maybeVisibleInScope(QualifiedName scope, QualifiedName type) {
-    switch (visibilityOf(type)) {
+  private static boolean maybeVisibleInScope(
+      QualifiedName scope,
+      Visibility visibility,
+      QualifiedName type) {
+    switch (visibility) {
       case PUBLIC:
       case PROTECTED:
         // type is either nested in scope or a supertype of scope.
@@ -181,47 +167,10 @@ class ScopeHandler {
       case UNKNOWN:
         return true;
     }
-    throw new IllegalStateException("Unknown visibility " + visibilityOf(type));
+    throw new IllegalStateException("Unknown visibility " + visibility);
   }
 
   private Visibility visibilityOf(QualifiedName type) {
-    Visibility visibility = typeVisibility.get(type);
-    if (visibility == null) {
-      TypeElement element = elements.getTypeElement(type.toString());
-      Set<Modifier> modifiers = element.getModifiers();
-      if (modifiers.contains(Modifier.PUBLIC)) {
-        visibility = Visibility.PUBLIC;
-      } else if (modifiers.contains(Modifier.PROTECTED)) {
-        visibility = Visibility.PROTECTED;
-      } else if (modifiers.contains(Modifier.PRIVATE)) {
-        visibility = Visibility.PRIVATE;
-      } else  {
-        visibility = Visibility.PACKAGE;
-      }
-      typeVisibility.put(type, visibility);
-    }
-    return visibility;
+    return typeVisibility.computeIfAbsent(type, t -> reflect.find(t.toString()).get().visibility());
   }
-
-  private static final TypeVisitor<Collection<QualifiedName>, ScopeHandler>
-      TYPES_IN_SCOPE =
-          new SimpleTypeVisitor6<Collection<QualifiedName>, ScopeHandler>() {
-            @Override
-            public Collection<QualifiedName> visitDeclared(
-                DeclaredType type,
-                ScopeHandler scopeHandler) {
-              QualifiedName typename = QualifiedName.of(asElement(type));
-              SetMultimap<String, QualifiedName> visibleInScope =
-                  scopeHandler.visibleTypes.get(typename);
-              if (visibleInScope != null) {
-                return visibleInScope.values();
-              }
-              return scopeHandler.cacheTypesInScope(typename, asElement(type)).values();
-            }
-
-            @Override
-            protected Collection<QualifiedName> defaultAction(TypeMirror e, ScopeHandler p) {
-              return ImmutableSet.of();
-            }
-          };
 }

--- a/src/test/java/org/inferred/freebuilder/processor/GeneratedTypeSubject.java
+++ b/src/test/java/org/inferred/freebuilder/processor/GeneratedTypeSubject.java
@@ -2,11 +2,6 @@ package org.inferred.freebuilder.processor;
 
 import static com.google.common.truth.Truth.THROW_ASSERTION_ERROR;
 
-import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newNestedClass;
-import static org.inferred.freebuilder.processor.util.ClassTypeImpl.newTopLevelClass;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
-
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.truth.FailureStrategy;
@@ -15,19 +10,12 @@ import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.FormatterException;
 
 import org.inferred.freebuilder.processor.util.CompilationUnitBuilder;
-import org.inferred.freebuilder.processor.util.QualifiedName;
 import org.inferred.freebuilder.processor.util.feature.Feature;
-import org.inferred.freebuilder.processor.util.feature.StaticFeatureSet;
 import org.junit.ComparisonFailure;
-import org.mockito.Mockito;
-import org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-
-import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.TypeElement;
 
 class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> {
 
@@ -48,10 +36,9 @@ class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> 
 
   public void generates(String... code) {
     String expected = Arrays.stream(code).collect(joining("\n", "", "\n"));
-    CompilationUnitBuilder compilationUnitBuilder = new CompilationUnitBuilder(
-            mockEnvironment(),
+    CompilationUnitBuilder compilationUnitBuilder = CompilationUnitBuilder.forTesting(
             getSubject().getName(),
-            new StaticFeatureSet(environmentFeatures.toArray(new Feature<?>[0])));
+            environmentFeatures.toArray(new Feature<?>[0]));
     String rawSource = compilationUnitBuilder
         .add(getSubject())
         .toString();
@@ -66,32 +53,6 @@ class GeneratedTypeSubject extends Subject<GeneratedTypeSubject, GeneratedType> 
         System.err.println((++no) + ": " + line);
       }
       failWithRawMessage("%s", e.getMessage());
-    }
-  }
-
-  private static ProcessingEnvironment mockEnvironment() {
-    ProcessingEnvironment env = Mockito.mock(ProcessingEnvironment.class, new ReturnsDeepStubs());
-    when(env.getElementUtils().getTypeElement(any())).thenAnswer(invocation -> {
-      return mockTypeElement(invocation.getArgumentAt(0, CharSequence.class));
-    });
-    return env;
-  }
-
-  private static TypeElement mockTypeElement(CharSequence name) {
-    try {
-      Class<?> cls = ClassLoader.getSystemClassLoader().loadClass(name.toString());
-      return classType(QualifiedName.of(cls));
-    } catch (ClassNotFoundException e) {
-      return null;
-    }
-  }
-
-  private static TypeElement classType(QualifiedName visibleType) {
-    if (visibleType.isTopLevel()) {
-      return newTopLevelClass(visibleType.toString()).asElement();
-    } else {
-      TypeElement parent = classType(visibleType.enclosingType());
-      return newNestedClass(parent, visibleType.getSimpleName()).asElement();
     }
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilderTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/CompilationUnitBuilderTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import static javax.lang.model.util.ElementFilter.fieldsIn;
@@ -35,7 +34,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
@@ -44,7 +42,6 @@ import java.util.AbstractMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.annotation.processing.Filer;
-import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
@@ -249,11 +246,7 @@ public class CompilationUnitBuilderTest {
   }
 
   private CompilationUnitBuilder newSourceWriter(String pkg, String simpleName) {
-    ProcessingEnvironment environment = Mockito.spy(model.environment());
-    doReturn(filer).when(environment).getFiler();
-    return new CompilationUnitBuilder(
-        environment,
-        QualifiedName.of(pkg, simpleName),
-        new StaticFeatureSet());
+    return CompilationUnitBuilder.forEnvironment(
+        model.environment(), QualifiedName.of(pkg, simpleName), new StaticFeatureSet());
   }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/util/ScopeHandlerTests.java
+++ b/src/test/java/org/inferred/freebuilder/processor/util/ScopeHandlerTests.java
@@ -24,7 +24,7 @@ public class ScopeHandlerTests {
 
   @Before
   public void setUp() {
-    handler = new ScopeHandler(model.elementUtils());
+    handler = new ScopeHandler(new CompilerReflection(model.elementUtils()));
   }
 
   @Test


### PR DESCRIPTION
Add a CompilationUnitBuilder factory method that uses the system classloader instead of a processing environment to inspect type information, much like GeneratedTypeSubject. However, rather than using mocks to pass that information to ScopeHandler, refactor the ProcessingEnvironment-specific bits out of ScopeHandler and just use polymorphism.