### PR TITLE
Change name of build and other methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,27 @@ For instance, `assertEquals` in JUnit relies on equality; it will not know to ch
 If you are only testing a subset of your fields for equality, consider separating your class in two, as you may have accidentally combined the key and the value of a map into a single object, and you may find your code becomes healthier after the separation.
 Alternatively, creating a custom [Comparator] will make it explicit that you are not using the natural definition of equality.
 
+### Custom conventional method names
+
+If for any reason your types cannot use the conventional method names (`build`, `buildPartial`, `clear` and `mergeFrom`), you can force FreeBuilder to generate package protected implementations, and even select alternative fallback names if necessary, by declaring an alternative visibility and/or incompatible signature. If the default name is not available, FreeBuilder will prepend an underscore and append "Impl" (and, if necessary, a number), e.g. `build` becomes `_buildImpl`.
+
+```java
+public interface MyType {
+  class Builder extends MyType_Builder {
+    public OtherDataType build() {
+      // This signature is not compatible with the default build method.
+      // FreeBuilder will instead declare a package-scoped _buildImpl.
+      ...
+    }
+    public DataType buildMyType() {
+      return _buildImpl();
+    }
+  }
+}
+```
+
+Note that this will, unfortunately, disable FreeBuilder's [enhanced support for nested builders](#nested-buildable-types) for this type, as it needs to be able to call these methods.
+
 ### Custom functional interfaces
 
 FreeBuilder's generated map and mutate methods take [UnaryOperator] or [Consumer] functional interfaces. If you need to use a different functional interface, you can override the generated methods in your Builder and change the parameter type. FreeBuilder will spot the incompatible override and change the code it generates to match:

--- a/generated/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
+++ b/generated/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
@@ -56,6 +56,7 @@ abstract class Datatype_Builder {
     PROPERTY_ENUM("propertyEnum"),
     BUILDER_SERIALIZABLE("builderSerializable"),
     HAS_TO_BUILDER_METHOD("hasToBuilderMethod"),
+    BUILD_METHOD("buildMethod"),
     VALUE_TYPE_VISIBILITY("valueTypeVisibility"),
     ;
 
@@ -91,6 +92,7 @@ abstract class Datatype_Builder {
       new LinkedHashMap<>();
   private boolean builderSerializable;
   private boolean hasToBuilderMethod;
+  private NameAndVisibility buildMethod;
   private List<Excerpt> generatedBuilderAnnotations = ImmutableList.of();
   private List<Excerpt> valueTypeAnnotations = ImmutableList.of();
   private Datatype.Visibility valueTypeVisibility;
@@ -662,6 +664,42 @@ abstract class Datatype_Builder {
   }
 
   /**
+   * Sets the value to be returned by {@link Datatype#getBuildMethod()}.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code buildMethod} is null
+   */
+  public Datatype.Builder setBuildMethod(NameAndVisibility buildMethod) {
+    this.buildMethod = Objects.requireNonNull(buildMethod);
+    _unsetProperties.remove(Property.BUILD_METHOD);
+    return (Datatype.Builder) this;
+  }
+
+  /**
+   * Replaces the value to be returned by {@link Datatype#getBuildMethod()} by applying {@code
+   * mapper} to it and using the result.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code mapper} is null or returns null
+   * @throws IllegalStateException if the field has not been set
+   */
+  public Datatype.Builder mapBuildMethod(UnaryOperator<NameAndVisibility> mapper) {
+    Objects.requireNonNull(mapper);
+    return setBuildMethod(mapper.apply(getBuildMethod()));
+  }
+
+  /**
+   * Returns the value that will be returned by {@link Datatype#getBuildMethod()}.
+   *
+   * @throws IllegalStateException if the field has not been set
+   */
+  public NameAndVisibility getBuildMethod() {
+    Preconditions.checkState(
+        !_unsetProperties.contains(Property.BUILD_METHOD), "buildMethod not set");
+    return buildMethod;
+  }
+
+  /**
    * Adds {@code element} to the list to be returned from {@link
    * Datatype#getGeneratedBuilderAnnotations()}.
    *
@@ -1093,6 +1131,10 @@ abstract class Datatype_Builder {
         || value.getHasToBuilderMethod() != defaults.getHasToBuilderMethod()) {
       setHasToBuilderMethod(value.getHasToBuilderMethod());
     }
+    if (defaults._unsetProperties.contains(Property.BUILD_METHOD)
+        || !Objects.equals(value.getBuildMethod(), defaults.getBuildMethod())) {
+      setBuildMethod(value.getBuildMethod());
+    }
     if (value instanceof Value && generatedBuilderAnnotations == ImmutableList.<Excerpt>of()) {
       generatedBuilderAnnotations = ImmutableList.copyOf(value.getGeneratedBuilderAnnotations());
     } else {
@@ -1178,6 +1220,11 @@ abstract class Datatype_Builder {
             || template.getHasToBuilderMethod() != defaults.getHasToBuilderMethod())) {
       setHasToBuilderMethod(template.getHasToBuilderMethod());
     }
+    if (!base._unsetProperties.contains(Property.BUILD_METHOD)
+        && (defaults._unsetProperties.contains(Property.BUILD_METHOD)
+            || !Objects.equals(template.getBuildMethod(), defaults.getBuildMethod()))) {
+      setBuildMethod(template.getBuildMethod());
+    }
     addAllGeneratedBuilderAnnotations(base.generatedBuilderAnnotations);
     addAllValueTypeAnnotations(base.valueTypeAnnotations);
     if (!base._unsetProperties.contains(Property.VALUE_TYPE_VISIBILITY)
@@ -1210,6 +1257,7 @@ abstract class Datatype_Builder {
     standardMethodUnderrides.clear();
     builderSerializable = defaults.builderSerializable;
     hasToBuilderMethod = defaults.hasToBuilderMethod;
+    buildMethod = defaults.buildMethod;
     clearGeneratedBuilderAnnotations();
     clearValueTypeAnnotations();
     valueTypeVisibility = defaults.valueTypeVisibility;
@@ -1271,6 +1319,7 @@ abstract class Datatype_Builder {
     private final ImmutableMap<StandardMethod, UnderrideLevel> standardMethodUnderrides;
     private final boolean builderSerializable;
     private final boolean hasToBuilderMethod;
+    private final NameAndVisibility buildMethod;
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
     private final Visibility valueTypeVisibility;
@@ -1290,6 +1339,7 @@ abstract class Datatype_Builder {
       this.standardMethodUnderrides = ImmutableMap.copyOf(builder.standardMethodUnderrides);
       this.builderSerializable = builder.builderSerializable;
       this.hasToBuilderMethod = builder.hasToBuilderMethod;
+      this.buildMethod = builder.buildMethod;
       this.generatedBuilderAnnotations = ImmutableList.copyOf(builder.generatedBuilderAnnotations);
       this.valueTypeAnnotations = ImmutableList.copyOf(builder.valueTypeAnnotations);
       this.valueTypeVisibility = builder.valueTypeVisibility;
@@ -1362,6 +1412,11 @@ abstract class Datatype_Builder {
     }
 
     @Override
+    public NameAndVisibility getBuildMethod() {
+      return buildMethod;
+    }
+
+    @Override
     public ImmutableList<Excerpt> getGeneratedBuilderAnnotations() {
       return generatedBuilderAnnotations;
     }
@@ -1397,6 +1452,7 @@ abstract class Datatype_Builder {
       builder.standardMethodUnderrides.putAll(standardMethodUnderrides);
       builder.builderSerializable = builderSerializable;
       builder.hasToBuilderMethod = hasToBuilderMethod;
+      builder.buildMethod = buildMethod;
       builder.generatedBuilderAnnotations = generatedBuilderAnnotations;
       builder.valueTypeAnnotations = valueTypeAnnotations;
       builder.valueTypeVisibility = valueTypeVisibility;
@@ -1424,6 +1480,7 @@ abstract class Datatype_Builder {
           && Objects.equals(standardMethodUnderrides, other.standardMethodUnderrides)
           && builderSerializable == other.builderSerializable
           && hasToBuilderMethod == other.hasToBuilderMethod
+          && Objects.equals(buildMethod, other.buildMethod)
           && Objects.equals(generatedBuilderAnnotations, other.generatedBuilderAnnotations)
           && Objects.equals(valueTypeAnnotations, other.valueTypeAnnotations)
           && Objects.equals(valueTypeVisibility, other.valueTypeVisibility)
@@ -1446,6 +1503,7 @@ abstract class Datatype_Builder {
           standardMethodUnderrides,
           builderSerializable,
           hasToBuilderMethod,
+          buildMethod,
           generatedBuilderAnnotations,
           valueTypeAnnotations,
           valueTypeVisibility,
@@ -1485,6 +1543,8 @@ abstract class Datatype_Builder {
           .append(builderSerializable)
           .append(", hasToBuilderMethod=")
           .append(hasToBuilderMethod)
+          .append(", buildMethod=")
+          .append(buildMethod)
           .append(", generatedBuilderAnnotations=")
           .append(generatedBuilderAnnotations)
           .append(", valueTypeAnnotations=")
@@ -1518,6 +1578,7 @@ abstract class Datatype_Builder {
     private final ImmutableMap<StandardMethod, UnderrideLevel> standardMethodUnderrides;
     private final boolean builderSerializable;
     private final boolean hasToBuilderMethod;
+    private final NameAndVisibility buildMethod;
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
     private final Visibility valueTypeVisibility;
@@ -1538,6 +1599,7 @@ abstract class Datatype_Builder {
       this.standardMethodUnderrides = ImmutableMap.copyOf(builder.standardMethodUnderrides);
       this.builderSerializable = builder.builderSerializable;
       this.hasToBuilderMethod = builder.hasToBuilderMethod;
+      this.buildMethod = builder.buildMethod;
       this.generatedBuilderAnnotations = ImmutableList.copyOf(builder.generatedBuilderAnnotations);
       this.valueTypeAnnotations = ImmutableList.copyOf(builder.valueTypeAnnotations);
       this.valueTypeVisibility = builder.valueTypeVisibility;
@@ -1641,6 +1703,14 @@ abstract class Datatype_Builder {
     }
 
     @Override
+    public NameAndVisibility getBuildMethod() {
+      if (_unsetProperties.contains(Property.BUILD_METHOD)) {
+        throw new UnsupportedOperationException("buildMethod not set");
+      }
+      return buildMethod;
+    }
+
+    @Override
     public ImmutableList<Excerpt> getGeneratedBuilderAnnotations() {
       return generatedBuilderAnnotations;
     }
@@ -1686,6 +1756,7 @@ abstract class Datatype_Builder {
       builder.standardMethodUnderrides.putAll(standardMethodUnderrides);
       builder.builderSerializable = builderSerializable;
       builder.hasToBuilderMethod = hasToBuilderMethod;
+      builder.buildMethod = buildMethod;
       builder.generatedBuilderAnnotations = generatedBuilderAnnotations;
       builder.valueTypeAnnotations = valueTypeAnnotations;
       builder.valueTypeVisibility = valueTypeVisibility;
@@ -1714,6 +1785,7 @@ abstract class Datatype_Builder {
           && Objects.equals(standardMethodUnderrides, other.standardMethodUnderrides)
           && builderSerializable == other.builderSerializable
           && hasToBuilderMethod == other.hasToBuilderMethod
+          && Objects.equals(buildMethod, other.buildMethod)
           && Objects.equals(generatedBuilderAnnotations, other.generatedBuilderAnnotations)
           && Objects.equals(valueTypeAnnotations, other.valueTypeAnnotations)
           && Objects.equals(valueTypeVisibility, other.valueTypeVisibility)
@@ -1737,6 +1809,7 @@ abstract class Datatype_Builder {
           standardMethodUnderrides,
           builderSerializable,
           hasToBuilderMethod,
+          buildMethod,
           generatedBuilderAnnotations,
           valueTypeAnnotations,
           valueTypeVisibility,
@@ -1783,6 +1856,9 @@ abstract class Datatype_Builder {
       }
       if (!_unsetProperties.contains(Property.HAS_TO_BUILDER_METHOD)) {
         result.append(", hasToBuilderMethod=").append(hasToBuilderMethod);
+      }
+      if (!_unsetProperties.contains(Property.BUILD_METHOD)) {
+        result.append(", buildMethod=").append(buildMethod);
       }
       result
           .append(", generatedBuilderAnnotations=")

--- a/generated/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
+++ b/generated/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
@@ -57,6 +57,7 @@ abstract class Datatype_Builder {
     BUILDER_SERIALIZABLE("builderSerializable"),
     HAS_TO_BUILDER_METHOD("hasToBuilderMethod"),
     BUILD_METHOD("buildMethod"),
+    BUILD_PARTIAL_METHOD("buildPartialMethod"),
     VALUE_TYPE_VISIBILITY("valueTypeVisibility"),
     ;
 
@@ -93,6 +94,7 @@ abstract class Datatype_Builder {
   private boolean builderSerializable;
   private boolean hasToBuilderMethod;
   private NameAndVisibility buildMethod;
+  private NameAndVisibility buildPartialMethod;
   private List<Excerpt> generatedBuilderAnnotations = ImmutableList.of();
   private List<Excerpt> valueTypeAnnotations = ImmutableList.of();
   private Datatype.Visibility valueTypeVisibility;
@@ -700,6 +702,42 @@ abstract class Datatype_Builder {
   }
 
   /**
+   * Sets the value to be returned by {@link Datatype#getBuildPartialMethod()}.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code buildPartialMethod} is null
+   */
+  public Datatype.Builder setBuildPartialMethod(NameAndVisibility buildPartialMethod) {
+    this.buildPartialMethod = Objects.requireNonNull(buildPartialMethod);
+    _unsetProperties.remove(Property.BUILD_PARTIAL_METHOD);
+    return (Datatype.Builder) this;
+  }
+
+  /**
+   * Replaces the value to be returned by {@link Datatype#getBuildPartialMethod()} by applying
+   * {@code mapper} to it and using the result.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code mapper} is null or returns null
+   * @throws IllegalStateException if the field has not been set
+   */
+  public Datatype.Builder mapBuildPartialMethod(UnaryOperator<NameAndVisibility> mapper) {
+    Objects.requireNonNull(mapper);
+    return setBuildPartialMethod(mapper.apply(getBuildPartialMethod()));
+  }
+
+  /**
+   * Returns the value that will be returned by {@link Datatype#getBuildPartialMethod()}.
+   *
+   * @throws IllegalStateException if the field has not been set
+   */
+  public NameAndVisibility getBuildPartialMethod() {
+    Preconditions.checkState(
+        !_unsetProperties.contains(Property.BUILD_PARTIAL_METHOD), "buildPartialMethod not set");
+    return buildPartialMethod;
+  }
+
+  /**
    * Adds {@code element} to the list to be returned from {@link
    * Datatype#getGeneratedBuilderAnnotations()}.
    *
@@ -1135,6 +1173,10 @@ abstract class Datatype_Builder {
         || !Objects.equals(value.getBuildMethod(), defaults.getBuildMethod())) {
       setBuildMethod(value.getBuildMethod());
     }
+    if (defaults._unsetProperties.contains(Property.BUILD_PARTIAL_METHOD)
+        || !Objects.equals(value.getBuildPartialMethod(), defaults.getBuildPartialMethod())) {
+      setBuildPartialMethod(value.getBuildPartialMethod());
+    }
     if (value instanceof Value && generatedBuilderAnnotations == ImmutableList.<Excerpt>of()) {
       generatedBuilderAnnotations = ImmutableList.copyOf(value.getGeneratedBuilderAnnotations());
     } else {
@@ -1225,6 +1267,12 @@ abstract class Datatype_Builder {
             || !Objects.equals(template.getBuildMethod(), defaults.getBuildMethod()))) {
       setBuildMethod(template.getBuildMethod());
     }
+    if (!base._unsetProperties.contains(Property.BUILD_PARTIAL_METHOD)
+        && (defaults._unsetProperties.contains(Property.BUILD_PARTIAL_METHOD)
+            || !Objects.equals(
+                template.getBuildPartialMethod(), defaults.getBuildPartialMethod()))) {
+      setBuildPartialMethod(template.getBuildPartialMethod());
+    }
     addAllGeneratedBuilderAnnotations(base.generatedBuilderAnnotations);
     addAllValueTypeAnnotations(base.valueTypeAnnotations);
     if (!base._unsetProperties.contains(Property.VALUE_TYPE_VISIBILITY)
@@ -1258,6 +1306,7 @@ abstract class Datatype_Builder {
     builderSerializable = defaults.builderSerializable;
     hasToBuilderMethod = defaults.hasToBuilderMethod;
     buildMethod = defaults.buildMethod;
+    buildPartialMethod = defaults.buildPartialMethod;
     clearGeneratedBuilderAnnotations();
     clearValueTypeAnnotations();
     valueTypeVisibility = defaults.valueTypeVisibility;
@@ -1320,6 +1369,7 @@ abstract class Datatype_Builder {
     private final boolean builderSerializable;
     private final boolean hasToBuilderMethod;
     private final NameAndVisibility buildMethod;
+    private final NameAndVisibility buildPartialMethod;
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
     private final Visibility valueTypeVisibility;
@@ -1340,6 +1390,7 @@ abstract class Datatype_Builder {
       this.builderSerializable = builder.builderSerializable;
       this.hasToBuilderMethod = builder.hasToBuilderMethod;
       this.buildMethod = builder.buildMethod;
+      this.buildPartialMethod = builder.buildPartialMethod;
       this.generatedBuilderAnnotations = ImmutableList.copyOf(builder.generatedBuilderAnnotations);
       this.valueTypeAnnotations = ImmutableList.copyOf(builder.valueTypeAnnotations);
       this.valueTypeVisibility = builder.valueTypeVisibility;
@@ -1417,6 +1468,11 @@ abstract class Datatype_Builder {
     }
 
     @Override
+    public NameAndVisibility getBuildPartialMethod() {
+      return buildPartialMethod;
+    }
+
+    @Override
     public ImmutableList<Excerpt> getGeneratedBuilderAnnotations() {
       return generatedBuilderAnnotations;
     }
@@ -1453,6 +1509,7 @@ abstract class Datatype_Builder {
       builder.builderSerializable = builderSerializable;
       builder.hasToBuilderMethod = hasToBuilderMethod;
       builder.buildMethod = buildMethod;
+      builder.buildPartialMethod = buildPartialMethod;
       builder.generatedBuilderAnnotations = generatedBuilderAnnotations;
       builder.valueTypeAnnotations = valueTypeAnnotations;
       builder.valueTypeVisibility = valueTypeVisibility;
@@ -1481,6 +1538,7 @@ abstract class Datatype_Builder {
           && builderSerializable == other.builderSerializable
           && hasToBuilderMethod == other.hasToBuilderMethod
           && Objects.equals(buildMethod, other.buildMethod)
+          && Objects.equals(buildPartialMethod, other.buildPartialMethod)
           && Objects.equals(generatedBuilderAnnotations, other.generatedBuilderAnnotations)
           && Objects.equals(valueTypeAnnotations, other.valueTypeAnnotations)
           && Objects.equals(valueTypeVisibility, other.valueTypeVisibility)
@@ -1504,6 +1562,7 @@ abstract class Datatype_Builder {
           builderSerializable,
           hasToBuilderMethod,
           buildMethod,
+          buildPartialMethod,
           generatedBuilderAnnotations,
           valueTypeAnnotations,
           valueTypeVisibility,
@@ -1545,6 +1604,8 @@ abstract class Datatype_Builder {
           .append(hasToBuilderMethod)
           .append(", buildMethod=")
           .append(buildMethod)
+          .append(", buildPartialMethod=")
+          .append(buildPartialMethod)
           .append(", generatedBuilderAnnotations=")
           .append(generatedBuilderAnnotations)
           .append(", valueTypeAnnotations=")
@@ -1579,6 +1640,7 @@ abstract class Datatype_Builder {
     private final boolean builderSerializable;
     private final boolean hasToBuilderMethod;
     private final NameAndVisibility buildMethod;
+    private final NameAndVisibility buildPartialMethod;
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
     private final Visibility valueTypeVisibility;
@@ -1600,6 +1662,7 @@ abstract class Datatype_Builder {
       this.builderSerializable = builder.builderSerializable;
       this.hasToBuilderMethod = builder.hasToBuilderMethod;
       this.buildMethod = builder.buildMethod;
+      this.buildPartialMethod = builder.buildPartialMethod;
       this.generatedBuilderAnnotations = ImmutableList.copyOf(builder.generatedBuilderAnnotations);
       this.valueTypeAnnotations = ImmutableList.copyOf(builder.valueTypeAnnotations);
       this.valueTypeVisibility = builder.valueTypeVisibility;
@@ -1711,6 +1774,14 @@ abstract class Datatype_Builder {
     }
 
     @Override
+    public NameAndVisibility getBuildPartialMethod() {
+      if (_unsetProperties.contains(Property.BUILD_PARTIAL_METHOD)) {
+        throw new UnsupportedOperationException("buildPartialMethod not set");
+      }
+      return buildPartialMethod;
+    }
+
+    @Override
     public ImmutableList<Excerpt> getGeneratedBuilderAnnotations() {
       return generatedBuilderAnnotations;
     }
@@ -1757,6 +1828,7 @@ abstract class Datatype_Builder {
       builder.builderSerializable = builderSerializable;
       builder.hasToBuilderMethod = hasToBuilderMethod;
       builder.buildMethod = buildMethod;
+      builder.buildPartialMethod = buildPartialMethod;
       builder.generatedBuilderAnnotations = generatedBuilderAnnotations;
       builder.valueTypeAnnotations = valueTypeAnnotations;
       builder.valueTypeVisibility = valueTypeVisibility;
@@ -1786,6 +1858,7 @@ abstract class Datatype_Builder {
           && builderSerializable == other.builderSerializable
           && hasToBuilderMethod == other.hasToBuilderMethod
           && Objects.equals(buildMethod, other.buildMethod)
+          && Objects.equals(buildPartialMethod, other.buildPartialMethod)
           && Objects.equals(generatedBuilderAnnotations, other.generatedBuilderAnnotations)
           && Objects.equals(valueTypeAnnotations, other.valueTypeAnnotations)
           && Objects.equals(valueTypeVisibility, other.valueTypeVisibility)
@@ -1810,6 +1883,7 @@ abstract class Datatype_Builder {
           builderSerializable,
           hasToBuilderMethod,
           buildMethod,
+          buildPartialMethod,
           generatedBuilderAnnotations,
           valueTypeAnnotations,
           valueTypeVisibility,
@@ -1859,6 +1933,9 @@ abstract class Datatype_Builder {
       }
       if (!_unsetProperties.contains(Property.BUILD_METHOD)) {
         result.append(", buildMethod=").append(buildMethod);
+      }
+      if (!_unsetProperties.contains(Property.BUILD_PARTIAL_METHOD)) {
+        result.append(", buildPartialMethod=").append(buildPartialMethod);
       }
       result
           .append(", generatedBuilderAnnotations=")

--- a/generated/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
+++ b/generated/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
@@ -59,6 +59,8 @@ abstract class Datatype_Builder {
     BUILD_METHOD("buildMethod"),
     BUILD_PARTIAL_METHOD("buildPartialMethod"),
     CLEAR_METHOD("clearMethod"),
+    MERGE_FROM_BUILDER_METHOD("mergeFromBuilderMethod"),
+    MERGE_FROM_VALUE_METHOD("mergeFromValueMethod"),
     VALUE_TYPE_VISIBILITY("valueTypeVisibility"),
     ;
 
@@ -97,6 +99,8 @@ abstract class Datatype_Builder {
   private NameAndVisibility buildMethod;
   private NameAndVisibility buildPartialMethod;
   private NameAndVisibility clearMethod;
+  private NameAndVisibility mergeFromBuilderMethod;
+  private NameAndVisibility mergeFromValueMethod;
   private List<Excerpt> generatedBuilderAnnotations = ImmutableList.of();
   private List<Excerpt> valueTypeAnnotations = ImmutableList.of();
   private Datatype.Visibility valueTypeVisibility;
@@ -776,6 +780,80 @@ abstract class Datatype_Builder {
   }
 
   /**
+   * Sets the value to be returned by {@link Datatype#getMergeFromBuilderMethod()}.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code mergeFromBuilderMethod} is null
+   */
+  public Datatype.Builder setMergeFromBuilderMethod(NameAndVisibility mergeFromBuilderMethod) {
+    this.mergeFromBuilderMethod = Objects.requireNonNull(mergeFromBuilderMethod);
+    _unsetProperties.remove(Property.MERGE_FROM_BUILDER_METHOD);
+    return (Datatype.Builder) this;
+  }
+
+  /**
+   * Replaces the value to be returned by {@link Datatype#getMergeFromBuilderMethod()} by applying
+   * {@code mapper} to it and using the result.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code mapper} is null or returns null
+   * @throws IllegalStateException if the field has not been set
+   */
+  public Datatype.Builder mapMergeFromBuilderMethod(UnaryOperator<NameAndVisibility> mapper) {
+    Objects.requireNonNull(mapper);
+    return setMergeFromBuilderMethod(mapper.apply(getMergeFromBuilderMethod()));
+  }
+
+  /**
+   * Returns the value that will be returned by {@link Datatype#getMergeFromBuilderMethod()}.
+   *
+   * @throws IllegalStateException if the field has not been set
+   */
+  public NameAndVisibility getMergeFromBuilderMethod() {
+    Preconditions.checkState(
+        !_unsetProperties.contains(Property.MERGE_FROM_BUILDER_METHOD),
+        "mergeFromBuilderMethod not set");
+    return mergeFromBuilderMethod;
+  }
+
+  /**
+   * Sets the value to be returned by {@link Datatype#getMergeFromValueMethod()}.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code mergeFromValueMethod} is null
+   */
+  public Datatype.Builder setMergeFromValueMethod(NameAndVisibility mergeFromValueMethod) {
+    this.mergeFromValueMethod = Objects.requireNonNull(mergeFromValueMethod);
+    _unsetProperties.remove(Property.MERGE_FROM_VALUE_METHOD);
+    return (Datatype.Builder) this;
+  }
+
+  /**
+   * Replaces the value to be returned by {@link Datatype#getMergeFromValueMethod()} by applying
+   * {@code mapper} to it and using the result.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code mapper} is null or returns null
+   * @throws IllegalStateException if the field has not been set
+   */
+  public Datatype.Builder mapMergeFromValueMethod(UnaryOperator<NameAndVisibility> mapper) {
+    Objects.requireNonNull(mapper);
+    return setMergeFromValueMethod(mapper.apply(getMergeFromValueMethod()));
+  }
+
+  /**
+   * Returns the value that will be returned by {@link Datatype#getMergeFromValueMethod()}.
+   *
+   * @throws IllegalStateException if the field has not been set
+   */
+  public NameAndVisibility getMergeFromValueMethod() {
+    Preconditions.checkState(
+        !_unsetProperties.contains(Property.MERGE_FROM_VALUE_METHOD),
+        "mergeFromValueMethod not set");
+    return mergeFromValueMethod;
+  }
+
+  /**
    * Adds {@code element} to the list to be returned from {@link
    * Datatype#getGeneratedBuilderAnnotations()}.
    *
@@ -1219,6 +1297,15 @@ abstract class Datatype_Builder {
         || !Objects.equals(value.getClearMethod(), defaults.getClearMethod())) {
       setClearMethod(value.getClearMethod());
     }
+    if (defaults._unsetProperties.contains(Property.MERGE_FROM_BUILDER_METHOD)
+        || !Objects.equals(
+            value.getMergeFromBuilderMethod(), defaults.getMergeFromBuilderMethod())) {
+      setMergeFromBuilderMethod(value.getMergeFromBuilderMethod());
+    }
+    if (defaults._unsetProperties.contains(Property.MERGE_FROM_VALUE_METHOD)
+        || !Objects.equals(value.getMergeFromValueMethod(), defaults.getMergeFromValueMethod())) {
+      setMergeFromValueMethod(value.getMergeFromValueMethod());
+    }
     if (value instanceof Value && generatedBuilderAnnotations == ImmutableList.<Excerpt>of()) {
       generatedBuilderAnnotations = ImmutableList.copyOf(value.getGeneratedBuilderAnnotations());
     } else {
@@ -1320,6 +1407,18 @@ abstract class Datatype_Builder {
             || !Objects.equals(template.getClearMethod(), defaults.getClearMethod()))) {
       setClearMethod(template.getClearMethod());
     }
+    if (!base._unsetProperties.contains(Property.MERGE_FROM_BUILDER_METHOD)
+        && (defaults._unsetProperties.contains(Property.MERGE_FROM_BUILDER_METHOD)
+            || !Objects.equals(
+                template.getMergeFromBuilderMethod(), defaults.getMergeFromBuilderMethod()))) {
+      setMergeFromBuilderMethod(template.getMergeFromBuilderMethod());
+    }
+    if (!base._unsetProperties.contains(Property.MERGE_FROM_VALUE_METHOD)
+        && (defaults._unsetProperties.contains(Property.MERGE_FROM_VALUE_METHOD)
+            || !Objects.equals(
+                template.getMergeFromValueMethod(), defaults.getMergeFromValueMethod()))) {
+      setMergeFromValueMethod(template.getMergeFromValueMethod());
+    }
     addAllGeneratedBuilderAnnotations(base.generatedBuilderAnnotations);
     addAllValueTypeAnnotations(base.valueTypeAnnotations);
     if (!base._unsetProperties.contains(Property.VALUE_TYPE_VISIBILITY)
@@ -1355,6 +1454,8 @@ abstract class Datatype_Builder {
     buildMethod = defaults.buildMethod;
     buildPartialMethod = defaults.buildPartialMethod;
     clearMethod = defaults.clearMethod;
+    mergeFromBuilderMethod = defaults.mergeFromBuilderMethod;
+    mergeFromValueMethod = defaults.mergeFromValueMethod;
     clearGeneratedBuilderAnnotations();
     clearValueTypeAnnotations();
     valueTypeVisibility = defaults.valueTypeVisibility;
@@ -1419,6 +1520,8 @@ abstract class Datatype_Builder {
     private final NameAndVisibility buildMethod;
     private final NameAndVisibility buildPartialMethod;
     private final NameAndVisibility clearMethod;
+    private final NameAndVisibility mergeFromBuilderMethod;
+    private final NameAndVisibility mergeFromValueMethod;
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
     private final Visibility valueTypeVisibility;
@@ -1441,6 +1544,8 @@ abstract class Datatype_Builder {
       this.buildMethod = builder.buildMethod;
       this.buildPartialMethod = builder.buildPartialMethod;
       this.clearMethod = builder.clearMethod;
+      this.mergeFromBuilderMethod = builder.mergeFromBuilderMethod;
+      this.mergeFromValueMethod = builder.mergeFromValueMethod;
       this.generatedBuilderAnnotations = ImmutableList.copyOf(builder.generatedBuilderAnnotations);
       this.valueTypeAnnotations = ImmutableList.copyOf(builder.valueTypeAnnotations);
       this.valueTypeVisibility = builder.valueTypeVisibility;
@@ -1528,6 +1633,16 @@ abstract class Datatype_Builder {
     }
 
     @Override
+    public NameAndVisibility getMergeFromBuilderMethod() {
+      return mergeFromBuilderMethod;
+    }
+
+    @Override
+    public NameAndVisibility getMergeFromValueMethod() {
+      return mergeFromValueMethod;
+    }
+
+    @Override
     public ImmutableList<Excerpt> getGeneratedBuilderAnnotations() {
       return generatedBuilderAnnotations;
     }
@@ -1566,6 +1681,8 @@ abstract class Datatype_Builder {
       builder.buildMethod = buildMethod;
       builder.buildPartialMethod = buildPartialMethod;
       builder.clearMethod = clearMethod;
+      builder.mergeFromBuilderMethod = mergeFromBuilderMethod;
+      builder.mergeFromValueMethod = mergeFromValueMethod;
       builder.generatedBuilderAnnotations = generatedBuilderAnnotations;
       builder.valueTypeAnnotations = valueTypeAnnotations;
       builder.valueTypeVisibility = valueTypeVisibility;
@@ -1596,6 +1713,8 @@ abstract class Datatype_Builder {
           && Objects.equals(buildMethod, other.buildMethod)
           && Objects.equals(buildPartialMethod, other.buildPartialMethod)
           && Objects.equals(clearMethod, other.clearMethod)
+          && Objects.equals(mergeFromBuilderMethod, other.mergeFromBuilderMethod)
+          && Objects.equals(mergeFromValueMethod, other.mergeFromValueMethod)
           && Objects.equals(generatedBuilderAnnotations, other.generatedBuilderAnnotations)
           && Objects.equals(valueTypeAnnotations, other.valueTypeAnnotations)
           && Objects.equals(valueTypeVisibility, other.valueTypeVisibility)
@@ -1621,6 +1740,8 @@ abstract class Datatype_Builder {
           buildMethod,
           buildPartialMethod,
           clearMethod,
+          mergeFromBuilderMethod,
+          mergeFromValueMethod,
           generatedBuilderAnnotations,
           valueTypeAnnotations,
           valueTypeVisibility,
@@ -1666,6 +1787,10 @@ abstract class Datatype_Builder {
           .append(buildPartialMethod)
           .append(", clearMethod=")
           .append(clearMethod)
+          .append(", mergeFromBuilderMethod=")
+          .append(mergeFromBuilderMethod)
+          .append(", mergeFromValueMethod=")
+          .append(mergeFromValueMethod)
           .append(", generatedBuilderAnnotations=")
           .append(generatedBuilderAnnotations)
           .append(", valueTypeAnnotations=")
@@ -1702,6 +1827,8 @@ abstract class Datatype_Builder {
     private final NameAndVisibility buildMethod;
     private final NameAndVisibility buildPartialMethod;
     private final NameAndVisibility clearMethod;
+    private final NameAndVisibility mergeFromBuilderMethod;
+    private final NameAndVisibility mergeFromValueMethod;
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
     private final Visibility valueTypeVisibility;
@@ -1725,6 +1852,8 @@ abstract class Datatype_Builder {
       this.buildMethod = builder.buildMethod;
       this.buildPartialMethod = builder.buildPartialMethod;
       this.clearMethod = builder.clearMethod;
+      this.mergeFromBuilderMethod = builder.mergeFromBuilderMethod;
+      this.mergeFromValueMethod = builder.mergeFromValueMethod;
       this.generatedBuilderAnnotations = ImmutableList.copyOf(builder.generatedBuilderAnnotations);
       this.valueTypeAnnotations = ImmutableList.copyOf(builder.valueTypeAnnotations);
       this.valueTypeVisibility = builder.valueTypeVisibility;
@@ -1852,6 +1981,22 @@ abstract class Datatype_Builder {
     }
 
     @Override
+    public NameAndVisibility getMergeFromBuilderMethod() {
+      if (_unsetProperties.contains(Property.MERGE_FROM_BUILDER_METHOD)) {
+        throw new UnsupportedOperationException("mergeFromBuilderMethod not set");
+      }
+      return mergeFromBuilderMethod;
+    }
+
+    @Override
+    public NameAndVisibility getMergeFromValueMethod() {
+      if (_unsetProperties.contains(Property.MERGE_FROM_VALUE_METHOD)) {
+        throw new UnsupportedOperationException("mergeFromValueMethod not set");
+      }
+      return mergeFromValueMethod;
+    }
+
+    @Override
     public ImmutableList<Excerpt> getGeneratedBuilderAnnotations() {
       return generatedBuilderAnnotations;
     }
@@ -1900,6 +2045,8 @@ abstract class Datatype_Builder {
       builder.buildMethod = buildMethod;
       builder.buildPartialMethod = buildPartialMethod;
       builder.clearMethod = clearMethod;
+      builder.mergeFromBuilderMethod = mergeFromBuilderMethod;
+      builder.mergeFromValueMethod = mergeFromValueMethod;
       builder.generatedBuilderAnnotations = generatedBuilderAnnotations;
       builder.valueTypeAnnotations = valueTypeAnnotations;
       builder.valueTypeVisibility = valueTypeVisibility;
@@ -1931,6 +2078,8 @@ abstract class Datatype_Builder {
           && Objects.equals(buildMethod, other.buildMethod)
           && Objects.equals(buildPartialMethod, other.buildPartialMethod)
           && Objects.equals(clearMethod, other.clearMethod)
+          && Objects.equals(mergeFromBuilderMethod, other.mergeFromBuilderMethod)
+          && Objects.equals(mergeFromValueMethod, other.mergeFromValueMethod)
           && Objects.equals(generatedBuilderAnnotations, other.generatedBuilderAnnotations)
           && Objects.equals(valueTypeAnnotations, other.valueTypeAnnotations)
           && Objects.equals(valueTypeVisibility, other.valueTypeVisibility)
@@ -1957,6 +2106,8 @@ abstract class Datatype_Builder {
           buildMethod,
           buildPartialMethod,
           clearMethod,
+          mergeFromBuilderMethod,
+          mergeFromValueMethod,
           generatedBuilderAnnotations,
           valueTypeAnnotations,
           valueTypeVisibility,
@@ -2012,6 +2163,12 @@ abstract class Datatype_Builder {
       }
       if (!_unsetProperties.contains(Property.CLEAR_METHOD)) {
         result.append(", clearMethod=").append(clearMethod);
+      }
+      if (!_unsetProperties.contains(Property.MERGE_FROM_BUILDER_METHOD)) {
+        result.append(", mergeFromBuilderMethod=").append(mergeFromBuilderMethod);
+      }
+      if (!_unsetProperties.contains(Property.MERGE_FROM_VALUE_METHOD)) {
+        result.append(", mergeFromValueMethod=").append(mergeFromValueMethod);
       }
       result
           .append(", generatedBuilderAnnotations=")

--- a/generated/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
+++ b/generated/main/java/org/inferred/freebuilder/processor/Datatype_Builder.java
@@ -58,6 +58,7 @@ abstract class Datatype_Builder {
     HAS_TO_BUILDER_METHOD("hasToBuilderMethod"),
     BUILD_METHOD("buildMethod"),
     BUILD_PARTIAL_METHOD("buildPartialMethod"),
+    CLEAR_METHOD("clearMethod"),
     VALUE_TYPE_VISIBILITY("valueTypeVisibility"),
     ;
 
@@ -95,6 +96,7 @@ abstract class Datatype_Builder {
   private boolean hasToBuilderMethod;
   private NameAndVisibility buildMethod;
   private NameAndVisibility buildPartialMethod;
+  private NameAndVisibility clearMethod;
   private List<Excerpt> generatedBuilderAnnotations = ImmutableList.of();
   private List<Excerpt> valueTypeAnnotations = ImmutableList.of();
   private Datatype.Visibility valueTypeVisibility;
@@ -738,6 +740,42 @@ abstract class Datatype_Builder {
   }
 
   /**
+   * Sets the value to be returned by {@link Datatype#getClearMethod()}.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code clearMethod} is null
+   */
+  public Datatype.Builder setClearMethod(NameAndVisibility clearMethod) {
+    this.clearMethod = Objects.requireNonNull(clearMethod);
+    _unsetProperties.remove(Property.CLEAR_METHOD);
+    return (Datatype.Builder) this;
+  }
+
+  /**
+   * Replaces the value to be returned by {@link Datatype#getClearMethod()} by applying {@code
+   * mapper} to it and using the result.
+   *
+   * @return this {@code Builder} object
+   * @throws NullPointerException if {@code mapper} is null or returns null
+   * @throws IllegalStateException if the field has not been set
+   */
+  public Datatype.Builder mapClearMethod(UnaryOperator<NameAndVisibility> mapper) {
+    Objects.requireNonNull(mapper);
+    return setClearMethod(mapper.apply(getClearMethod()));
+  }
+
+  /**
+   * Returns the value that will be returned by {@link Datatype#getClearMethod()}.
+   *
+   * @throws IllegalStateException if the field has not been set
+   */
+  public NameAndVisibility getClearMethod() {
+    Preconditions.checkState(
+        !_unsetProperties.contains(Property.CLEAR_METHOD), "clearMethod not set");
+    return clearMethod;
+  }
+
+  /**
    * Adds {@code element} to the list to be returned from {@link
    * Datatype#getGeneratedBuilderAnnotations()}.
    *
@@ -1177,6 +1215,10 @@ abstract class Datatype_Builder {
         || !Objects.equals(value.getBuildPartialMethod(), defaults.getBuildPartialMethod())) {
       setBuildPartialMethod(value.getBuildPartialMethod());
     }
+    if (defaults._unsetProperties.contains(Property.CLEAR_METHOD)
+        || !Objects.equals(value.getClearMethod(), defaults.getClearMethod())) {
+      setClearMethod(value.getClearMethod());
+    }
     if (value instanceof Value && generatedBuilderAnnotations == ImmutableList.<Excerpt>of()) {
       generatedBuilderAnnotations = ImmutableList.copyOf(value.getGeneratedBuilderAnnotations());
     } else {
@@ -1273,6 +1315,11 @@ abstract class Datatype_Builder {
                 template.getBuildPartialMethod(), defaults.getBuildPartialMethod()))) {
       setBuildPartialMethod(template.getBuildPartialMethod());
     }
+    if (!base._unsetProperties.contains(Property.CLEAR_METHOD)
+        && (defaults._unsetProperties.contains(Property.CLEAR_METHOD)
+            || !Objects.equals(template.getClearMethod(), defaults.getClearMethod()))) {
+      setClearMethod(template.getClearMethod());
+    }
     addAllGeneratedBuilderAnnotations(base.generatedBuilderAnnotations);
     addAllValueTypeAnnotations(base.valueTypeAnnotations);
     if (!base._unsetProperties.contains(Property.VALUE_TYPE_VISIBILITY)
@@ -1307,6 +1354,7 @@ abstract class Datatype_Builder {
     hasToBuilderMethod = defaults.hasToBuilderMethod;
     buildMethod = defaults.buildMethod;
     buildPartialMethod = defaults.buildPartialMethod;
+    clearMethod = defaults.clearMethod;
     clearGeneratedBuilderAnnotations();
     clearValueTypeAnnotations();
     valueTypeVisibility = defaults.valueTypeVisibility;
@@ -1370,6 +1418,7 @@ abstract class Datatype_Builder {
     private final boolean hasToBuilderMethod;
     private final NameAndVisibility buildMethod;
     private final NameAndVisibility buildPartialMethod;
+    private final NameAndVisibility clearMethod;
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
     private final Visibility valueTypeVisibility;
@@ -1391,6 +1440,7 @@ abstract class Datatype_Builder {
       this.hasToBuilderMethod = builder.hasToBuilderMethod;
       this.buildMethod = builder.buildMethod;
       this.buildPartialMethod = builder.buildPartialMethod;
+      this.clearMethod = builder.clearMethod;
       this.generatedBuilderAnnotations = ImmutableList.copyOf(builder.generatedBuilderAnnotations);
       this.valueTypeAnnotations = ImmutableList.copyOf(builder.valueTypeAnnotations);
       this.valueTypeVisibility = builder.valueTypeVisibility;
@@ -1473,6 +1523,11 @@ abstract class Datatype_Builder {
     }
 
     @Override
+    public NameAndVisibility getClearMethod() {
+      return clearMethod;
+    }
+
+    @Override
     public ImmutableList<Excerpt> getGeneratedBuilderAnnotations() {
       return generatedBuilderAnnotations;
     }
@@ -1510,6 +1565,7 @@ abstract class Datatype_Builder {
       builder.hasToBuilderMethod = hasToBuilderMethod;
       builder.buildMethod = buildMethod;
       builder.buildPartialMethod = buildPartialMethod;
+      builder.clearMethod = clearMethod;
       builder.generatedBuilderAnnotations = generatedBuilderAnnotations;
       builder.valueTypeAnnotations = valueTypeAnnotations;
       builder.valueTypeVisibility = valueTypeVisibility;
@@ -1539,6 +1595,7 @@ abstract class Datatype_Builder {
           && hasToBuilderMethod == other.hasToBuilderMethod
           && Objects.equals(buildMethod, other.buildMethod)
           && Objects.equals(buildPartialMethod, other.buildPartialMethod)
+          && Objects.equals(clearMethod, other.clearMethod)
           && Objects.equals(generatedBuilderAnnotations, other.generatedBuilderAnnotations)
           && Objects.equals(valueTypeAnnotations, other.valueTypeAnnotations)
           && Objects.equals(valueTypeVisibility, other.valueTypeVisibility)
@@ -1563,6 +1620,7 @@ abstract class Datatype_Builder {
           hasToBuilderMethod,
           buildMethod,
           buildPartialMethod,
+          clearMethod,
           generatedBuilderAnnotations,
           valueTypeAnnotations,
           valueTypeVisibility,
@@ -1606,6 +1664,8 @@ abstract class Datatype_Builder {
           .append(buildMethod)
           .append(", buildPartialMethod=")
           .append(buildPartialMethod)
+          .append(", clearMethod=")
+          .append(clearMethod)
           .append(", generatedBuilderAnnotations=")
           .append(generatedBuilderAnnotations)
           .append(", valueTypeAnnotations=")
@@ -1641,6 +1701,7 @@ abstract class Datatype_Builder {
     private final boolean hasToBuilderMethod;
     private final NameAndVisibility buildMethod;
     private final NameAndVisibility buildPartialMethod;
+    private final NameAndVisibility clearMethod;
     private final ImmutableList<Excerpt> generatedBuilderAnnotations;
     private final ImmutableList<Excerpt> valueTypeAnnotations;
     private final Visibility valueTypeVisibility;
@@ -1663,6 +1724,7 @@ abstract class Datatype_Builder {
       this.hasToBuilderMethod = builder.hasToBuilderMethod;
       this.buildMethod = builder.buildMethod;
       this.buildPartialMethod = builder.buildPartialMethod;
+      this.clearMethod = builder.clearMethod;
       this.generatedBuilderAnnotations = ImmutableList.copyOf(builder.generatedBuilderAnnotations);
       this.valueTypeAnnotations = ImmutableList.copyOf(builder.valueTypeAnnotations);
       this.valueTypeVisibility = builder.valueTypeVisibility;
@@ -1782,6 +1844,14 @@ abstract class Datatype_Builder {
     }
 
     @Override
+    public NameAndVisibility getClearMethod() {
+      if (_unsetProperties.contains(Property.CLEAR_METHOD)) {
+        throw new UnsupportedOperationException("clearMethod not set");
+      }
+      return clearMethod;
+    }
+
+    @Override
     public ImmutableList<Excerpt> getGeneratedBuilderAnnotations() {
       return generatedBuilderAnnotations;
     }
@@ -1829,6 +1899,7 @@ abstract class Datatype_Builder {
       builder.hasToBuilderMethod = hasToBuilderMethod;
       builder.buildMethod = buildMethod;
       builder.buildPartialMethod = buildPartialMethod;
+      builder.clearMethod = clearMethod;
       builder.generatedBuilderAnnotations = generatedBuilderAnnotations;
       builder.valueTypeAnnotations = valueTypeAnnotations;
       builder.valueTypeVisibility = valueTypeVisibility;
@@ -1859,6 +1930,7 @@ abstract class Datatype_Builder {
           && hasToBuilderMethod == other.hasToBuilderMethod
           && Objects.equals(buildMethod, other.buildMethod)
           && Objects.equals(buildPartialMethod, other.buildPartialMethod)
+          && Objects.equals(clearMethod, other.clearMethod)
           && Objects.equals(generatedBuilderAnnotations, other.generatedBuilderAnnotations)
           && Objects.equals(valueTypeAnnotations, other.valueTypeAnnotations)
           && Objects.equals(valueTypeVisibility, other.valueTypeVisibility)
@@ -1884,6 +1956,7 @@ abstract class Datatype_Builder {
           hasToBuilderMethod,
           buildMethod,
           buildPartialMethod,
+          clearMethod,
           generatedBuilderAnnotations,
           valueTypeAnnotations,
           valueTypeVisibility,
@@ -1936,6 +2009,9 @@ abstract class Datatype_Builder {
       }
       if (!_unsetProperties.contains(Property.BUILD_PARTIAL_METHOD)) {
         result.append(", buildPartialMethod=").append(buildPartialMethod);
+      }
+      if (!_unsetProperties.contains(Property.CLEAR_METHOD)) {
+        result.append(", clearMethod=").append(clearMethod);
       }
       result
           .append(", generatedBuilderAnnotations=")

--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.transform;
 
 import static org.inferred.freebuilder.processor.GwtSupport.gwtMetadata;
+import static org.inferred.freebuilder.processor.NamePicker.pickName;
 import static org.inferred.freebuilder.processor.model.MethodFinder.methodsOn;
 import static org.inferred.freebuilder.processor.model.ModelUtils.asElement;
 import static org.inferred.freebuilder.processor.model.ModelUtils.getReturnType;
@@ -144,6 +145,7 @@ class Analyser {
         .setPartialType(partialType.withParameters(typeParameters))
         .setPropertyEnum(propertyType.withParameters())
         .putAllStandardMethodUnderrides(findUnderriddenMethods(methods))
+        .setBuildMethod(pickName(builder, elements, types, type.asType(), "build"))
         .setHasToBuilderMethod(hasToBuilderMethod(
             builder, constructionAndExtension.isExtensible(), methods))
         .setBuilderSerializable(shouldBuilderBeSerializable(builder))

--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -148,6 +148,10 @@ class Analyser {
         .setBuildMethod(pickName(builder, elements, types, type.asType(), "build"))
         .setBuildPartialMethod(pickName(builder, elements, types, type.asType(), "buildPartial"))
         .setClearMethod(pickName(builder, elements, types, builder, "clear"))
+        .setMergeFromBuilderMethod(pickName(
+            builder, elements, types, builder, "mergeFrom", builder))
+        .setMergeFromValueMethod(pickName(
+            builder, elements, types, builder, "mergeFrom", type.asType()))
         .setHasToBuilderMethod(hasToBuilderMethod(
             builder, constructionAndExtension.isExtensible(), methods))
         .setBuilderSerializable(shouldBuilderBeSerializable(builder))

--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -146,6 +146,7 @@ class Analyser {
         .setPropertyEnum(propertyType.withParameters())
         .putAllStandardMethodUnderrides(findUnderriddenMethods(methods))
         .setBuildMethod(pickName(builder, elements, types, type.asType(), "build"))
+        .setBuildPartialMethod(pickName(builder, elements, types, type.asType(), "buildPartial"))
         .setHasToBuilderMethod(hasToBuilderMethod(
             builder, constructionAndExtension.isExtensible(), methods))
         .setBuilderSerializable(shouldBuilderBeSerializable(builder))

--- a/src/main/java/org/inferred/freebuilder/processor/Analyser.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Analyser.java
@@ -147,6 +147,7 @@ class Analyser {
         .putAllStandardMethodUnderrides(findUnderriddenMethods(methods))
         .setBuildMethod(pickName(builder, elements, types, type.asType(), "build"))
         .setBuildPartialMethod(pickName(builder, elements, types, type.asType(), "buildPartial"))
+        .setClearMethod(pickName(builder, elements, types, builder, "clear"))
         .setHasToBuilderMethod(hasToBuilderMethod(
             builder, constructionAndExtension.isExtensible(), methods))
         .setBuilderSerializable(shouldBuilderBeSerializable(builder))

--- a/src/main/java/org/inferred/freebuilder/processor/BuildableType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildableType.java
@@ -140,7 +140,10 @@ public abstract class BuildableType {
       // Make sure the user isn't preventing us generating required methods.
       if (methodIsObscured(builderMirror, elements, types, type, "build")
          || methodIsObscured(builderMirror, elements, types, type, "buildPartial")
-         || methodIsObscured(builderMirror, elements, types, builderMirror, "clear")) {
+         || methodIsObscured(builderMirror, elements, types, builderMirror, "clear")
+         || methodIsObscured(
+             builderMirror, elements, types, builderMirror, "mergeFrom", builderMirror)
+         || methodIsObscured(builderMirror, elements, types, builderMirror, "mergeFrom", type)) {
         return Optional.empty();
       }
     } else {
@@ -179,9 +182,10 @@ public abstract class BuildableType {
       Elements elements,
       Types types,
       DeclaredType returnType,
-      String methodName) {
+      String methodName,
+      DeclaredType... parameterTypes) {
     NameAndVisibility buildMethod =
-        pickName(targetType, elements, types, returnType, methodName);
+        pickName(targetType, elements, types, returnType, methodName, parameterTypes);
     return buildMethod.name() != methodName || buildMethod.visibility() != Visibility.PUBLIC;
   }
 

--- a/src/main/java/org/inferred/freebuilder/processor/BuildableType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildableType.java
@@ -139,7 +139,8 @@ public abstract class BuildableType {
     if (findAnnotationMirror(element, FreeBuilder.class).isPresent()) {
       // Make sure the user isn't preventing us generating required methods.
       if (methodIsObscured(builderMirror, elements, types, type, "build")
-         || methodIsObscured(builderMirror, elements, types, type, "buildPartial")) {
+         || methodIsObscured(builderMirror, elements, types, type, "buildPartial")
+         || methodIsObscured(builderMirror, elements, types, builderMirror, "clear")) {
         return Optional.empty();
       }
     } else {

--- a/src/main/java/org/inferred/freebuilder/processor/BuildableType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildableType.java
@@ -15,6 +15,7 @@
  */
 package org.inferred.freebuilder.processor;
 
+import static org.inferred.freebuilder.processor.NamePicker.pickName;
 import static org.inferred.freebuilder.processor.model.ModelUtils.asElement;
 import static org.inferred.freebuilder.processor.model.ModelUtils.findAnnotationMirror;
 import static org.inferred.freebuilder.processor.model.ModelUtils.needsSafeVarargs;
@@ -24,6 +25,7 @@ import static java.util.stream.Collectors.toList;
 import static javax.lang.model.element.Modifier.PUBLIC;
 
 import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.Datatype.Visibility;
 import org.inferred.freebuilder.processor.source.Excerpt;
 import org.inferred.freebuilder.processor.source.Excerpts;
 import org.inferred.freebuilder.processor.source.Type;
@@ -134,7 +136,14 @@ public abstract class BuildableType {
      * probably skip this for @FreeBuilder-types anyway, to avoid extra types whenever possible,
      * which leaves a lot of complicated code supporting a currently non-existent edge case.
      */
-    if (!findAnnotationMirror(element, FreeBuilder.class).isPresent()) {
+    if (findAnnotationMirror(element, FreeBuilder.class).isPresent()) {
+      // Make sure the user isn't preventing us generating required methods.
+      NameAndVisibility buildMethod =
+          pickName(builderMirror, elements, types, element.asType(), "build");
+      if (buildMethod.name() != "build" || buildMethod.visibility() != Visibility.PUBLIC) {
+        return Optional.empty();
+      }
+    } else {
       List<ExecutableElement> methods = elements.getAllMembers(builder)
           .stream()
           .flatMap(METHODS)

--- a/src/main/java/org/inferred/freebuilder/processor/BuildableType.java
+++ b/src/main/java/org/inferred/freebuilder/processor/BuildableType.java
@@ -138,9 +138,8 @@ public abstract class BuildableType {
      */
     if (findAnnotationMirror(element, FreeBuilder.class).isPresent()) {
       // Make sure the user isn't preventing us generating required methods.
-      NameAndVisibility buildMethod =
-          pickName(builderMirror, elements, types, element.asType(), "build");
-      if (buildMethod.name() != "build" || buildMethod.visibility() != Visibility.PUBLIC) {
+      if (methodIsObscured(builderMirror, elements, types, type, "build")
+         || methodIsObscured(builderMirror, elements, types, type, "buildPartial")) {
         return Optional.empty();
       }
     } else {
@@ -172,6 +171,17 @@ public abstract class BuildableType {
     }
 
     return Optional.of(builderMirror);
+  }
+
+  private static boolean methodIsObscured(
+      DeclaredType targetType,
+      Elements elements,
+      Types types,
+      DeclaredType returnType,
+      String methodName) {
+    NameAndVisibility buildMethod =
+        pickName(targetType, elements, types, returnType, methodName);
+    return buildMethod.name() != methodName || buildMethod.visibility() != Visibility.PUBLIC;
   }
 
   public static BuildableType create(

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -137,6 +137,12 @@ public abstract class Datatype {
   /** Returns the clear method to be generated. */
   public abstract NameAndVisibility getClearMethod();
 
+  /** Returns the mergeFrom(Builder) method to be generated. */
+  public abstract NameAndVisibility getMergeFromBuilderMethod();
+
+  /** Returns the mergeFrom(Value) method to be generated. */
+  public abstract NameAndVisibility getMergeFromValueMethod();
+
   /** Returns a list of annotations that should be applied to the generated builder class. */
   public abstract ImmutableList<Excerpt> getGeneratedBuilderAnnotations();
 
@@ -160,6 +166,8 @@ public abstract class Datatype {
       super.setBuildMethod(NameAndVisibility.of("build", Visibility.PUBLIC));
       super.setBuildPartialMethod(NameAndVisibility.of("buildPartial", Visibility.PUBLIC));
       super.setClearMethod(NameAndVisibility.of("clear", Visibility.PUBLIC));
+      super.setMergeFromBuilderMethod(NameAndVisibility.of("mergeFrom", Visibility.PUBLIC));
+      super.setMergeFromValueMethod(NameAndVisibility.of("mergeFrom", Visibility.PUBLIC));
       super.setValueTypeVisibility(Visibility.PRIVATE);
       super.setHasToBuilderMethod(false);
     }

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -128,6 +128,9 @@ public abstract class Datatype {
   /** Returns whether the value type has a toBuilder method that needs to be generated. */
   public abstract boolean getHasToBuilderMethod();
 
+  /** Returns the build method to be generated. */
+  public abstract NameAndVisibility getBuildMethod();
+
   /** Returns a list of annotations that should be applied to the generated builder class. */
   public abstract ImmutableList<Excerpt> getGeneratedBuilderAnnotations();
 
@@ -148,6 +151,7 @@ public abstract class Datatype {
   public static class Builder extends Datatype_Builder {
 
     public Builder() {
+      super.setBuildMethod(NameAndVisibility.of("build", Visibility.PUBLIC));
       super.setValueTypeVisibility(Visibility.PRIVATE);
       super.setHasToBuilderMethod(false);
     }

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -134,6 +134,9 @@ public abstract class Datatype {
   /** Returns the partial build method to be generated. */
   public abstract NameAndVisibility getBuildPartialMethod();
 
+  /** Returns the clear method to be generated. */
+  public abstract NameAndVisibility getClearMethod();
+
   /** Returns a list of annotations that should be applied to the generated builder class. */
   public abstract ImmutableList<Excerpt> getGeneratedBuilderAnnotations();
 
@@ -156,6 +159,7 @@ public abstract class Datatype {
     public Builder() {
       super.setBuildMethod(NameAndVisibility.of("build", Visibility.PUBLIC));
       super.setBuildPartialMethod(NameAndVisibility.of("buildPartial", Visibility.PUBLIC));
+      super.setClearMethod(NameAndVisibility.of("clear", Visibility.PUBLIC));
       super.setValueTypeVisibility(Visibility.PRIVATE);
       super.setHasToBuilderMethod(false);
     }

--- a/src/main/java/org/inferred/freebuilder/processor/Datatype.java
+++ b/src/main/java/org/inferred/freebuilder/processor/Datatype.java
@@ -131,6 +131,9 @@ public abstract class Datatype {
   /** Returns the build method to be generated. */
   public abstract NameAndVisibility getBuildMethod();
 
+  /** Returns the partial build method to be generated. */
+  public abstract NameAndVisibility getBuildPartialMethod();
+
   /** Returns a list of annotations that should be applied to the generated builder class. */
   public abstract ImmutableList<Excerpt> getGeneratedBuilderAnnotations();
 
@@ -152,6 +155,7 @@ public abstract class Datatype {
 
     public Builder() {
       super.setBuildMethod(NameAndVisibility.of("build", Visibility.PUBLIC));
+      super.setBuildPartialMethod(NameAndVisibility.of("buildPartial", Visibility.PUBLIC));
       super.setValueTypeVisibility(Visibility.PRIVATE);
       super.setHasToBuilderMethod(false);
     }

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
@@ -149,8 +149,9 @@ public class GeneratedBuilder extends GeneratedType {
       code.addLine("  if (value instanceof %s) {", rebuildable.getQualifiedName())
           .addLine("    return ((%s) value).toBuilder();", rebuildable)
           .addLine("  } else {")
-          .addLine("    return %s.mergeFrom(value);",
-              builderFactory.newBuilder(datatype.getBuilder(), EXPLICIT_TYPES))
+          .addLine("    return %s.%s(value);",
+              builderFactory.newBuilder(datatype.getBuilder(), EXPLICIT_TYPES),
+              datatype.getMergeFromValueMethod().name())
           .addLine("  }");
     }
     code.addLine("}");
@@ -202,7 +203,11 @@ public class GeneratedBuilder extends GeneratedType {
         .addLine(" *")
         .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */")
-        .addLine("public %s mergeFrom(%s value) {", datatype.getBuilder(), datatype.getType());
+        .addLine("%s%s %s(%s value) {",
+            datatype.getMergeFromValueMethod().visibility(),
+            datatype.getBuilder(),
+            datatype.getMergeFromValueMethod().name(),
+            datatype.getType());
     generatorsByProperty.values().forEach(generator -> generator.addMergeFromValue(code, "value"));
     code.addLine("  return (%s) this;", datatype.getBuilder())
         .addLine("}");
@@ -216,7 +221,10 @@ public class GeneratedBuilder extends GeneratedType {
         .addLine(" *")
         .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */")
-        .addLine("public %1$s mergeFrom(%1$s template) {", datatype.getBuilder());
+        .addLine("%1$s%2$s %3$s(%2$s template) {",
+            datatype.getMergeFromBuilderMethod().visibility(),
+            datatype.getBuilder(),
+            datatype.getMergeFromBuilderMethod().name());
     generatorsByProperty.values().forEach(generator -> {
       generator.addMergeFromBuilder(code, "template");
     });

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
@@ -182,7 +182,10 @@ public class GeneratedBuilder extends GeneratedType {
           .addLine(" * @throws IllegalStateException if any field has not been set");
     }
     code.addLine(" */")
-        .addLine("public %s build() {", datatype.getType());
+        .addLine("%s%s %s() {",
+            datatype.getBuildMethod().visibility(),
+            datatype.getType(),
+            datatype.getBuildMethod().name());
     if (hasRequiredProperties) {
       code.add(PreconditionExcerpts.checkState(
           "%1$s.isEmpty()", "Not set: %1$s", UNSET_PROPERTIES));
@@ -268,7 +271,9 @@ public class GeneratedBuilder extends GeneratedType {
     }
     code.addLine("will propagate the partial status of its input, overriding")
         .addLine(" * %s to return another partial.",
-            datatype.getBuilder().javadocNoArgMethodLink("build").withText("build()"))
+            datatype.getBuilder()
+                .javadocNoArgMethodLink(datatype.getBuildMethod().name())
+                .withText(datatype.getBuildMethod().name() + "()"))
         .addLine(" * This allows for robust tests of modify-rebuild code.")
         .addLine(" *")
         .addLine(" * <p>Partials should only ever be used in tests. They permit writing robust")
@@ -535,7 +540,8 @@ public class GeneratedBuilder extends GeneratedType {
       code.addLine("")
           .addLine("  private static class PartialBuilder%s extends %s {",
               datatype.getType().declarationParameters(), datatype.getBuilder())
-          .addLine("    @Override public %s build() {", datatype.getType())
+          .addLine("    @Override public %s %s() {",
+              datatype.getType(), datatype.getBuildMethod().name())
           .addLine("      return buildPartial();")
           .addLine("    }")
           .addLine("  }");

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
@@ -238,7 +238,10 @@ public class GeneratedBuilder extends GeneratedType {
         .addLine(" *")
         .addLine(" * @return this {@code %s} object", datatype.getBuilder().getSimpleName())
         .addLine(" */")
-        .addLine("public %s clear() {", datatype.getBuilder());
+        .addLine("%s%s %s() {",
+            datatype.getClearMethod().visibility(),
+            datatype.getBuilder(),
+            datatype.getClearMethod().name());
     generatorsByProperty.values().forEach(codeGenerator -> {
       codeGenerator.addClearField(code);
     });

--- a/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GeneratedBuilder.java
@@ -284,7 +284,10 @@ public class GeneratedBuilder extends GeneratedType {
     if (code.feature(GUAVA).isAvailable()) {
       code.addLine("@%s()", VisibleForTesting.class);
     }
-    code.addLine("public %s buildPartial() {", datatype.getType())
+    code.addLine("%s%s %s() {",
+            datatype.getBuildPartialMethod().visibility(),
+            datatype.getType(),
+            datatype.getBuildPartialMethod().name())
         .addLine("  return %s(this);", datatype.getPartialType().constructor())
         .addLine("}");
   }
@@ -542,7 +545,7 @@ public class GeneratedBuilder extends GeneratedType {
               datatype.getType().declarationParameters(), datatype.getBuilder())
           .addLine("    @Override public %s %s() {",
               datatype.getType(), datatype.getBuildMethod().name())
-          .addLine("      return buildPartial();")
+          .addLine("      return %s();", datatype.getBuildPartialMethod().name())
           .addLine("    }")
           .addLine("  }");
     }

--- a/src/main/java/org/inferred/freebuilder/processor/GwtSupport.java
+++ b/src/main/java/org/inferred/freebuilder/processor/GwtSupport.java
@@ -141,7 +141,8 @@ class GwtSupport {
               .addLine("    }");
         }
       }
-      code.addLine("    return (%s) %s.build();", datatype.getValueType(), builder)
+      code.addLine("    return (%s) %s.%s();",
+              datatype.getValueType(), builder, datatype.getBuildMethod().name())
           .addLine("  }");
     }
 

--- a/src/main/java/org/inferred/freebuilder/processor/NameAndVisibility.java
+++ b/src/main/java/org/inferred/freebuilder/processor/NameAndVisibility.java
@@ -1,0 +1,50 @@
+package org.inferred.freebuilder.processor;
+
+import org.inferred.freebuilder.processor.Datatype.Visibility;
+
+import java.util.Objects;
+
+public class NameAndVisibility {
+
+  public static NameAndVisibility of(String name, Visibility visibility) {
+    return new NameAndVisibility(name, visibility);
+  }
+
+  private final String name;
+  private final Visibility visibility;
+
+  private NameAndVisibility(String name, Visibility visibility) {
+    this.name = name;
+    this.visibility = visibility;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public Visibility visibility() {
+    return visibility;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, visibility);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof NameAndVisibility)) {
+      return false;
+    }
+    NameAndVisibility other = (NameAndVisibility) obj;
+    return Objects.equals(name, other.name) && visibility == other.visibility;
+  }
+
+  @Override
+  public String toString() {
+    return "NameAndVisibility{name=" + name + ", visibility=" + visibility + "}";
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/NamePicker.java
+++ b/src/main/java/org/inferred/freebuilder/processor/NamePicker.java
@@ -1,0 +1,73 @@
+package org.inferred.freebuilder.processor;
+
+import static org.inferred.freebuilder.processor.model.MethodFinder.methodsOn;
+import static org.inferred.freebuilder.processor.model.ModelUtils.asElement;
+import static org.inferred.freebuilder.processor.model.ModelUtils.getReturnType;
+
+import static java.util.stream.Collectors.toMap;
+
+import org.inferred.freebuilder.processor.Datatype.Visibility;
+
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collector;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+public class NamePicker {
+
+  /** Find an available name and visibility for a method. */
+  public static NameAndVisibility pickName(
+      DeclaredType targetType,
+      Elements elements,
+      Types types,
+      TypeMirror returnType,
+      String preferredName) {
+    Map<String, ExecutableElement> methodsByName =
+        methodsOn(asElement(targetType), elements, errorType -> { })
+            .stream()
+            .filter(noParameters())
+            .collect(byName());
+
+    String name = preferredName;
+    Visibility visibility = Visibility.PUBLIC;
+
+    for (int attempt = 1; true; attempt++) {
+      ExecutableElement method = methodsByName.get(name);
+      if (method == null) {
+        // No (parameterless) method exists with this name, so we can create one
+        return NameAndVisibility.of(name, visibility);
+      }
+      boolean sufficientVisibility = !method.getModifiers().contains(Modifier.PRIVATE);
+      TypeMirror actualReturnType = getReturnType(targetType, method, types);
+      boolean correctReturnType = types.isSameType(actualReturnType, returnType);
+      if (sufficientVisibility && correctReturnType) {
+        // A method exists with this name, but it is not incompatible
+        if (!method.getModifiers().contains(Modifier.PUBLIC)) {
+          visibility = Visibility.PACKAGE;
+        }
+        return NameAndVisibility.of(name, visibility);
+      }
+
+      // This method name is already taken by an incompatible method; try a different name.
+      name = "_" + preferredName + "Impl";
+      visibility = Visibility.PACKAGE;
+      if (attempt > 1) {
+        name += attempt;
+      }
+    }
+  }
+
+  private static Predicate<? super ExecutableElement> noParameters() {
+    return method -> method.getParameters().isEmpty();
+  }
+
+  private static Collector<ExecutableElement, ?, Map<String, ExecutableElement>> byName() {
+    return toMap(method -> method.getSimpleName().toString(), method -> method);
+  }
+}

--- a/src/main/java/org/inferred/freebuilder/processor/model/ModelUtils.java
+++ b/src/main/java/org/inferred/freebuilder/processor/model/ModelUtils.java
@@ -298,9 +298,24 @@ public class ModelUtils {
    * javac works fine.)
    */
   public static TypeMirror getReturnType(TypeElement type, ExecutableElement method, Types types) {
+    return getReturnType((DeclaredType) type.asType(), method, types);
+  }
+
+  /**
+   * Determines the return type of {@code method}, if called on an instance of type {@code type}.
+   *
+   * <p>For instance, in this example, myY.getProperty() returns List&lt;T&gt;, not T:<pre><code>
+   *    interface X&lt;T&gt; {
+   *      T getProperty();
+   *    }
+   *    &#64;FreeBuilder interface Y&lt;T&gt; extends X&lt;List&lt;T&gt;&gt; { }</code></pre>
+   *
+   * <p>(Unfortunately, a bug in Eclipse prevents us handling these cases correctly at the moment.
+   * javac works fine.)
+   */
+  public static TypeMirror getReturnType(DeclaredType type, ExecutableElement method, Types types) {
     try {
-      ExecutableType executableType = (ExecutableType)
-          types.asMemberOf((DeclaredType) type.asType(), method);
+      ExecutableType executableType = (ExecutableType) types.asMemberOf(type, method);
       return executableType.getReturnType();
     } catch (IllegalArgumentException e) {
       // Eclipse incorrectly throws an IllegalArgumentException here:

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -1279,6 +1279,38 @@ public class AnalyserTest {
   }
 
   @Test
+  public void protectedClearMethod() throws CannotGenerateCodeException {
+    GeneratedBuilder builder = (GeneratedBuilder) analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public static class Builder extends DataType_Builder {",
+        "    protected Builder clear() {",
+        "      return super.clear();",
+        "    }",
+        "  }",
+        "}"));
+
+    assertThat(builder.getDatatype().getClearMethod())
+        .isEqualTo(NameAndVisibility.of("clear", Visibility.PACKAGE));
+  }
+
+  @Test
+  public void privateClearMethod() throws CannotGenerateCodeException {
+    GeneratedBuilder builder = (GeneratedBuilder) analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public static class Builder extends DataType_Builder {",
+        "    private Builder clear() {",
+        "      return super._clearImpl();",
+        "    }",
+        "  }",
+        "}"));
+
+    assertThat(builder.getDatatype().getClearMethod())
+        .isEqualTo(NameAndVisibility.of("_clearImpl", Visibility.PACKAGE));
+  }
+
+  @Test
   public void privateNestedType() {
     try {
       analyser.analyse((TypeElement) model.newElementWithMarker(

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -1311,6 +1311,70 @@ public class AnalyserTest {
   }
 
   @Test
+  public void protectedMergeFromBuilderMethod() throws CannotGenerateCodeException {
+    GeneratedBuilder builder = (GeneratedBuilder) analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public static class Builder extends DataType_Builder {",
+        "    protected Builder mergeFrom(Builder builder) {",
+        "      return super.mergeFrom(builder);",
+        "    }",
+        "  }",
+        "}"));
+
+    assertThat(builder.getDatatype().getMergeFromBuilderMethod())
+        .isEqualTo(NameAndVisibility.of("mergeFrom", Visibility.PACKAGE));
+  }
+
+  @Test
+  public void privateMergeFromBuilderMethod() throws CannotGenerateCodeException {
+    GeneratedBuilder builder = (GeneratedBuilder) analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public static class Builder extends DataType_Builder {",
+        "    private Builder mergeFrom(Builder builder) {",
+        "      return super._mergeFromImpl(builder);",
+        "    }",
+        "  }",
+        "}"));
+
+    assertThat(builder.getDatatype().getMergeFromBuilderMethod())
+        .isEqualTo(NameAndVisibility.of("_mergeFromImpl", Visibility.PACKAGE));
+  }
+
+  @Test
+  public void protectedMergeFromValueMethod() throws CannotGenerateCodeException {
+    GeneratedBuilder builder = (GeneratedBuilder) analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public static class Builder extends DataType_Builder {",
+        "    protected Builder mergeFrom(DataType value) {",
+        "      return super.mergeFrom(value);",
+        "    }",
+        "  }",
+        "}"));
+
+    assertThat(builder.getDatatype().getMergeFromValueMethod())
+        .isEqualTo(NameAndVisibility.of("mergeFrom", Visibility.PACKAGE));
+  }
+
+  @Test
+  public void privateMergeFromValueMethod() throws CannotGenerateCodeException {
+    GeneratedBuilder builder = (GeneratedBuilder) analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public static class Builder extends DataType_Builder {",
+        "    private Builder mergeFrom(DataType value) {",
+        "      return super._mergeFromImpl(value);",
+        "    }",
+        "  }",
+        "}"));
+
+    assertThat(builder.getDatatype().getMergeFromValueMethod())
+        .isEqualTo(NameAndVisibility.of("_mergeFromImpl", Visibility.PACKAGE));
+  }
+
+  @Test
   public void privateNestedType() {
     try {
       analyser.analyse((TypeElement) model.newElementWithMarker(

--- a/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/AnalyserTest.java
@@ -1247,6 +1247,38 @@ public class AnalyserTest {
   }
 
   @Test
+  public void protectedBuildPartialMethod() throws CannotGenerateCodeException {
+    GeneratedBuilder builder = (GeneratedBuilder) analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public static class Builder extends DataType_Builder {",
+        "    protected DataType buildPartial() {",
+        "      return super.buildPartial();",
+        "    }",
+        "  }",
+        "}"));
+
+    assertThat(builder.getDatatype().getBuildPartialMethod())
+        .isEqualTo(NameAndVisibility.of("buildPartial", Visibility.PACKAGE));
+  }
+
+  @Test
+  public void privateBuildPartialMethod() throws CannotGenerateCodeException {
+    GeneratedBuilder builder = (GeneratedBuilder) analyser.analyse(model.newType(
+        "package com.example;",
+        "public class DataType {",
+        "  public static class Builder extends DataType_Builder {",
+        "    private DataType buildPartial() {",
+        "      return super._buildPartialImpl();",
+        "    }",
+        "  }",
+        "}"));
+
+    assertThat(builder.getDatatype().getBuildPartialMethod())
+        .isEqualTo(NameAndVisibility.of("_buildPartialImpl", Visibility.PACKAGE));
+  }
+
+  @Test
   public void privateNestedType() {
     try {
       analyser.analyse((TypeElement) model.newElementWithMarker(

--- a/src/test/java/org/inferred/freebuilder/processor/BuildableTypeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuildableTypeTest.java
@@ -36,6 +36,22 @@ public class BuildableTypeTest {
   }
 
   @Test
+  public void simpleFreebuilderAnnotatedTypeWithExplicitBuildMethod() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder {",
+        "    public DataType build();",
+        "  }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertTrue(result.isPresent());
+  }
+
+  @Test
   public void freebuilderAnnotatedTypeWithHiddenBuildMethod() {
     TypeElement type = model.newType(
         "package com.example;",
@@ -44,6 +60,38 @@ public class BuildableTypeTest {
         "  int value();",
         "  class Builder extends DataType_Builder {",
         "    protected DataType build();",
+        "  }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void freebuilderAnnotatedTypeWithExplicitBuildPartialMethod() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder {",
+        "    public DataType buildPartial();",
+        "  }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertTrue(result.isPresent());
+  }
+
+  @Test
+  public void freebuilderAnnotatedTypeWithHiddenBuildPartialMethod() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder {",
+        "    protected DataType buildPartial();",
         "  }",
         "}");
     Optional<DeclaredType> result = maybeBuilder(

--- a/src/test/java/org/inferred/freebuilder/processor/BuildableTypeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuildableTypeTest.java
@@ -130,4 +130,68 @@ public class BuildableTypeTest {
         (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
     assertFalse(result.isPresent());
   }
+
+  @Test
+  public void freebuilderAnnotatedTypeWithExplicitMergeFromBuilderMethod() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder {",
+        "    public Builder mergeFrom(Builder builder);",
+        "  }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertTrue(result.isPresent());
+  }
+
+  @Test
+  public void freebuilderAnnotatedTypeWithHiddenMergeFromBuilderMethod() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder {",
+        "    protected Builder mergeFrom(Builder builder);",
+        "  }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void freebuilderAnnotatedTypeWithExplicitMergeFromValueMethod() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder {",
+        "    public Builder mergeFrom(DataType value);",
+        "  }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertTrue(result.isPresent());
+  }
+
+  @Test
+  public void freebuilderAnnotatedTypeWithHiddenMergeFromValueMethod() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder {",
+        "    protected Builder mergeFrom(DataType value);",
+        "  }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertFalse(result.isPresent());
+  }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/BuildableTypeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuildableTypeTest.java
@@ -98,4 +98,36 @@ public class BuildableTypeTest {
         (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
     assertFalse(result.isPresent());
   }
+
+  @Test
+  public void freebuilderAnnotatedTypeWithExplicitClearMethod() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder {",
+        "    public Builder clear();",
+        "  }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertTrue(result.isPresent());
+  }
+
+  @Test
+  public void freebuilderAnnotatedTypeWithHiddenClearMethod() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder {",
+        "    protected Builder clear();",
+        "  }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertFalse(result.isPresent());
+  }
 }

--- a/src/test/java/org/inferred/freebuilder/processor/BuildableTypeTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/BuildableTypeTest.java
@@ -1,0 +1,53 @@
+package org.inferred.freebuilder.processor;
+
+import static org.inferred.freebuilder.processor.BuildableType.maybeBuilder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.inferred.freebuilder.FreeBuilder;
+import org.inferred.freebuilder.processor.source.testing.ModelRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Optional;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+
+@RunWith(JUnit4.class)
+public class BuildableTypeTest {
+
+  @Rule public final ModelRule model = new ModelRule();
+
+  @Test
+  public void simpleFreebuilderAnnotatedType() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder { }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertTrue(result.isPresent());
+  }
+
+  @Test
+  public void freebuilderAnnotatedTypeWithHiddenBuildMethod() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "@" + FreeBuilder.class.getName(),
+        "public interface DataType {",
+        "  int value();",
+        "  class Builder extends DataType_Builder {",
+        "    protected DataType build();",
+        "  }",
+        "}");
+    Optional<DeclaredType> result = maybeBuilder(
+        (DeclaredType) type.asType(), model.elementUtils(), model.typeUtils());
+    assertFalse(result.isPresent());
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/NamePickerTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/NamePickerTest.java
@@ -1,0 +1,230 @@
+package org.inferred.freebuilder.processor;
+
+import static org.inferred.freebuilder.processor.NamePicker.pickName;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.reflect.TypeToken;
+
+import org.inferred.freebuilder.processor.Datatype.Visibility;
+import org.inferred.freebuilder.processor.source.testing.ModelRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
+@RunWith(JUnit4.class)
+public class NamePickerTest {
+
+  @Rule public final ModelRule model = new ModelRule();
+
+  private DeclaredType exampleType;
+
+  @Before
+  public void createExampleType() {
+    TypeElement type = model.newType(
+        "package com.example;",
+        "public class DataType extends ThingThatWillBeGenerated {",
+        "  public int methodReturningInt();",
+        "  protected int protectedMethod();",
+        "  int packageProtectedMethod();",
+        "  private int privateMethod();",
+        "  private int otherPrivateMethod();",
+        "  private int _otherPrivateMethodImpl();",
+        "  public java.util.List<Integer> methodReturningIntegerList();",
+        "  public int methodTakingFloat(float a);",
+        "  protected int protectedMethodTakingFloat(float a);",
+        "  int packageProtectedMethodTakingFloat(float a);",
+        "  private int privateMethodTakingFloat(float a);",
+        "  public int methodTakingIntegerList(java.util.List<Integer> a);",
+        "}");
+    exampleType = (DeclaredType) type.asType();
+  }
+
+  private NameAndVisibility pickNameForExampleType(
+      Class<?> returnType, String preferredName, Class<?>... parameterTypes) {
+    TypeMirror[] parameterTypeMirrors = Arrays
+        .asList(parameterTypes)
+        .stream()
+        .map(model::typeMirror)
+        .collect(toArray(TypeMirror[]::new));
+    return pickName(
+        exampleType,
+        model.elementUtils(),
+        model.typeUtils(),
+        model.typeMirror(returnType),
+        preferredName,
+        parameterTypeMirrors);
+  }
+
+  private NameAndVisibility pickNameForExampleType(
+      TypeToken<?> returnType, String preferredName, TypeToken<?>... parameterTypes) {
+    TypeMirror[] parameterTypeMirrors = Arrays
+        .asList(parameterTypes)
+        .stream()
+        .map(model::typeMirror)
+        .collect(toArray(TypeMirror[]::new));
+    return pickName(
+        exampleType,
+        model.elementUtils(),
+        model.typeUtils(),
+        model.typeMirror(returnType),
+        preferredName,
+        parameterTypeMirrors);
+  }
+
+  @Test
+  public void unusedMethodName() {
+    NameAndVisibility result = pickNameForExampleType(int.class, "unusedMethod");
+    assertEquals("unusedMethod", result.name());
+    assertEquals(Visibility.PUBLIC, result.visibility());
+  }
+
+  @Test
+  public void methodOverridePublic() {
+    NameAndVisibility result = pickNameForExampleType(int.class, "methodReturningInt");
+    assertEquals("methodReturningInt", result.name());
+    assertEquals(Visibility.PUBLIC, result.visibility());
+  }
+
+  @Test
+  public void methodOverrideProtected() {
+    NameAndVisibility result = pickNameForExampleType(int.class, "protectedMethod");
+    assertEquals("protectedMethod", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  @Test
+  public void methodOverridePackageProtected() {
+    NameAndVisibility result = pickNameForExampleType(int.class, "packageProtectedMethod");
+    assertEquals("packageProtectedMethod", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  @Test
+  public void methodOverridePrivate() {
+    NameAndVisibility result = pickNameForExampleType(int.class, "privateMethod");
+    assertEquals("_privateMethodImpl", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  @Test
+  public void methodOverridePrivate_secondChoiceAlsoPrivate() {
+    NameAndVisibility result = pickNameForExampleType(int.class, "otherPrivateMethod");
+    assertEquals("_otherPrivateMethodImpl2", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  @Test
+  public void incompatibleReturnType() {
+    NameAndVisibility result = pickNameForExampleType(Integer.class, "methodReturningInt");
+    assertEquals("_methodReturningIntImpl", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  @Test
+  public void incompatibleGenericReturnType() {
+    NameAndVisibility result = pickNameForExampleType(
+        new TypeToken<List<String>>() { }, "methodReturningIntegerList");
+    assertEquals("_methodReturningIntegerListImpl", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  @Test
+  public void unusedMethodNameWithParameter() {
+    NameAndVisibility result = pickNameForExampleType(int.class, "unusedMethod", int.class);
+    assertEquals("unusedMethod", result.name());
+    assertEquals(Visibility.PUBLIC, result.visibility());
+  }
+
+  @Test
+  public void methodNameUsedForDifferentNumberOfArguments() {
+    NameAndVisibility result = pickNameForExampleType(int.class, "protectedMethod", int.class);
+    assertEquals("protectedMethod", result.name());
+    assertEquals(Visibility.PUBLIC, result.visibility());
+  }
+
+  @Test
+  public void singleParameterMethodOverridePublic() {
+    NameAndVisibility result = pickNameForExampleType(int.class, "methodTakingFloat", float.class);
+    assertEquals("methodTakingFloat", result.name());
+    assertEquals(Visibility.PUBLIC, result.visibility());
+  }
+
+  @Test
+  public void singleParameterMethodOverrideProtected() {
+    NameAndVisibility result = pickNameForExampleType(
+        int.class, "protectedMethodTakingFloat", float.class);
+    assertEquals("protectedMethodTakingFloat", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  @Test
+  public void singleParameterMethodOverridePackageProtected() {
+    NameAndVisibility result = pickNameForExampleType(
+        int.class, "packageProtectedMethodTakingFloat", float.class);
+    assertEquals("packageProtectedMethodTakingFloat", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  @Test
+  public void singleParameterMethodOverridePrivate() {
+    NameAndVisibility result = pickNameForExampleType(
+        int.class, "privateMethodTakingFloat", float.class);
+    assertEquals("_privateMethodTakingFloatImpl", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  @Test
+  public void singleParameterMethodOverload() {
+    NameAndVisibility result = pickNameForExampleType(int.class, "methodTakingFloat", int.class);
+    assertEquals("methodTakingFloat", result.name());
+    assertEquals(Visibility.PUBLIC, result.visibility());
+  }
+
+  @Test
+  public void singleParameterIncompatibleReturnType() {
+    NameAndVisibility result =
+        pickNameForExampleType(float.class, "methodTakingFloat", float.class);
+    assertEquals("_methodTakingFloatImpl", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  @Test
+  public void singleParameterGenericMethodOverload() {
+    NameAndVisibility result = pickNameForExampleType(
+        TypeToken.of(int.class), "methodTakingIntegerList", new TypeToken<List<Integer>>() {});
+    assertEquals("methodTakingIntegerList", result.name());
+    assertEquals(Visibility.PUBLIC, result.visibility());
+  }
+
+  @Test
+  public void incompatibleParameter() {
+    NameAndVisibility result = pickNameForExampleType(
+        TypeToken.of(int.class), "methodTakingIntegerList", new TypeToken<List<Float>>() {});
+    assertEquals("_methodTakingIntegerListImpl", result.name());
+    assertEquals(Visibility.PACKAGE, result.visibility());
+  }
+
+  private static <T> Collector<T, ?, T[]> toArray(Function<Integer, T[]> arrayConstructor) {
+    return Collector.of(
+        (Supplier<List<T>>) ArrayList::new,
+        List::add,
+        (left, right) -> {
+          left.addAll(right);
+          return left;
+        },
+        list -> list.toArray(arrayConstructor.apply(list.size())));
+  }
+}

--- a/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
@@ -1356,6 +1356,130 @@ public class ProcessorTest {
   }
 
   @Test
+  public void testProtectedMergeFromBuilderMethod() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SourceBuilder.forTesting()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  %s<String> getNames();", List.class)
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {")
+            .addLine("    protected Builder mergeFrom(Builder builder) {")
+            .addLine("      return super.mergeFrom(builder);")
+            .addLine("    }")
+            .addLine("    public Builder coalesce(Builder builder) {")
+            .addLine("      return mergeFrom(builder);")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}"))
+        .with(testBuilder()
+            .addLine("DataType.Builder template = new DataType.Builder().addNames(\"jill\");")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .addNames(\"fred\")")
+            .addLine("    .coalesce(template)")
+            .addLine("    .addNames(\"bob\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getNames()).containsExactly(\"fred\", \"jill\", \"bob\");")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testIncompatibleMergeFromBuilderMethod() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SourceBuilder.forTesting()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  %s<String> getNames();", List.class)
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {")
+            .addLine("    public int mergeFrom(Builder builder) {")
+            .addLine("      return 0;")
+            .addLine("    }")
+            .addLine("    public Builder coalesce(Builder builder) {")
+            .addLine("      return _mergeFromImpl(builder);")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}"))
+        .with(testBuilder()
+            .addLine("DataType.Builder template = new DataType.Builder().addNames(\"jill\");")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .addNames(\"fred\")")
+            .addLine("    .coalesce(template)")
+            .addLine("    .addNames(\"bob\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getNames()).containsExactly(\"fred\", \"jill\", \"bob\");")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testProtectedMergeFromValueMethod() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SourceBuilder.forTesting()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  %s<String> getNames();", List.class)
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {")
+            .addLine("    protected Builder mergeFrom(DataType value) {")
+            .addLine("      return super.mergeFrom(value);")
+            .addLine("    }")
+            .addLine("    public Builder coalesce(DataType value) {")
+            .addLine("      return mergeFrom(value);")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}"))
+        .with(testBuilder()
+            .addLine("DataType template = new DataType.Builder().addNames(\"jill\").build();")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .addNames(\"fred\")")
+            .addLine("    .coalesce(template)")
+            .addLine("    .addNames(\"bob\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getNames()).containsExactly(\"fred\", \"jill\", \"bob\");")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testIncompatibleMergeFromValueMethod() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SourceBuilder.forTesting()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  %s<String> getNames();", List.class)
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {")
+            .addLine("    public int mergeFrom(DataType value) {")
+            .addLine("      return 0;")
+            .addLine("    }")
+            .addLine("    public Builder coalesce(DataType value) {")
+            .addLine("      return _mergeFromImpl(value);")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}"))
+        .with(testBuilder()
+            .addLine("DataType template = new DataType.Builder().addNames(\"jill\").build();")
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .addNames(\"fred\")")
+            .addLine("    .coalesce(template)")
+            .addLine("    .addNames(\"bob\")")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getNames()).containsExactly(\"fred\", \"jill\", \"bob\");")
+            .build())
+        .runTest();
+  }
+
+  @Test
   public void testToBuilder() {
     behaviorTester
         .with(new Processor(features))

--- a/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
@@ -1184,6 +1184,62 @@ public class ProcessorTest {
   }
 
   @Test
+  public void testProtectedBuildMethod() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SourceBuilder.forTesting()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  String getName();")
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {")
+            .addLine("    protected DataType build() {")
+            .addLine("      return super.build();")
+            .addLine("    }")
+            .addLine("    public DataType buildComplete() {")
+            .addLine("      return build();")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}"))
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setName(\"fred\")")
+            .addLine("    .buildComplete();")
+            .addLine("assertEquals(\"fred\", value.getName());")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testIncompatibleBuildMethod() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SourceBuilder.forTesting()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  String getName();")
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {")
+            .addLine("    public int build() {")
+            .addLine("      return 0;")
+            .addLine("    }")
+            .addLine("    public DataType buildComplete() {")
+            .addLine("      return _buildImpl();")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}"))
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setName(\"fred\")")
+            .addLine("    .buildComplete();")
+            .addLine("assertEquals(\"fred\", value.getName());")
+            .build())
+        .runTest();
+  }
+
+  @Test
   public void testToBuilder() {
     behaviorTester
         .with(new Processor(features))

--- a/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
@@ -1298,6 +1298,64 @@ public class ProcessorTest {
   }
 
   @Test
+  public void testProtectedClearMethod() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SourceBuilder.forTesting()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  %s<String> getNames();", List.class)
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {")
+            .addLine("    protected Builder clear() {")
+            .addLine("      return super.clear();")
+            .addLine("    }")
+            .addLine("    public Builder wipe() {")
+            .addLine("      return clear();")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}"))
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .addNames(\"fred\")")
+            .addLine("    .wipe()")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getNames()).isEmpty();")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testIncompatibleClearMethod() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SourceBuilder.forTesting()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  %s<String> getNames();", List.class)
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {")
+            .addLine("    public int clear() {")
+            .addLine("      return 0;")
+            .addLine("    }")
+            .addLine("    public Builder wipe() {")
+            .addLine("      return _clearImpl();")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}"))
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .addNames(\"fred\")")
+            .addLine("    .wipe()")
+            .addLine("    .build();")
+            .addLine("assertThat(value.getNames()).isEmpty();")
+            .build())
+        .runTest();
+  }
+
+  @Test
   public void testToBuilder() {
     behaviorTester
         .with(new Processor(features))

--- a/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
+++ b/src/test/java/org/inferred/freebuilder/processor/ProcessorTest.java
@@ -1240,6 +1240,64 @@ public class ProcessorTest {
   }
 
   @Test
+  public void testProtectedBuildPartialMethod() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SourceBuilder.forTesting()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  String getName();")
+            .addLine("  int getValue();")
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {")
+            .addLine("    protected DataType buildPartial() {")
+            .addLine("      return super.buildPartial();")
+            .addLine("    }")
+            .addLine("    public DataType buildFraction() {")
+            .addLine("      return buildPartial();")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}"))
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setName(\"fred\")")
+            .addLine("    .buildFraction();")
+            .addLine("assertEquals(\"fred\", value.getName());")
+            .build())
+        .runTest();
+  }
+
+  @Test
+  public void testIncompatibleBuildPartialMethod() {
+    behaviorTester
+        .with(new Processor(features))
+        .with(SourceBuilder.forTesting()
+            .addLine("package com.example;")
+            .addLine("@%s", FreeBuilder.class)
+            .addLine("public interface DataType {")
+            .addLine("  String getName();")
+            .addLine("  int getValue();")
+            .addLine("")
+            .addLine("  class Builder extends DataType_Builder {")
+            .addLine("    public int buildPartial() {")
+            .addLine("      return 0;")
+            .addLine("    }")
+            .addLine("    public DataType buildFraction() {")
+            .addLine("      return _buildPartialImpl();")
+            .addLine("    }")
+            .addLine("  }")
+            .addLine("}"))
+        .with(testBuilder()
+            .addLine("DataType value = new DataType.Builder()")
+            .addLine("    .setName(\"fred\")")
+            .addLine("    .buildFraction();")
+            .addLine("assertEquals(\"fred\", value.getName());")
+            .build())
+        .runTest();
+  }
+
+  @Test
   public void testToBuilder() {
     behaviorTester
         .with(new Processor(features))


### PR DESCRIPTION
If generating public `build`, `buildPartial`, `clear` or `mergeFrom` methods would cause a compiler error, instead make them package-protected and, if necessary, find an alternative method name by prepending an underscore and appending `Impl` and optionally a number.

Additionally, check for this possibility in `BuildableType`, so we do not accidentally generate non-compiling code. (We used to rely entirely on the presence of the `@FreeBuilder` annotation, as that would guarantee a compiler error anyway!)

This closes #432.