### PR TITLE
Change NotInToString, IgnoredByEquals retention to compile time.

### DIFF
--- a/src/main/java/org/inferred/freebuilder/IgnoredByEquals.java
+++ b/src/main/java/org/inferred/freebuilder/IgnoredByEquals.java
@@ -1,8 +1,6 @@
 package org.inferred.freebuilder;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Comparator;
 import java.util.Map;
@@ -22,6 +20,5 @@ import java.util.Set;
  * explicit field-ignoring {@link Comparator} in the parts of the code that need it.
  */
 @Target(ElementType.METHOD)
-@Retention(RetentionPolicy.SOURCE)
 public @interface IgnoredByEquals {
 }

--- a/src/main/java/org/inferred/freebuilder/NotInToString.java
+++ b/src/main/java/org/inferred/freebuilder/NotInToString.java
@@ -1,8 +1,6 @@
 package org.inferred.freebuilder;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -10,6 +8,5 @@ import java.lang.annotation.Target;
  * its generated {@link Object#toString()} implementation.
  */
 @Target(ElementType.METHOD)
-@Retention(RetentionPolicy.SOURCE)
 public @interface NotInToString {
 }


### PR DESCRIPTION
Hi @alicederyn . I went to go try the new annotations but I have a unique situation in my project.

Scenario:
There is an interface Foo in module A.
With interface SubFoo that extends Foo in module B.

SubFoo is annotated with @FreeBuilder
Foo has some methods annotated with @NotInToString and/or @IgnoredByEquals.

Then when SubFoo is generated these annotations will not be retain across modules.

Let me know if the situation is strange, or if there is a reasons why one would want to limit the retention to source. Thank you.
