### PR TITLE
Move generated code to top-level generated directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,14 @@ compileTestJava {
   targetCompatibility = 1.8
 }
 
+sourceSets {
+  main {
+    java {
+      srcDir file('generated/main/java')
+    }
+  }
+}
+
 dependencies {
   compile googleJavaFormat
   compile guava
@@ -534,9 +542,10 @@ eclipse.classpath {
   // This allows us to compile it with an older JVM than the tests
   file.withXml { xml ->
     node = xml.asNode()
-    node.findAll { it.@kind == 'src' && it.@path != 'src/main/java' }.each { src ->
-        node.remove(src)
-    }
+    node.findAll { it.@kind == 'src' &&
+                   ( it.@path.contains('/test/') ||
+                     it.@path.contains('/it/')) }
+        .each { src -> node.remove(src) }
   }
   // Don't include test dependencies in the classpath
   plusConfigurations.clear()

--- a/generated/main/java/org/inferred/freebuilder/processor/BuildableType_Builder.java
+++ b/generated/main/java/org/inferred/freebuilder/processor/BuildableType_Builder.java
@@ -3,17 +3,14 @@ package org.inferred.freebuilder.processor;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+import javax.annotation.Generated;
 import org.inferred.freebuilder.processor.BuildableType.MergeBuilderMethod;
 import org.inferred.freebuilder.processor.BuildableType.PartialToBuilderMethod;
 import org.inferred.freebuilder.processor.source.Excerpt;
 import org.inferred.freebuilder.processor.source.Type;
-
-import java.util.EnumSet;
-import java.util.Objects;
-import java.util.function.UnaryOperator;
-
-import javax.annotation.Generated;
 
 /**
  * Auto-generated superclass of {@link BuildableType.Builder}, derived from the API of {@link

--- a/generated/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
+++ b/generated/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
@@ -5,13 +5,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
-import org.inferred.freebuilder.processor.Datatype.StandardMethod;
-import org.inferred.freebuilder.processor.Datatype.UnderrideLevel;
-import org.inferred.freebuilder.processor.source.Excerpt;
-import org.inferred.freebuilder.processor.source.Type;
-import org.inferred.freebuilder.processor.source.TypeClass;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -26,8 +19,12 @@ import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.BaseStream;
-
 import javax.annotation.Generated;
+import org.inferred.freebuilder.processor.Datatype.StandardMethod;
+import org.inferred.freebuilder.processor.Datatype.UnderrideLevel;
+import org.inferred.freebuilder.processor.source.Excerpt;
+import org.inferred.freebuilder.processor.source.Type;
+import org.inferred.freebuilder.processor.source.TypeClass;
 
 /**
  * Auto-generated superclass of {@link Datatype.Builder}, derived from the API of {@link Datatype}.

--- a/generated/main/java/org/inferred/freebuilder/processor/property/Property_Builder.java
+++ b/generated/main/java/org/inferred/freebuilder/processor/property/Property_Builder.java
@@ -4,9 +4,6 @@ package org.inferred.freebuilder.processor.property;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-
-import org.inferred.freebuilder.processor.source.Excerpt;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -19,9 +16,9 @@ import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.BaseStream;
-
 import javax.annotation.Generated;
 import javax.lang.model.type.TypeMirror;
+import org.inferred.freebuilder.processor.source.Excerpt;
 
 /**
  * Auto-generated superclass of {@link Property.Builder}, derived from the API of {@link Property}.

--- a/generated/main/java/org/inferred/freebuilder/processor/source/TypeUsage_Builder.java
+++ b/generated/main/java/org/inferred/freebuilder/processor/source/TypeUsage_Builder.java
@@ -3,13 +3,11 @@ package org.inferred.freebuilder.processor.source;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.IntUnaryOperator;
 import java.util.function.UnaryOperator;
-
 import javax.annotation.Generated;
 
 /**

--- a/src/main/java/org/inferred/freebuilder/processor/BuildableType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildableType.java
@@ -55,6 +55,7 @@ import javax.lang.model.util.Types;
  * <li> a mergeWith(Value) method.
  * </ul>
  */
+@FreeBuilder
 public abstract class BuildableType {
 
   /** How to merge the values from one Builder into another. */

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.source.Excerpt;
 import org.inferred.freebuilder.processor.source.QualifiedName;
 import org.inferred.freebuilder.processor.source.SourceBuilder;
@@ -31,6 +32,7 @@ import java.util.Optional;
 /**
  * Metadata about a user's datatype.
  */
+@FreeBuilder
 public abstract class Datatype {
 
   /** Standard Java methods that may be underridden. */

--- a/src/main/java/org/inferred/freebuilder/processor/property/Property.java
+++ b/src/main/java/org/inferred/freebuilder/processor/property/Property.java
@@ -2,6 +2,7 @@ package org.inferred.freebuilder.processor.property;
 
 import com.google.common.collect.ImmutableList;
 
+import org.inferred.freebuilder.FreeBuilder;
 import org.inferred.freebuilder.processor.Datatype;
 import org.inferred.freebuilder.processor.source.Excerpt;
 import org.inferred.freebuilder.processor.source.FieldAccess;
@@ -11,6 +12,7 @@ import java.util.Optional;
 import javax.lang.model.type.TypeMirror;
 
 /** Datatype about a property of a {@link Datatype}. */
+@FreeBuilder
 public abstract class Property {
 
   /** Returns the type of the property. */

--- a/src/main/java/org/inferred/freebuilder/processor/source/TypeUsage.java
+++ b/src/main/java/org/inferred/freebuilder/processor/source/TypeUsage.java
@@ -1,7 +1,10 @@
 package org.inferred.freebuilder.processor.source;
 
+import org.inferred.freebuilder.FreeBuilder;
+
 import java.util.Optional;
 
+@FreeBuilder
 interface TypeUsage {
 
   int start();


### PR DESCRIPTION
Simplify the process of dogfooding FreeBuilder by moving the four generated source units to a separate top-level "generated" directory, and permanently annotating the types responsible for generating them with `@FreeBuilder`. Eclipse can then be easily configured to automatically regenerate the code on-the-fly.