### PR TITLE
Add a new dependency in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ sourceSets {
 }
 
 dependencies {
+  compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
   compile googleJavaFormat
   compile guava
   compileOnly autoService


### PR DESCRIPTION
After running the command `./gradlew eclipse`, I successfully build that two eclipse projects. But when I opened them in eclipse, I got several errors about annotations, So I manually added a new dependency in build.gradle. 