### PR TITLE
Run CI as a GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: Set $JAVA_11_HOME
+      run: echo "JAVA_11_HOME=$JAVA_HOME" >> $GITHUB_ENV
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+    - name: Set $JAVA_8_HOME
+      run: echo "JAVA_8_HOME=$JAVA_HOME" >> $GITHUB_ENV
+    - name: Build
+      uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7
+      with:
+        arguments: build
+

--- a/gradle/java-compatibility.gradle
+++ b/gradle/java-compatibility.gradle
@@ -11,10 +11,15 @@
 import org.gradle.internal.jvm.JavaInfo
 import org.gradle.internal.jvm.Jvm
 
+// These JDKs must be installed
+// For other versions, we will fall back to the closest required JDK if unavailable
+TreeSet<JavaVersion> requiredJdks = [JavaVersion.toVersion("8"), JavaVersion.toVersion("11")]
+
 // Map Java version to JVM information, using $JAVA_x_HOME environment variables
 // and falling back to gradle properties as an extra option for devs.
 Map<Integer, Jvm> jvms = [:].withDefault { String versionString ->
   JavaVersion version = JavaVersion.toVersion(versionString)
+  JavaVersion fallback = requiredJdks.higher(version);
   String propertyName = "java${version.majorVersion}Home"
   String envName = "JAVA_${version.majorVersion}_HOME"
   JavaInfo javaInfo
@@ -22,6 +27,9 @@ Map<Integer, Jvm> jvms = [:].withDefault { String versionString ->
     javaInfo = Jvm.forHome(file(getProperty(propertyName)))
   } else if (System.env.containsKey(envName)) {
     javaInfo = Jvm.forHome(file(System.env[envName]))
+  } else if (!requiredJdks.contains(version) && fallback != null) {
+    logger.info "Java ${versionString} not found; falling back to ${fallback}";
+    return jvms[fallback.majorVersion];
   } else {
     throw new RuntimeException("Set the property $propertyName in your gradle.properties"
         + " pointing to a Java $version installation")

--- a/gradle/publication.gradle
+++ b/gradle/publication.gradle
@@ -160,26 +160,28 @@ afterEvaluate {
     }
   }
 
-  bintray {
-    user = System.env.BINTRAY_USER
-    key = System.env.BINTRAY_KEY
-    publications = ['JarPublication']
-    publish = true
-    pkg {
-      name = project.pom.project.groupId + ':' + project.pom.project.artifactId
-      repo = 'maven'
-      userOrg = System.env.BINTRAY_ORG ?: System.env.BINTRAY_USER
-      vcsUrl = project.pom.scm.connection.replaceAll('^scm:[^:]*:', '')
-      licenses = [project.pom.project.license.shortName]
-      version {
-        name = project.version
-        desc = "$project.archivesBaseName $project.version"
-        released = new Date()
-        vcsTag = System.env.TRAVIS_TAG
-        if (System.env.OSS_USER != null) {
-          mavenCentralSync {
-            user = System.env.OSS_USER
-            password = System.env.OSS_PASSWORD
+  if (project.pom.scm.connection != null) {
+    bintray {
+      user = System.env.BINTRAY_USER
+      key = System.env.BINTRAY_KEY
+      publications = ['JarPublication']
+      publish = true
+      pkg {
+        name = project.pom.project.groupId + ':' + project.pom.project.artifactId
+        repo = 'maven'
+        userOrg = System.env.BINTRAY_ORG ?: System.env.BINTRAY_USER
+        vcsUrl = project.pom.scm.connection.replaceAll('^scm:[^:]*:', '')
+        licenses = [project.pom.project.license.shortName]
+        version {
+          name = project.version
+          desc = "$project.archivesBaseName $project.version"
+          released = new Date()
+          vcsTag = System.env.TRAVIS_TAG
+          if (System.env.OSS_USER != null) {
+            mavenCentralSync {
+              user = System.env.OSS_USER
+              password = System.env.OSS_PASSWORD
+            }
           }
         }
       }


### PR DESCRIPTION
Run `gradle build` on each push as a GitHub action.

In passing, fix a couple of minor annoyances in the `build.gradle`:

 - If the main gradle fails to initialize (for instance, if `$JAVA_8_HOME` is not set), the project.pom.scm may not be configured. If so, skip bintray configuration to avoid a second failure that obscures the first.
 - Automatically fall back to JDK 11 if JDK versions 9 and 10 are not installed, as they are no longer easily available. We were already doing this for 10 on Travis. This does mean we can't guarantee that FreeBuilder doesn't accidentally start using JRE-11 library features on 9 and 10.